### PR TITLE
Add authority-fenced provider binding and schema admission

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/JellyfinPlatformProviderBindingHostTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/JellyfinPlatformProviderBindingHostTests.cs
@@ -1,0 +1,589 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
+{
+    /// <summary>Focused contract tests for lazy foreign concrete-type binding.</summary>
+    public sealed class JellyfinPlatformProviderBindingHostTests
+    {
+        private static readonly Guid ProviderId = new("0a110000-1111-4222-8333-444455556666");
+        private static readonly Version ProviderVersion = new(1, 2, 3);
+
+        [Fact]
+        public void AbsentProviderIsRejectedWithoutResolvingAService()
+        {
+            var resolveCalls = 0;
+            var result = Host(
+                Array.Empty<LocalPlugin>(),
+                _ =>
+                {
+                    resolveCalls++;
+                    return null;
+                }).Bind(Request());
+
+            AssertRejected(PlatformProviderHostBindingStatus.ProviderAbsent, result);
+            Assert.Equal(0, resolveCalls);
+        }
+
+        [Theory]
+        [InlineData(PluginStatus.Restart)]
+        [InlineData(PluginStatus.Disabled)]
+        [InlineData(PluginStatus.NotSupported)]
+        [InlineData(PluginStatus.Malfunctioned)]
+        [InlineData(PluginStatus.Superseded)]
+        [InlineData(PluginStatus.Deleted)]
+        public void EveryNonActiveHostStatusIsRejectedBeforeServiceResolution(PluginStatus status)
+        {
+            var resolveCalls = 0;
+            var plugin = Plugin(status, new ProviderBindingTestPluginInstance());
+
+            var result = Host(
+                new[] { plugin },
+                _ =>
+                {
+                    resolveCalls++;
+                    return null;
+                }).Bind(Request());
+
+            AssertRejected(PlatformProviderHostBindingStatus.ProviderNotActive, result);
+            Assert.Equal(0, resolveCalls);
+        }
+
+        [Fact]
+        public void DuplicateExactGuidIsRejectedInsteadOfSelectingEitherInstance()
+        {
+            var first = Plugin(PluginStatus.Active, new ProviderBindingTestPluginInstance());
+            var duplicate = Plugin(
+                PluginStatus.Active,
+                new ProviderBindingTestPluginInstance(),
+                id: first.Id);
+
+            var result = Host(new[] { first, duplicate }).Bind(Request(first.Id));
+
+            AssertRejected(PlatformProviderHostBindingStatus.HostIdentityChanged, result);
+        }
+
+        [Fact]
+        public void ExactGuidIsSelectedWithoutConsultingNamesOrOtherPlugins()
+        {
+            var foreign = ForeignAssembly(validAbi: true);
+            var target = Plugin(PluginStatus.Active, foreign.PluginInstance, name: "mutable name");
+            var decoy = Plugin(
+                PluginStatus.Active,
+                new ProviderBindingTestPluginInstance(),
+                id: Guid.NewGuid(),
+                name: "mutable name");
+
+            var result = Host(
+                new[] { decoy, target },
+                type => type == foreign.EntrypointType ? foreign.Entrypoint : null)
+                .Bind(Request(target.Id));
+
+            Assert.Equal(PlatformProviderHostBindingStatus.Bound, result.Status);
+            Assert.NotNull(result.Binding);
+        }
+
+        [Fact]
+        public void ExactVersionValueBindsWhileVersionDriftFailsClosed()
+        {
+            var foreign = ForeignAssembly(validAbi: true);
+            var plugin = Plugin(PluginStatus.Active, foreign.PluginInstance);
+            var host = Host(new[] { plugin }, _ => foreign.Entrypoint);
+
+            var exact = host.Bind(Request(version: new Version(ProviderVersion.ToString())));
+            var drifted = host.Bind(Request(version: new Version(1, 2, 4)));
+
+            Assert.Equal(PlatformProviderHostBindingStatus.Bound, exact.Status);
+            AssertRejected(PlatformProviderHostBindingStatus.HostIdentityChanged, drifted);
+        }
+
+        [Fact]
+        public void MissingLivePluginInstanceIsRejectedBeforeEntrypointInspection()
+        {
+            var plugin = Plugin(PluginStatus.Active, instance: null);
+
+            var result = Host(new[] { plugin }).Bind(Request());
+
+            AssertRejected(PlatformProviderHostBindingStatus.ProviderInstanceUnavailable, result);
+        }
+
+        [Fact]
+        public void MissingConventionEntrypointIsDistinctFromAnAbiMismatch()
+        {
+            var missing = Host(new[]
+            {
+                Plugin(PluginStatus.Active, new ProviderBindingTestPluginInstance()),
+            }).Bind(Request());
+            var wrongAbi = ForeignAssembly(validAbi: false);
+            var mismatched = Host(new[]
+            {
+                Plugin(PluginStatus.Active, wrongAbi.PluginInstance),
+            }).Bind(Request());
+
+            AssertRejected(PlatformProviderHostBindingStatus.EntrypointMissing, missing);
+            AssertRejected(PlatformProviderHostBindingStatus.AbiMismatch, mismatched);
+        }
+
+        [Fact]
+        public void NullThrowingAndWrongConcreteServiceResolutionFailClosed()
+        {
+            var foreign = ForeignAssembly(validAbi: true);
+            var plugin = Plugin(PluginStatus.Active, foreign.PluginInstance);
+
+            AssertRejected(
+                PlatformProviderHostBindingStatus.ServiceUnavailable,
+                Host(new[] { plugin }, _ => null).Bind(Request()));
+            AssertRejected(
+                PlatformProviderHostBindingStatus.ServiceResolutionFailed,
+                Host(new[] { plugin }, _ => throw new InvalidOperationException("test resolver fault"))
+                    .Bind(Request()));
+            AssertRejected(
+                PlatformProviderHostBindingStatus.ServiceResolutionFailed,
+                Host(new[] { plugin }, _ => new object()).Bind(Request()));
+        }
+
+        [Fact]
+        public void UnexpectedInventoryFailureMapsToTheClosedBindingFailure()
+        {
+            var host = new JellyfinPlatformProviderBindingHost(
+                () => throw new InvalidOperationException("test inventory fault"),
+                _ => throw new InvalidOperationException("must not resolve"));
+
+            AssertRejected(PlatformProviderHostBindingStatus.BindingFailed, host.Bind(Request()));
+        }
+
+        [Fact]
+        public void ConstructionIsLazyAndEachBindReenumeratesAndResolvesAtMostOnce()
+        {
+            var inventoryReads = 0;
+            var resolutionCalls = 0;
+            var foreign = ForeignAssembly(validAbi: true);
+            var plugin = Plugin(PluginStatus.Active, foreign.PluginInstance);
+            var installed = true;
+            var host = new JellyfinPlatformProviderBindingHost(
+                () =>
+                {
+                    inventoryReads++;
+                    return installed ? new[] { plugin } : Array.Empty<LocalPlugin>();
+                },
+                type =>
+                {
+                    resolutionCalls++;
+                    Assert.Same(foreign.EntrypointType, type);
+                    return foreign.Entrypoint;
+                });
+
+            Assert.Equal(0, inventoryReads);
+            Assert.Equal(0, resolutionCalls);
+
+            var first = host.Bind(Request());
+            installed = false;
+            var second = host.Bind(Request());
+
+            Assert.Equal(PlatformProviderHostBindingStatus.Bound, first.Status);
+            AssertRejected(PlatformProviderHostBindingStatus.ProviderAbsent, second);
+            Assert.Equal(3, inventoryReads);
+            Assert.Equal(1, resolutionCalls);
+        }
+
+        [Fact]
+        public void InventoryChangeDuringServiceResolutionRejectsTheStaleBinding()
+        {
+            var foreign = ForeignAssembly(validAbi: true);
+            var plugin = Plugin(PluginStatus.Active, foreign.PluginInstance);
+            IEnumerable<LocalPlugin> installed = new[] { plugin };
+            var host = new JellyfinPlatformProviderBindingHost(
+                () => installed,
+                _ =>
+                {
+                    installed = Array.Empty<LocalPlugin>();
+                    return foreign.Entrypoint;
+                });
+
+            var result = host.Bind(Request());
+
+            AssertRejected(PlatformProviderHostBindingStatus.ProviderAbsent, result);
+        }
+
+        [Fact]
+        public void ExplicitRevalidationRequiresTheSameLivePluginInstanceAndAssembly()
+        {
+            var foreign = ForeignAssembly(validAbi: true);
+            var plugin = Plugin(PluginStatus.Active, foreign.PluginInstance);
+            IEnumerable<LocalPlugin> installed = new[] { plugin };
+            var host = Host(
+                installed,
+                _ => foreign.Entrypoint);
+            var bound = Assert.IsType<PlatformProviderForeignEntrypoint>(
+                host.Bind(Request()).Binding);
+
+            installed = new[]
+            {
+                Plugin(PluginStatus.Active, new ProviderBindingTestPluginInstance()),
+            };
+
+            Assert.Equal(
+                PlatformProviderHostBindingStatus.HostIdentityChanged,
+                new JellyfinPlatformProviderBindingHost(
+                    () => installed,
+                    _ => throw new InvalidOperationException("must not resolve"))
+                    .Revalidate(Request(), bound));
+        }
+
+        [Fact]
+        public void SuccessfulBindingReturnsExactForeignReflectionFactsWithoutInvokingProviderCode()
+        {
+            ProviderInvocationProbe.Reset();
+            var foreign = ForeignAssembly(validAbi: true);
+            var plugin = Plugin(PluginStatus.Active, foreign.PluginInstance);
+
+            var result = Host(
+                new[] { plugin },
+                type => type == foreign.EntrypointType ? foreign.Entrypoint : null)
+                .Bind(Request());
+
+            Assert.Equal(PlatformProviderHostBindingStatus.Bound, result.Status);
+            var binding = Assert.IsType<PlatformProviderForeignEntrypoint>(result.Binding);
+            Assert.Same(foreign.PluginInstance.GetType().Assembly, binding.Assembly);
+            Assert.Same(foreign.EntrypointType, binding.EntrypointType);
+            Assert.Same(foreign.Entrypoint, binding.Instance);
+            Assert.Equal("InvokeAsync", binding.InvocationMethod.Name);
+            Assert.Same(foreign.EntrypointType, binding.InvocationMethod.DeclaringType);
+            Assert.Equal(0, ProviderInvocationProbe.InvocationCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvocationMethodShapes))]
+        public void InvocationMethodResolutionAcceptsOnlyTheExactFrozenAbi(
+            Type entrypointType,
+            bool expected)
+        {
+            var accepted = JellyfinPlatformProviderBindingHost.TryResolveInvocationMethod(
+                entrypointType,
+                out var method);
+
+            Assert.Equal(expected, accepted);
+            Assert.Equal(expected, method is not null);
+            if (method is not null)
+            {
+                Assert.Equal("InvokeAsync", method.Name);
+                Assert.Equal(typeof(Task<string>), method.ReturnType);
+            }
+        }
+
+        public static TheoryData<Type, bool> InvocationMethodShapes => new()
+        {
+            { typeof(ExactEntrypoint), true },
+            { typeof(WrongNameEntrypoint), false },
+            { typeof(TaskOnlyEntrypoint), false },
+            { typeof(ValueTaskEntrypoint), false },
+            { typeof(StaticEntrypoint), false },
+            { typeof(GenericMethodEntrypoint), false },
+            { typeof(WrongOperationParameterEntrypoint), false },
+            { typeof(WrongJsonParameterEntrypoint), false },
+            { typeof(WrongCancellationParameterEntrypoint), false },
+            { typeof(OptionalParameterEntrypoint), false },
+            { typeof(ParamsEntrypoint), false },
+            { typeof(ByRefEntrypoint), false },
+            { typeof(OverloadedEntrypoint), false },
+            { typeof(InheritedOnlyEntrypoint), false },
+            { typeof(DeclaredExactWithInheritedOverloadEntrypoint), false },
+            { VarArgsEntrypoint(), false },
+            { typeof(AbstractEntrypoint), false },
+            { typeof(GenericEntrypoint<>), false },
+            { typeof(PrivateEntrypoint), false },
+            { typeof(StructEntrypoint), false },
+        };
+
+        private static JellyfinPlatformProviderBindingHost Host(
+            IEnumerable<LocalPlugin> plugins,
+            Func<Type, object?>? resolve = null) => new(
+            () => plugins,
+            resolve ?? (_ => null));
+
+        private static LocalPlugin Plugin(
+            PluginStatus status,
+            IPlugin? instance,
+            Guid? id = null,
+            string name = "Provider",
+            string version = "1.2.3")
+        {
+            var plugin = new LocalPlugin(
+                "/plugins/" + name,
+                true,
+                new PluginManifest
+                {
+                    Id = id ?? ProviderId,
+                    Name = name,
+                    Version = version,
+                    Status = status,
+                });
+            plugin.Instance = instance;
+            return plugin;
+        }
+
+        private static PlatformProviderHostBindingRequest Request(
+            Guid? id = null,
+            Version? version = null) => new(id ?? ProviderId, version ?? ProviderVersion);
+
+        private static void AssertRejected(
+            PlatformProviderHostBindingStatus expected,
+            PlatformProviderHostBindingResult result)
+        {
+            Assert.Equal(expected, result.Status);
+            Assert.Null(result.Binding);
+        }
+
+        private static ForeignFixture ForeignAssembly(bool validAbi)
+        {
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("Canopy.ProviderBinding.Tests." + Guid.NewGuid().ToString("N")),
+                AssemblyBuilderAccess.RunAndCollect);
+            var module = assembly.DefineDynamicModule("Provider");
+            var pluginBuilder = module.DefineType(
+                "ForeignPluginInstance",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed,
+                typeof(ProviderBindingTestPluginInstance));
+            pluginBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+            var pluginType = pluginBuilder.CreateType()!;
+            var entrypointBuilder = module.DefineType(
+                "JellyfinCanopy.ExtensionProviderEntrypoint",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed);
+            entrypointBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+            var method = entrypointBuilder.DefineMethod(
+                "InvokeAsync",
+                MethodAttributes.Public | MethodAttributes.HideBySig,
+                validAbi ? typeof(Task<string>) : typeof(Task),
+                new[] { typeof(string), typeof(string), typeof(CancellationToken) });
+            var il = method.GetILGenerator();
+            il.Emit(OpCodes.Call, typeof(ProviderInvocationProbe).GetMethod(
+                nameof(ProviderInvocationProbe.MarkInvoked),
+                BindingFlags.Public | BindingFlags.Static)!);
+            if (validAbi)
+            {
+                il.Emit(OpCodes.Ldstr, "{}");
+                il.Emit(OpCodes.Call, typeof(Task).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                    .Single(candidate => candidate.Name == nameof(Task.FromResult))
+                    .MakeGenericMethod(typeof(string)));
+            }
+            else
+            {
+                il.Emit(OpCodes.Call, typeof(Task).GetProperty(nameof(Task.CompletedTask))!.GetMethod!);
+            }
+
+            il.Emit(OpCodes.Ret);
+            var entrypointType = entrypointBuilder.CreateType()!;
+            return new ForeignFixture(
+                (IPlugin)Activator.CreateInstance(pluginType)!,
+                entrypointType,
+                Activator.CreateInstance(entrypointType)!);
+        }
+
+        private static Type VarArgsEntrypoint()
+        {
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName("Canopy.ProviderBinding.VarArgs.Tests." + Guid.NewGuid().ToString("N")),
+                AssemblyBuilderAccess.RunAndCollect);
+            var typeBuilder = assembly
+                .DefineDynamicModule("Provider")
+                .DefineType(
+                    "VarArgsEntrypoint",
+                    TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed);
+            typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+            var method = typeBuilder.DefineMethod(
+                "InvokeAsync",
+                MethodAttributes.Public | MethodAttributes.HideBySig,
+                CallingConventions.VarArgs,
+                typeof(Task<string>),
+                new[] { typeof(string), typeof(string), typeof(CancellationToken) });
+            var il = method.GetILGenerator();
+            il.Emit(OpCodes.Ldstr, "{}");
+            il.Emit(OpCodes.Call, typeof(Task).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Single(candidate => candidate.Name == nameof(Task.FromResult))
+                .MakeGenericMethod(typeof(string)));
+            il.Emit(OpCodes.Ret);
+            return typeBuilder.CreateType()!;
+        }
+
+        private sealed record ForeignFixture(
+            IPlugin PluginInstance,
+            Type EntrypointType,
+            object Entrypoint);
+
+        /// <summary>Public base that lets a dynamic foreign assembly expose an IPlugin instance.</summary>
+        public class ProviderBindingTestPluginInstance : IPlugin
+        {
+            public string Name => "Foreign provider test plugin";
+
+            public string Description => "Test-only live provider instance.";
+
+            public Guid Id { get; } = Guid.NewGuid();
+
+            public Version Version { get; } = ProviderVersion;
+
+            public string AssemblyFilePath => GetType().Assembly.Location;
+
+            public bool CanUninstall => false;
+
+            public string DataFolderPath => "/test-provider";
+
+            public PluginInfo GetPluginInfo() => new(Name, Version, Description, Id, CanUninstall);
+
+            public void OnUninstalling()
+            {
+            }
+        }
+
+        /// <summary>Observable guard proving binding never executes the operation method.</summary>
+        public static class ProviderInvocationProbe
+        {
+            private static int _invocationCount;
+
+            public static int InvocationCount => Volatile.Read(ref _invocationCount);
+
+            public static void MarkInvoked() => Interlocked.Increment(ref _invocationCount);
+
+            public static void Reset() => Volatile.Write(ref _invocationCount, 0);
+        }
+
+        public sealed class ExactEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class WrongNameEntrypoint
+        {
+            public Task<string> Invoke(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class TaskOnlyEntrypoint
+        {
+            public Task InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.CompletedTask;
+        }
+
+        public sealed class ValueTaskEntrypoint
+        {
+            public ValueTask<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                ValueTask.FromResult("{}");
+        }
+
+        public sealed class StaticEntrypoint
+        {
+            public static Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class GenericMethodEntrypoint
+        {
+            public Task<string> InvokeAsync<T>(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class WrongOperationParameterEntrypoint
+        {
+            public Task<string> InvokeAsync(object operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class WrongJsonParameterEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, object requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class WrongCancellationParameterEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationTokenSource cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class OptionalParameterEntrypoint
+        {
+            public Task<string> InvokeAsync(
+                string operationId,
+                string requestJson,
+                CancellationToken cancellationToken = default) => Task.FromResult("{}");
+        }
+
+        public sealed class ParamsEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, params CancellationToken[] cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class ByRefEntrypoint
+        {
+            public Task<string> InvokeAsync(ref string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class OverloadedEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+
+            public Task<string> InvokeAsync(string operationId, string requestJson) => Task.FromResult("{}");
+        }
+
+        public class BaseEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class InheritedOnlyEntrypoint : BaseEntrypoint
+        {
+        }
+
+        public class BaseOverloadEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class DeclaredExactWithInheritedOverloadEntrypoint : BaseOverloadEntrypoint
+        {
+            public Task<string> InvokeAsync(
+                string operationId,
+                string requestJson,
+                CancellationToken cancellationToken) => Task.FromResult("{}");
+        }
+
+        public abstract class AbstractEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public sealed class GenericEntrypoint<T>
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        private sealed class PrivateEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+
+        public readonly struct StructEntrypoint
+        {
+            public Task<string> InvokeAsync(string operationId, string requestJson, CancellationToken cancellationToken) =>
+                Task.FromResult("{}");
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformHostSeamTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformHostSeamTests.cs
@@ -60,6 +60,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform
             ["JellyfinPlatformHost.cs"] =
                 "The adapter itself. It exists to be the single translation point between "
                 + "Jellyfin's managers and the kernel's own host types.",
+            ["JellyfinPlatformProviderBindingHost.cs"] =
+                "The narrowly scoped lazy provider-binding adapter. It is the sole owner of "
+                + "live LocalPlugin instances and foreign concrete-type DI resolution; the "
+                + "kernel sees only BCL reflection primitives through a host-neutral seam.",
         };
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderBindingArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderBindingArchitectureTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformProviderBindingArchitectureTests
+{
+    private const string BindingServiceFile = "PlatformProviderBindingService.cs";
+    private const string BindingHostFile = "JellyfinPlatformProviderBindingHost.cs";
+    private const string BindingDomainFile = "IPlatformProviderBindingHost.cs";
+
+    [Fact]
+    public void BindingOutcomesAndPublishedShapesAreExactClosedContracts()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "Bound", "AuthorityUnavailable", "OperationUnavailable", "ProtocolUnsupported",
+                "GrantInsufficient", "ProviderAbsent", "ProviderNotActive", "HostIdentityChanged",
+                "ProviderInstanceUnavailable", "EntrypointMissing", "AbiMismatch", "ServiceUnavailable",
+                "ServiceResolutionFailed", "SchemaMissing", "SchemaResourceAmbiguous", "SchemaReadFailed",
+                "SchemaTooLarge", "SchemaHashMismatch", "SchemaInvalidUtf8", "SchemaInvalidJson",
+                "SchemaBoundsExceeded", "SchemaIdentityMismatch", "SchemaDialectUnsupported",
+                "SchemaExternalReference", "SchemaVocabularyUnsupported", "AuthorityChanged", "BindingFailed",
+            },
+            Enum.GetNames<PlatformProviderBindingStatus>());
+        Assert.Equal(
+            Enumerable.Range(1, 27),
+            Enum.GetValues<PlatformProviderBindingStatus>().Select(value => (int)value));
+        Assert.Equal(
+            new[]
+            {
+                "Bound", "ProviderAbsent", "ProviderNotActive", "HostIdentityChanged",
+                "ProviderInstanceUnavailable", "EntrypointMissing", "AbiMismatch", "ServiceUnavailable",
+                "ServiceResolutionFailed", "BindingFailed",
+            },
+            Enum.GetNames<PlatformProviderHostBindingStatus>());
+
+        AssertImmutable(typeof(PlatformProviderBindingResult), new[] { "Binding", "Status" });
+        AssertImmutable(
+            typeof(PlatformProviderBoundOperation),
+            new[] { "Claim", "Entrypoint", "Schemas" });
+        AssertImmutable(
+            typeof(PlatformProviderForeignEntrypoint),
+            new[] { "Assembly", "EntrypointType", "Instance", "InvocationMethod" });
+        AssertImmutable(
+            typeof(PlatformProviderHostBindingRequest),
+            new[] { "HostVersion", "PluginId" });
+        AssertImmutable(
+            typeof(PlatformProviderHostBindingResult),
+            new[] { "Binding", "Status" });
+    }
+
+    [Fact]
+    public void BindingCoordinatorHasNoInvocationCacheRouteTimerOrHostManagerSurface()
+    {
+        var code = Code(SourceFile(BindingServiceFile));
+        Assert.Contains("ClaimOperationBinding(", code, StringComparison.Ordinal);
+        Assert.Equal(2, Count(code, "RevalidateOperationBindingClaim("));
+        Assert.Contains("PlatformProviderEmbeddedSchemaAdmission.Admit", code, StringComparison.Ordinal);
+        Assert.Contains("_host.Revalidate(hostRequest, hostResult.Binding)", code, StringComparison.Ordinal);
+        foreach (var forbidden in new[]
+        {
+            "MethodInfo.Invoke", ".Invoke(instance", "InvocationMethod.Invoke", "InvokeAsync(",
+            "Assembly.Load", "LoadFromAssemblyPath", "Activator", "IPluginManager", "LocalPlugin",
+            "System.IO", "File.", "Directory.", "Path.", "HttpClient", "Controller", "Route(",
+            "IHostedService", "BackgroundService", "Timer", "Task.Delay", "ConcurrentDictionary",
+            "MemoryCache", "ILogger", "Android", "CanopyConformance",
+        })
+        {
+            Assert.DoesNotContain(forbidden, code, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void JellyfinAdapterIsTheOnlyLiveForeignBindingOwnerAndNeverInvokesOrLoads()
+    {
+        Assert.Equal(new[] { BindingHostFile }, Owners("plugin.Instance"));
+        Assert.Equal(new[] { BindingHostFile }, Owners("serviceProvider.GetService"));
+        Assert.Equal(new[] { BindingHostFile }, Owners("_resolve(entrypointType)"));
+        Assert.Equal(new[] { BindingHostFile }, Owners("TryResolveInvocationMethod"));
+
+        var code = Code(SourceFile(BindingHostFile));
+        Assert.Contains("candidate.Id == request.PluginId", code, StringComparison.Ordinal);
+        Assert.Contains("plugin.Manifest.Status != PluginStatus.Active", code, StringComparison.Ordinal);
+        Assert.Contains("pluginInstance.GetType().Assembly", code, StringComparison.Ordinal);
+        Assert.Contains("binding.IsBoundToHostPluginInstance(pluginInstance)", code, StringComparison.Ordinal);
+        Assert.Contains("BindingFlags.DeclaredOnly", code, StringComparison.Ordinal);
+        foreach (var forbidden in new[]
+        {
+            "MethodInfo.Invoke", ".Invoke(instance", "InvocationMethod.Invoke", "InvokeAsync(",
+            "Assembly.Load", "LoadFromAssemblyPath", "Assembly.LoadFile", "Assembly.LoadFrom",
+            "Activator", "File.", "Directory.", "Path.", "Controller", "Route(", "IHostedService",
+            "BackgroundService", "Timer", "Task.Delay", "HttpClient", "ILogger", "Android",
+            "CanopyConformance",
+        })
+        {
+            Assert.DoesNotContain(forbidden, code, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void CompositionIsLazySingletonOnlyAndCreatesNoStartupConsumer()
+    {
+        var registrator = Code(SourceFile("PluginServiceRegistrator.cs"));
+        Assert.Contains(
+            "AddSingleton<IPlatformProviderBindingHost, JellyfinPlatformProviderBindingHost>()",
+            registrator,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "AddSingleton(serviceProvider => new PlatformProviderBindingService(",
+            registrator,
+            StringComparison.Ordinal);
+        Assert.Equal(new[] { "PluginServiceRegistrator.cs" }, Owners("new PlatformProviderBindingService("));
+
+        var production = string.Join('\n', ProductionFiles().Select(Code));
+        Assert.DoesNotContain("AddHostedService<PlatformProviderBinding", production, StringComparison.Ordinal);
+        Assert.DoesNotContain("IHostedService<PlatformProviderBinding", production, StringComparison.Ordinal);
+        Assert.DoesNotContain("PlatformProviderBindingController", production, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HostNeutralBoundaryCarriesOnlyBclReflectionFactsAndNoJellyfinTypes()
+    {
+        var code = Code(SourceFile(BindingDomainFile));
+        foreach (var forbidden in new[]
+        {
+            "MediaBrowser", "IPluginManager", "LocalPlugin", "PluginStatus", "IServiceProvider",
+            "File.", "Directory.", "Path.", "Controller", "Route(", "HttpClient", "Android",
+        })
+        {
+            Assert.DoesNotContain(forbidden, code, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static void AssertImmutable(Type type, string[] expectedProperties)
+    {
+        Assert.True(type.IsSealed || type.IsValueType);
+        Assert.Empty(type.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        var properties = type
+            .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(expectedProperties, properties.Select(property => property.Name));
+        Assert.All(properties, property => Assert.False(property.CanWrite));
+    }
+
+    private static int Count(string value, string fragment)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = value.IndexOf(fragment, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += fragment.Length;
+        }
+
+        return count;
+    }
+
+    private static string[] Owners(string fragment) => ProductionFiles()
+        .Where(file => Code(file).Contains(fragment, StringComparison.Ordinal))
+        .Select(Path.GetFileName)
+        .OrderBy(name => name, StringComparer.Ordinal)
+        .ToArray()!;
+
+    private static string Code(string file) => PlatformHostSeamTests.CodeOnly(File.ReadAllText(file));
+
+    private static string SourceFile(string name) => ProductionFiles()
+        .Single(file => Path.GetFileName(file) == name);
+
+    private static string[] ProductionFiles() => Directory
+        .EnumerateFiles(ProductionRoot(), "*.cs", SearchOption.AllDirectories)
+        .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+        .ToArray();
+
+    private static string ProductionRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy"));
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderBindingServiceTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderBindingServiceTests.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformProviderBindingServiceTests
+{
+    private const string OperationId = "org.jellyfin.canopy.conformance.hello";
+    private const string ItemLookup = "jellyfin.canopy.items.lookup";
+    private const string StorageRead = "jellyfin.canopy.storage.read";
+    private static readonly Guid PluginId = new("0a110000-1111-4222-8333-444455556666");
+    private static readonly Guid AdminId = new("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static readonly DateTimeOffset Now = new(2026, 8, 4, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ExactAlphaFixtureBindsAtomicallyWithoutInvokingItsOperation()
+    {
+        using var foreign = AlphaForeignBinding.Load();
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var services = new ServiceCollection();
+        services.AddSingleton(foreign.Binding.EntrypointType, foreign.Binding.Instance);
+        using var serviceProvider = services.BuildServiceProvider();
+        var plugin = new LocalPlugin(
+            "/plugins/alpha",
+            true,
+            new PluginManifest
+            {
+                Id = PluginId,
+                Name = "mutable display name",
+                Version = "1.0.0.0",
+                Status = PluginStatus.Active,
+            })
+        {
+            Instance = foreign.PluginInstance,
+        };
+        var host = new JellyfinPlatformProviderBindingHost(
+            () => new[] { plugin },
+            serviceProvider.GetService);
+        var service = Service(registry, host);
+
+        var result = service.Bind(PluginId, OperationId, negotiatedProtocol: 1);
+
+        Assert.Equal(PlatformProviderBindingStatus.Bound, result.Status);
+        var binding = Assert.IsType<PlatformProviderBoundOperation>(result.Binding);
+        Assert.Same(foreign.Binding.Assembly, binding.Entrypoint.Assembly);
+        Assert.Same(foreign.Binding.EntrypointType, binding.Entrypoint.EntrypointType);
+        Assert.Same(foreign.Binding.Instance, binding.Entrypoint.Instance);
+        Assert.Same(foreign.Binding.InvocationMethod, binding.Entrypoint.InvocationMethod);
+        Assert.Equal(PluginId, binding.Claim.PluginId);
+        Assert.Equal(1, binding.Claim.NegotiatedProtocol);
+        Assert.Equal(
+            binding.Claim.Operation.RequestSchemaId,
+            binding.Schemas.RequestSchema.GetProperty("$id").GetString());
+        Assert.Equal(
+            binding.Claim.Operation.ResponseSchemaId,
+            binding.Schemas.ResponseSchema.GetProperty("$id").GetString());
+        Assert.Same(
+            foreign.Binding.Instance,
+            serviceProvider.GetService(foreign.Binding.EntrypointType));
+    }
+
+    [Theory]
+    [MemberData(nameof(HostRejections))]
+    public void EveryHostRejectionMapsWithoutPublishingPartialBinding(
+        int hostStatusValue,
+        int expectedValue)
+    {
+        var hostStatus = (PlatformProviderHostBindingStatus)hostStatusValue;
+        var expected = (PlatformProviderBindingStatus)expectedValue;
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var host = new RecordingHost(_ => PlatformProviderHostBindingResult.Rejected(hostStatus));
+
+        var result = Service(registry, host).Bind(PluginId, OperationId, 1);
+
+        Assert.Equal(expected, result.Status);
+        Assert.Null(result.Binding);
+        Assert.Single(host.Requests);
+    }
+
+    [Fact]
+    public void RegistryRefusalsNeverReachTheForeignBindingHost()
+    {
+        var enabled = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var insufficient = EnabledRegistry(new[] { StorageRead });
+        var pending = PendingRegistry();
+        var host = new RecordingHost(_ => throw new InvalidOperationException("must not bind"));
+
+        AssertRejected(
+            Service(enabled, host).Bind(PluginId, "org.jellyfin.canopy.unknown", 1),
+            PlatformProviderBindingStatus.OperationUnavailable);
+        AssertRejected(
+            Service(enabled, host).Bind(PluginId, OperationId, 2),
+            PlatformProviderBindingStatus.ProtocolUnsupported);
+        AssertRejected(
+            Service(insufficient, host).Bind(PluginId, OperationId, 1),
+            PlatformProviderBindingStatus.GrantInsufficient);
+        AssertRejected(
+            Service(pending, host).Bind(PluginId, OperationId, 1),
+            PlatformProviderBindingStatus.AuthorityUnavailable);
+        Assert.Empty(host.Requests);
+    }
+
+    [Fact]
+    public void MissingEmbeddedSchemasRejectTheWholeBinding()
+    {
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var type = typeof(LocalExactEntrypoint);
+        var entrypoint = new LocalExactEntrypoint();
+        var foreign = new PlatformProviderForeignEntrypoint(
+            type.Assembly,
+            entrypoint,
+            type,
+            entrypoint,
+            type.GetMethod(nameof(LocalExactEntrypoint.InvokeAsync))!);
+
+        var result = Service(
+            registry,
+            new RecordingHost(_ => PlatformProviderHostBindingResult.Bound(foreign)))
+            .Bind(PluginId, OperationId, 1);
+
+        AssertRejected(result, PlatformProviderBindingStatus.SchemaMissing);
+    }
+
+    [Fact]
+    public void AuthorityMutationDuringForeignBindingRejectsTheOtherwiseValidBinding()
+    {
+        using var foreign = AlphaForeignBinding.Load();
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var host = new RecordingHost(_ =>
+        {
+            registry.BeginReconciliation();
+            return PlatformProviderHostBindingResult.Bound(foreign.Binding);
+        });
+
+        var result = Service(registry, host).Bind(PluginId, OperationId, 1);
+
+        AssertRejected(result, PlatformProviderBindingStatus.AuthorityChanged);
+    }
+
+    [Fact]
+    public void AuthorityMutationAfterSchemaAdmissionRejectsTheOtherwiseValidBinding()
+    {
+        using var foreign = AlphaForeignBinding.Load();
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var service = new PlatformProviderBindingService(
+            new Lazy<PlatformProviderRegistry>(() => registry),
+            new RecordingHost(_ => PlatformProviderHostBindingResult.Bound(foreign.Binding)),
+            (assembly, requestId, requestHash, responseId, responseHash) =>
+            {
+                var admitted = PlatformProviderEmbeddedSchemaAdmission.Admit(
+                    assembly,
+                    requestId,
+                    requestHash,
+                    responseId,
+                    responseHash);
+                Assert.Equal(PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted, admitted.Status);
+                registry.BeginReconciliation();
+                return admitted;
+            });
+
+        var result = service.Bind(PluginId, OperationId, 1);
+
+        AssertRejected(result, PlatformProviderBindingStatus.AuthorityChanged);
+    }
+
+    [Fact]
+    public void HostLifecycleChangeAfterSchemaAdmissionRejectsTheOtherwiseValidBinding()
+    {
+        using var foreign = AlphaForeignBinding.Load();
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var host = new RecordingHost(
+            _ => PlatformProviderHostBindingResult.Bound(foreign.Binding),
+            (_, _) => PlatformProviderHostBindingStatus.ProviderAbsent);
+
+        var result = Service(registry, host).Bind(PluginId, OperationId, 1);
+
+        AssertRejected(result, PlatformProviderBindingStatus.ProviderAbsent);
+    }
+
+    [Fact]
+    public void UnexpectedRegistryAndHostFailuresAreClosedAndRedacted()
+    {
+        var hostFailure = Service(
+            EnabledRegistry(new[] { ItemLookup, StorageRead }),
+            new RecordingHost(_ => throw new InvalidOperationException("foreign details")))
+            .Bind(PluginId, OperationId, 1);
+        var registryFailure = new PlatformProviderBindingService(
+            new Lazy<PlatformProviderRegistry>(() => throw new InvalidOperationException("store details")),
+            new RecordingHost(_ => throw new InvalidOperationException("must not bind")))
+            .Bind(PluginId, OperationId, 1);
+        using var foreign = AlphaForeignBinding.Load();
+        var revalidationFailure = Service(
+            EnabledRegistry(new[] { ItemLookup, StorageRead }),
+            new RecordingHost(
+                _ => PlatformProviderHostBindingResult.Bound(foreign.Binding),
+                (_, _) => throw new InvalidOperationException("host topology details")))
+            .Bind(PluginId, OperationId, 1);
+
+        AssertRejected(hostFailure, PlatformProviderBindingStatus.BindingFailed);
+        AssertRejected(registryFailure, PlatformProviderBindingStatus.BindingFailed);
+        AssertRejected(revalidationFailure, PlatformProviderBindingStatus.BindingFailed);
+    }
+
+    public static TheoryData<int, int>
+        HostRejections => new()
+        {
+            { (int)PlatformProviderHostBindingStatus.ProviderAbsent, (int)PlatformProviderBindingStatus.ProviderAbsent },
+            { (int)PlatformProviderHostBindingStatus.ProviderNotActive, (int)PlatformProviderBindingStatus.ProviderNotActive },
+            { (int)PlatformProviderHostBindingStatus.HostIdentityChanged, (int)PlatformProviderBindingStatus.HostIdentityChanged },
+            { (int)PlatformProviderHostBindingStatus.ProviderInstanceUnavailable, (int)PlatformProviderBindingStatus.ProviderInstanceUnavailable },
+            { (int)PlatformProviderHostBindingStatus.EntrypointMissing, (int)PlatformProviderBindingStatus.EntrypointMissing },
+            { (int)PlatformProviderHostBindingStatus.AbiMismatch, (int)PlatformProviderBindingStatus.AbiMismatch },
+            { (int)PlatformProviderHostBindingStatus.ServiceUnavailable, (int)PlatformProviderBindingStatus.ServiceUnavailable },
+            { (int)PlatformProviderHostBindingStatus.ServiceResolutionFailed, (int)PlatformProviderBindingStatus.ServiceResolutionFailed },
+            { (int)PlatformProviderHostBindingStatus.BindingFailed, (int)PlatformProviderBindingStatus.BindingFailed },
+        };
+
+    private static PlatformProviderBindingService Service(
+        PlatformProviderRegistry registry,
+        IPlatformProviderBindingHost host) => new(new Lazy<PlatformProviderRegistry>(() => registry), host);
+
+    private static PlatformProviderRegistry PendingRegistry()
+    {
+        var registry = Registry();
+        Reconcile(registry);
+        return registry;
+    }
+
+    private static PlatformProviderRegistry EnabledRegistry(IReadOnlyList<string> grants)
+    {
+        var registry = PendingRegistry();
+        var entry = Assert.Single(registry.Snapshot.Entries);
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.Applied,
+            registry.Apply(
+                PlatformProviderAdminCommand.Approve(
+                    registry.Snapshot.Revision,
+                    PluginId,
+                    entry.Generation,
+                    entry.Fingerprint!,
+                    grants,
+                    "Approve provider binding service test"),
+                AdminAuthorization()).Status);
+        return registry;
+    }
+
+    private static PlatformProviderRegistry Registry() =>
+        new(new RecordingStore(), new FixedTimeProvider(Now));
+
+    private static void Reconcile(PlatformProviderRegistry registry)
+    {
+        var snapshot = PlatformInstalledManifestBindingTests.Snapshot(
+            pluginId: PluginId,
+            version: new Version(1, 0, 0, 0));
+        var observation = PlatformInstalledManifestBinder.Bind(
+            snapshot,
+            PlatformInstalledManifestBindingTests.Snapshot(
+                pluginId: PluginId,
+                version: new Version(1, 0, 0, 0)),
+            PlatformInstalledManifestReadResult.Acquired(
+                File.ReadAllBytes(AlphaManifestPath()),
+                "sha256:provider-binding-service-test"));
+        var sweep = PlatformInstalledManifestSweep.EstablishCompleted(
+            ImmutableArray.Create(observation));
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.Applied,
+            registry.Reconcile(registry.BeginReconciliation(), sweep).Status);
+    }
+
+    private static PlatformProviderAdminAuthorization AdminAuthorization()
+    {
+        var boundaryActor = PlatformActorTestFactory.Create(
+            AdminId,
+            isElevated: true,
+            "provider-binding-service-test",
+            "test-client",
+            "test-device");
+        return Assert.IsType<PlatformProviderAdminAuthorization>(
+            PlatformProviderRegistryAdminBoundary.ReauthorizeElevatedAdministrator(
+                boundaryActor,
+                new ReauthorizationHost()));
+    }
+
+    private static void AssertRejected(
+        PlatformProviderBindingResult result,
+        PlatformProviderBindingStatus expected)
+    {
+        Assert.Equal(expected, result.Status);
+        Assert.Null(result.Binding);
+    }
+
+    private static string AlphaManifestPath() => Path.Combine(
+        RepositoryRoot(),
+        "conformance",
+        "platform-providers",
+        "Jellyfin.Plugin.CanopyConformance.Alpha",
+        "jellyfin-canopy-extension.json");
+
+    private static string AlphaAssemblyPath() => Path.Combine(
+        RepositoryRoot(),
+        "conformance",
+        "platform-providers",
+        "Jellyfin.Plugin.CanopyConformance.Alpha",
+        "bin",
+        "Release",
+        "net10.0",
+        "Jellyfin.Plugin.CanopyConformance.Alpha.dll");
+
+    private static string RepositoryRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(Path.GetDirectoryName(sourceFile)!, "..", ".."));
+
+    private sealed class RecordingHost(
+        Func<PlatformProviderHostBindingRequest, PlatformProviderHostBindingResult> bind,
+        Func<PlatformProviderHostBindingRequest, PlatformProviderForeignEntrypoint,
+            PlatformProviderHostBindingStatus>? revalidate = null)
+        : IPlatformProviderBindingHost
+    {
+        internal List<PlatformProviderHostBindingRequest> Requests { get; } = [];
+
+        public PlatformProviderHostBindingResult Bind(PlatformProviderHostBindingRequest request)
+        {
+            Requests.Add(request);
+            return bind(request);
+        }
+
+        public PlatformProviderHostBindingStatus Revalidate(
+            PlatformProviderHostBindingRequest request,
+            PlatformProviderForeignEntrypoint binding) =>
+            revalidate?.Invoke(request, binding) ?? PlatformProviderHostBindingStatus.Bound;
+    }
+
+    private sealed class AlphaForeignBinding : IDisposable
+    {
+        private readonly AssemblyLoadContext _loadContext;
+
+        private AlphaForeignBinding(
+            AssemblyLoadContext loadContext,
+            IPlugin pluginInstance,
+            PlatformProviderForeignEntrypoint binding)
+        {
+            _loadContext = loadContext;
+            PluginInstance = pluginInstance;
+            Binding = binding;
+        }
+
+        internal IPlugin PluginInstance { get; }
+
+        internal PlatformProviderForeignEntrypoint Binding { get; }
+
+        internal static AlphaForeignBinding Load()
+        {
+            var loadContext = new AssemblyLoadContext(
+                "provider-binding-service-alpha-" + Guid.NewGuid().ToString("N"),
+                isCollectible: true);
+            var assembly = loadContext.LoadFromAssemblyPath(AlphaAssemblyPath());
+            var type = assembly.GetType(PlatformProviderAbiContract.EntrypointTypeName)
+                ?? throw new InvalidOperationException("The Alpha fixture entrypoint is missing.");
+            var instance = Activator.CreateInstance(type)!;
+            var pluginType = assembly.GetType(
+                "Jellyfin.Plugin.CanopyConformance.Alpha.AlphaPlugin")
+                ?? throw new InvalidOperationException("The Alpha fixture plugin type is missing.");
+            var pluginInstance = Assert.IsAssignableFrom<IPlugin>(
+                RuntimeHelpers.GetUninitializedObject(pluginType));
+            var method = Assert.Single(type.GetMethods(BindingFlags.Public | BindingFlags.Instance),
+                candidate => candidate.Name == PlatformProviderAbiContract.InvocationMethodName);
+            return new AlphaForeignBinding(
+                loadContext,
+                pluginInstance,
+                new PlatformProviderForeignEntrypoint(
+                    assembly,
+                    pluginInstance,
+                    type,
+                    instance,
+                    method));
+        }
+
+        public void Dispose() => _loadContext.Unload();
+    }
+
+    private sealed class RecordingStore : IPlatformProviderRegistryStateStore
+    {
+        private PlatformProviderRegistryDurableState _state = PlatformProviderRegistryDurableState.Empty;
+
+        public PlatformProviderRegistryStoreLoadResult Load() =>
+            PlatformProviderRegistryStoreLoadResult.Healthy(_state);
+
+        public void Save(PlatformProviderRegistryDurableState state) => _state = state;
+
+        public void ResetQuarantined(Guid administratorId, string reason, DateTimeOffset decidedAtUtc) =>
+            _state = PlatformProviderRegistryDurableState.Empty;
+
+        public void FenceQuarantined()
+        {
+        }
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class ReauthorizationHost : IPlatformHost, IHostUsers
+    {
+        public IHostUsers Users => this;
+
+        public IHostLibrary Library => throw new NotSupportedException();
+
+        public IHostSessions Sessions => throw new NotSupportedException();
+
+        public IHostPlugins Plugins => throw new NotSupportedException();
+
+        public HostUser? Find(Guid id) => id == AdminId
+            ? new HostUser(AdminId, "Registry admin", true)
+            : null;
+
+        public IReadOnlyList<HostUser> All() => [];
+    }
+
+    public sealed class LocalExactEntrypoint
+    {
+        public Task<string> InvokeAsync(
+            string operationId,
+            string requestJson,
+            CancellationToken cancellationToken) => Task.FromResult("{}");
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderEmbeddedSchemaAdmissionTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderEmbeddedSchemaAdmissionTests.cs
@@ -1,0 +1,730 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformProviderEmbeddedSchemaAdmissionTests
+{
+    private const string RequestId =
+        "urn:jellyfin-canopy:provider-schema:org.example:hello:request:1";
+    private const string ResponseId =
+        "urn:jellyfin-canopy:provider-schema:org.example:hello:response:1";
+
+    [Fact]
+    public void StatusBoundsAndImmutablePublishedShapesAreExact()
+    {
+        Assert.Equal(
+            new[]
+            {
+                "Admitted", "InvalidInput", "SchemaMissing", "SchemaResourceAmbiguous",
+                "SchemaReadFailed", "SchemaTooLarge", "SchemaHashMismatch",
+                "SchemaInvalidUtf8", "SchemaInvalidJson", "SchemaBoundsExceeded",
+                "SchemaIdentityMismatch", "SchemaDialectUnsupported",
+                "SchemaExternalReference", "SchemaVocabularyUnsupported",
+            },
+            Enum.GetNames<PlatformProviderEmbeddedSchemaAdmissionStatus>());
+        Assert.Equal(
+            Enumerable.Range(0, 14),
+            Enum.GetValues<PlatformProviderEmbeddedSchemaAdmissionStatus>()
+                .Select(value => (int)value));
+
+        Assert.Equal(64 * 1024, PlatformProviderEmbeddedSchemaAdmission.MaximumDocumentBytes);
+        Assert.Equal(12, PlatformProviderEmbeddedSchemaAdmission.MaximumJsonDepth);
+        Assert.Equal(64, PlatformProviderEmbeddedSchemaAdmission.MaximumObjectProperties);
+        Assert.Equal(64, PlatformProviderEmbeddedSchemaAdmission.MaximumArrayItems);
+        Assert.Equal(256, PlatformProviderEmbeddedSchemaAdmission.MaximumPropertyNameBytes);
+        Assert.Equal(4 * 1024, PlatformProviderEmbeddedSchemaAdmission.MaximumStringBytes);
+        Assert.Equal(1024, PlatformProviderEmbeddedSchemaAdmission.MaximumResourceCount);
+        Assert.Equal(512, PlatformProviderEmbeddedSchemaAdmission.MaximumResourceNameBytes);
+        Assert.Equal(
+            "https://json-schema.org/draft/2020-12/schema",
+            PlatformProviderEmbeddedSchemaAdmission.JsonSchemaDialect);
+
+        AssertImmutable(
+            typeof(PlatformProviderEmbeddedSchemaAdmissionResult),
+            new[] { "Schemas", "Status" });
+        AssertImmutable(
+            typeof(PlatformProviderEmbeddedSchemaPair),
+            new[] { "RequestSchema", "ResponseSchema" });
+        Assert.DoesNotContain(
+            typeof(PlatformProviderEmbeddedSchemaAdmissionResult)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+            property => new[]
+            {
+                "Bytes", "Assembly", "Resource", "Path", "Url", "Exception", "Detail",
+            }.Any(token => property.Name.Contains(token, StringComparison.OrdinalIgnoreCase)));
+
+        var admit = typeof(PlatformProviderEmbeddedSchemaAdmission).GetMethod(
+            "Admit",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(admit);
+        Assert.Equal(
+            new[]
+            {
+                typeof(Assembly), typeof(string), typeof(string), typeof(string), typeof(string),
+            },
+            admit!.GetParameters().Select(parameter => parameter.ParameterType));
+    }
+
+    [Fact]
+    public void ExactPairIsAdmittedAtomicallyAndSurvivesSourceMutation()
+    {
+        var requestBytes = Schema(RequestId);
+        var responseBytes = Schema(ResponseId);
+        var assembly = ResourceAssembly.WithSchemas(requestBytes, responseBytes);
+
+        var result = Admit(assembly, RequestId, requestBytes, ResponseId, responseBytes);
+
+        Assert.Equal(PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted, result.Status);
+        var pair = Assert.IsType<PlatformProviderEmbeddedSchemaPair>(result.Schemas);
+        Array.Fill(requestBytes, (byte)'x');
+        Array.Fill(responseBytes, (byte)'y');
+        Assert.Equal(RequestId, pair.RequestSchema.GetProperty("$id").GetString());
+        Assert.Equal(ResponseId, pair.ResponseSchema.GetProperty("$id").GetString());
+        Assert.Equal(JsonValueKind.Object, pair.RequestSchema.ValueKind);
+        Assert.Equal(JsonValueKind.Object, pair.ResponseSchema.ValueKind);
+        Assert.Equal(2, assembly.OpenCount);
+    }
+
+    [Fact]
+    public void IndependentAlphaAssemblyAdmitsItsExactSchemasFromACollectibleLoadContext()
+    {
+        var root = RepositoryRoot();
+        var fixtureRoot = Path.Combine(
+            root,
+            "conformance",
+            "platform-providers",
+            "Jellyfin.Plugin.CanopyConformance.Alpha");
+        using var manifest = JsonDocument.Parse(File.ReadAllBytes(
+            Path.Combine(fixtureRoot, "jellyfin-canopy-extension.json")));
+        var operation = Assert.Single(
+            manifest.RootElement.GetProperty("providerOperations").EnumerateArray());
+        var assemblyPath = Path.Combine(
+            fixtureRoot,
+            "bin",
+            "Release",
+            "net10.0",
+            "Jellyfin.Plugin.CanopyConformance.Alpha.dll");
+        var loadContext = new AssemblyLoadContext(
+            "provider-schema-admission-alpha",
+            isCollectible: true);
+        try
+        {
+            var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+            Assert.NotSame(
+                AssemblyLoadContext.GetLoadContext(typeof(PlatformProviderEmbeddedSchemaAdmission).Assembly),
+                AssemblyLoadContext.GetLoadContext(assembly));
+
+            var result = PlatformProviderEmbeddedSchemaAdmission.Admit(
+                assembly,
+                operation.GetProperty("requestSchemaId").GetString()!,
+                operation.GetProperty("requestSchemaSha256").GetString()!,
+                operation.GetProperty("responseSchemaId").GetString()!,
+                operation.GetProperty("responseSchemaSha256").GetString()!);
+
+            Assert.Equal(PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted, result.Status);
+            var pair = Assert.IsType<PlatformProviderEmbeddedSchemaPair>(result.Schemas);
+            Assert.Equal(
+                operation.GetProperty("requestSchemaId").GetString(),
+                pair.RequestSchema.GetProperty("$id").GetString());
+            Assert.Equal(
+                operation.GetProperty("responseSchemaId").GetString(),
+                pair.ResponseSchema.GetProperty("$id").GetString());
+        }
+        finally
+        {
+            loadContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void SameDigestIsOpenedAndParsedOnceButStillChecksBothExpectedIds()
+    {
+        var bytes = Schema(RequestId);
+        var digest = Digest(bytes);
+        var assembly = ResourceAssembly.WithResource(ResourceName(digest), bytes);
+
+        var admitted = PlatformProviderEmbeddedSchemaAdmission.Admit(
+            assembly,
+            RequestId,
+            digest,
+            RequestId,
+            digest);
+        var mismatched = PlatformProviderEmbeddedSchemaAdmission.Admit(
+            assembly,
+            RequestId,
+            digest,
+            ResponseId,
+            digest);
+
+        Assert.Equal(PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted, admitted.Status);
+        Assert.Equal(
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaIdentityMismatch,
+            mismatched.Status);
+        Assert.Null(mismatched.Schemas);
+        Assert.Equal(2, assembly.OpenCount);
+    }
+
+    [Fact]
+    public void InvalidInputsFailBeforeAssemblyEnumerationOrResourceRead()
+    {
+        var bytes = Schema(RequestId);
+        var digest = Digest(bytes);
+        var assembly = ResourceAssembly.WithResource(ResourceName(digest), bytes);
+
+        foreach (var result in new[]
+        {
+            PlatformProviderEmbeddedSchemaAdmission.Admit(
+                assembly, string.Empty, digest, RequestId, digest),
+            PlatformProviderEmbeddedSchemaAdmission.Admit(
+                assembly, RequestId, digest.ToUpperInvariant(), RequestId, digest),
+            PlatformProviderEmbeddedSchemaAdmission.Admit(
+                assembly, RequestId, digest[..^1], RequestId, digest),
+            PlatformProviderEmbeddedSchemaAdmission.Admit(
+                assembly, "urn:invalid:\uD800", digest, RequestId, digest),
+            PlatformProviderEmbeddedSchemaAdmission.Admit(
+                null!, RequestId, digest, RequestId, digest),
+        })
+        {
+            Assert.Equal(PlatformProviderEmbeddedSchemaAdmissionStatus.InvalidInput, result.Status);
+            Assert.Null(result.Schemas);
+        }
+
+        Assert.Equal(0, assembly.InventoryCount);
+        Assert.Equal(0, assembly.OpenCount);
+    }
+
+    [Fact]
+    public void MissingAmbiguousInventoryAndReadFailuresAreClosedAndRedacted()
+    {
+        var bytes = Schema(RequestId);
+        var digest = Digest(bytes);
+        var name = ResourceName(digest);
+
+        AssertRejected(
+            ResourceAssembly.Empty,
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaMissing);
+        AssertRejected(
+            new ResourceAssembly(new[] { name, name }, _ => new MemoryStream(bytes)),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaResourceAmbiguous);
+        AssertRejected(
+            new ResourceAssembly(new[] { name }, _ => null),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaMissing);
+        AssertRejected(
+            new ResourceAssembly(new[] { name }, _ => new ThrowingReadStream()),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed);
+        AssertRejected(
+            ResourceAssembly.ThrowingInventory(),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed);
+        AssertRejected(
+            ResourceAssembly.NullInventory(),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed);
+    }
+
+    [Fact]
+    public void ResourceInventoryCountAndNameBytesHaveExactNegativeBoundaries()
+    {
+        var bytes = Schema(RequestId);
+        var digest = Digest(bytes);
+        var resourceName = ResourceName(digest);
+        var exactNames = Enumerable.Range(
+                0,
+                PlatformProviderEmbeddedSchemaAdmission.MaximumResourceCount - 1)
+            .Select(index => "Fixture.Decoy." + index)
+            .Append(resourceName)
+            .ToArray();
+        var exact = new ResourceAssembly(
+            exactNames,
+            requested => string.Equals(requested, resourceName, StringComparison.Ordinal)
+                ? new MemoryStream(bytes, writable: false)
+                : null);
+        var over = new ResourceAssembly(
+            exactNames.Append("Fixture.Decoy.Over").ToArray(),
+            _ => throw new InvalidOperationException("must not open"));
+
+        Assert.Equal(
+            PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted,
+            AdmitSame(exact, RequestId, digest).Status);
+        AssertRejected(
+            over,
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded);
+        Assert.Equal(0, over.OpenCount);
+
+        var exactName = new string(
+            'n',
+            PlatformProviderEmbeddedSchemaAdmission.MaximumResourceNameBytes);
+        var longName = exactName + "n";
+        AssertRejected(
+            new ResourceAssembly(new[] { exactName }, _ => null),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaMissing);
+        AssertRejected(
+            new ResourceAssembly(new[] { longName }, _ => throw new InvalidOperationException("must not open")),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded);
+    }
+
+    [Fact]
+    public void ReaderAcceptsExactMaximumAndRejectsMaximumPlusOneUsingCapPlusOne()
+    {
+        var exact = PadWithJsonWhitespace(
+            Schema(RequestId),
+            PlatformProviderEmbeddedSchemaAdmission.MaximumDocumentBytes);
+        var over = PadWithJsonWhitespace(
+            Schema(RequestId),
+            PlatformProviderEmbeddedSchemaAdmission.MaximumDocumentBytes + 1);
+        var exactAssembly = ResourceAssembly.WithResource(
+            ResourceName(Digest(exact)),
+            exact,
+            bytesPerRead: 7);
+        var overAssembly = ResourceAssembly.WithResource(
+            ResourceName(Digest(over)),
+            over,
+            bytesPerRead: 7);
+
+        Assert.Equal(
+            PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted,
+            AdmitSame(exactAssembly, RequestId, Digest(exact)).Status);
+        Assert.Equal(
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaTooLarge,
+            AdmitSame(overAssembly, RequestId, Digest(over)).Status);
+        Assert.Equal(
+            PlatformProviderEmbeddedSchemaAdmission.MaximumDocumentBytes + 1,
+            overAssembly.BytesRead);
+    }
+
+    [Fact]
+    public void ExactHashIsVerifiedBeforeUtf8AndJsonAdmission()
+    {
+        var valid = Schema(RequestId);
+        var digest = Digest(valid);
+        var different = Schema(RequestId, root => root["title"] = "different");
+        AssertRejected(
+            ResourceAssembly.WithResource(ResourceName(digest), different),
+            RequestId,
+            digest,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaHashMismatch);
+
+        var invalidUtf8 = valid.Concat(new byte[] { 0xFF }).ToArray();
+        AssertRejected(
+            ResourceAssembly.WithResource(ResourceName(Digest(invalidUtf8)), invalidUtf8),
+            RequestId,
+            Digest(invalidUtf8),
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidUtf8);
+
+        var bom = new byte[] { 0xEF, 0xBB, 0xBF }.Concat(valid).ToArray();
+        AssertRejected(
+            ResourceAssembly.WithResource(ResourceName(Digest(bom)), bom),
+            RequestId,
+            Digest(bom),
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidUtf8);
+    }
+
+    [Fact]
+    public void MalformedDuplicateTrailingAndNonObjectJsonAreRejected()
+    {
+        AssertContentRejected(
+            RequestId,
+            Encoding.UTF8.GetBytes("{\"$schema\":"),
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson);
+        AssertContentRejected(
+            RequestId,
+            Encoding.UTF8.GetBytes(
+                "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+                + "\"$id\":\"" + RequestId + "\",\"type\":\"object\",\"type\":\"object\"}"),
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson);
+        AssertContentRejected(
+            RequestId,
+            Schema(RequestId).Concat(Encoding.UTF8.GetBytes(" true")).ToArray(),
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson);
+        AssertContentRejected(
+            RequestId,
+            Encoding.UTF8.GetBytes("true"),
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson);
+    }
+
+    [Fact]
+    public void IdentityAndDialectMustBeExactAndPairFailurePublishesNothing()
+    {
+        var request = Schema(RequestId);
+        var wrongId = Schema("urn:wrong");
+        var wrongDialect = Schema(ResponseId, root =>
+            root["$schema"] = "https://json-schema.org/draft/2019-09/schema");
+
+        AssertContentRejected(
+            RequestId,
+            wrongId,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaIdentityMismatch);
+        AssertContentRejected(
+            ResponseId,
+            wrongDialect,
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaDialectUnsupported);
+
+        var assembly = ResourceAssembly.WithSchemas(request, wrongDialect);
+        var result = Admit(assembly, RequestId, request, ResponseId, wrongDialect);
+        Assert.Equal(
+            PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaDialectUnsupported,
+            result.Status);
+        Assert.Null(result.Schemas);
+    }
+
+    [Fact]
+    public void DepthPropertyArrayPropertyNameAndStringBoundsHaveExactNegativeBoundaries()
+    {
+        AssertAdmitted(NestedSchema(RequestId, 11));
+        AssertBoundsRejected(NestedSchema(RequestId, 12));
+
+        AssertAdmitted(ObjectPropertySchema(RequestId, 61));
+        AssertBoundsRejected(ObjectPropertySchema(RequestId, 62));
+
+        AssertAdmitted(ArrayItemSchema(RequestId, 64));
+        AssertBoundsRejected(ArrayItemSchema(RequestId, 65));
+
+        AssertAdmitted(PropertyNameSchema(
+            RequestId,
+            new string('p', PlatformProviderEmbeddedSchemaAdmission.MaximumPropertyNameBytes)));
+        AssertBoundsRejected(PropertyNameSchema(
+            RequestId,
+            new string('p', PlatformProviderEmbeddedSchemaAdmission.MaximumPropertyNameBytes + 1)));
+
+        AssertAdmitted(StringSchema(
+            RequestId,
+            new string('s', PlatformProviderEmbeddedSchemaAdmission.MaximumStringBytes)));
+        AssertBoundsRejected(StringSchema(
+            RequestId,
+            new string('s', PlatformProviderEmbeddedSchemaAdmission.MaximumStringBytes + 1)));
+    }
+
+    [Fact]
+    public void OnlyLocalStaticAndDynamicReferencesAreAdmitted()
+    {
+        AssertAdmitted(Schema(RequestId, root => root["$ref"] = "#/$defs/local"));
+        AssertAdmitted(Schema(RequestId, root => root["$dynamicRef"] = "#node"));
+        AssertExternalReference(Schema(RequestId, root => root["$ref"] = "other.json"));
+        AssertExternalReference(Schema(RequestId, root => root["$ref"] = "https://example.test/schema"));
+        AssertExternalReference(Schema(RequestId, root => root["$dynamicRef"] = "urn:remote"));
+        AssertExternalReference(Schema(RequestId, root => root["$ref"] = 1));
+    }
+
+    [Fact]
+    public void RequiredVocabularyIsClosedAndRecursiveKeywordsAreUnsupported()
+    {
+        AssertAdmitted(Schema(RequestId, root => root["$vocabulary"] = new JsonObject
+        {
+            ["https://json-schema.org/draft/2020-12/vocab/core"] = true,
+            ["urn:optional-custom"] = false,
+        }));
+        AssertVocabularyRejected(Schema(RequestId, root => root["$vocabulary"] = new JsonObject
+        {
+            ["urn:required-custom"] = true,
+        }));
+        AssertVocabularyRejected(Schema(RequestId, root => root["$vocabulary"] = "invalid"));
+        AssertVocabularyRejected(Schema(RequestId, root => root["$recursiveRef"] = "#"));
+        AssertVocabularyRejected(Schema(RequestId, root => root["$recursiveAnchor"] = true));
+    }
+
+    [Fact]
+    public void ProductionOwnerHasNoInvocationPathNetworkFilesystemCacheOrLoggingSurface()
+    {
+        var source = File.ReadAllText(ProductionSourcePath());
+        var code = PlatformHostSeamTests.CodeOnly(source);
+
+        Assert.Contains("GetManifestResourceStream(resourceName)", code, StringComparison.Ordinal);
+        Assert.Contains("SHA256.HashData(bytes)", code, StringComparison.Ordinal);
+        Assert.Contains("root.Clone()", code, StringComparison.Ordinal);
+        foreach (var forbidden in new[]
+        {
+            "MethodInfo.Invoke", ".Invoke(instance", "InvokeAsync(", "Assembly.Load",
+            "LoadFromAssemblyPath", "Activator", "System.Net", "HttpClient", "File.",
+            "Directory.", "Path.", "IPluginManager", "LocalPlugin", "IServiceProvider",
+            "Controller", "Route(", "IHostedService", "BackgroundService", "Timer",
+            "ConcurrentDictionary", "MemoryCache", "ILogger", "Android",
+        })
+        {
+            Assert.DoesNotContain(forbidden, code, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static PlatformProviderEmbeddedSchemaAdmissionResult Admit(
+        ResourceAssembly assembly,
+        string requestId,
+        byte[] request,
+        string responseId,
+        byte[] response) => PlatformProviderEmbeddedSchemaAdmission.Admit(
+            assembly,
+            requestId,
+            Digest(request),
+            responseId,
+            Digest(response));
+
+    private static PlatformProviderEmbeddedSchemaAdmissionResult AdmitSame(
+        ResourceAssembly assembly,
+        string id,
+        string digest) => PlatformProviderEmbeddedSchemaAdmission.Admit(
+            assembly,
+            id,
+            digest,
+            id,
+            digest);
+
+    private static void AssertRejected(
+        ResourceAssembly assembly,
+        string id,
+        string digest,
+        PlatformProviderEmbeddedSchemaAdmissionStatus expected)
+    {
+        var result = AdmitSame(assembly, id, digest);
+        Assert.Equal(expected, result.Status);
+        Assert.Null(result.Schemas);
+    }
+
+    private static void AssertContentRejected(
+        string id,
+        byte[] bytes,
+        PlatformProviderEmbeddedSchemaAdmissionStatus expected) => AssertRejected(
+            ResourceAssembly.WithResource(ResourceName(Digest(bytes)), bytes),
+            id,
+            Digest(bytes),
+            expected);
+
+    private static void AssertAdmitted(byte[] bytes) => Assert.Equal(
+        PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted,
+        AdmitSame(
+            ResourceAssembly.WithResource(ResourceName(Digest(bytes)), bytes),
+            RequestId,
+            Digest(bytes)).Status);
+
+    private static void AssertBoundsRejected(byte[] bytes) => AssertContentRejected(
+        RequestId,
+        bytes,
+        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded);
+
+    private static void AssertExternalReference(byte[] bytes) => AssertContentRejected(
+        RequestId,
+        bytes,
+        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaExternalReference);
+
+    private static void AssertVocabularyRejected(byte[] bytes) => AssertContentRejected(
+        RequestId,
+        bytes,
+        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaVocabularyUnsupported);
+
+    private static byte[] Schema(string id, Action<JsonObject>? mutate = null)
+    {
+        var root = new JsonObject
+        {
+            ["$schema"] = PlatformProviderEmbeddedSchemaAdmission.JsonSchemaDialect,
+            ["$id"] = id,
+            ["type"] = "object",
+        };
+        mutate?.Invoke(root);
+        return JsonSerializer.SerializeToUtf8Bytes(root);
+    }
+
+    private static byte[] NestedSchema(string id, int nestedObjects) => Schema(id, root =>
+    {
+        JsonObject current = root;
+        for (var index = 0; index < nestedObjects; index++)
+        {
+            var child = new JsonObject();
+            current["x"] = child;
+            current = child;
+        }
+    });
+
+    private static byte[] ObjectPropertySchema(string id, int customProperties) => Schema(id, root =>
+    {
+        for (var index = 0; index < customProperties; index++)
+        {
+            root["x" + index] = true;
+        }
+    });
+
+    private static byte[] ArrayItemSchema(string id, int items) => Schema(id, root =>
+        root["x"] = new JsonArray(Enumerable.Range(0, items)
+            .Select(index => JsonValue.Create(index))
+            .ToArray()));
+
+    private static byte[] PropertyNameSchema(string id, string propertyName) => Schema(id, root =>
+        root[propertyName] = true);
+
+    private static byte[] StringSchema(string id, string value) => Schema(id, root =>
+        root["x"] = value);
+
+    private static byte[] PadWithJsonWhitespace(byte[] source, int length)
+    {
+        Assert.True(source.Length <= length);
+        var result = new byte[length];
+        source.CopyTo(result, 0);
+        result.AsSpan(source.Length).Fill((byte)' ');
+        return result;
+    }
+
+    private static string Digest(byte[] bytes) =>
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static string ResourceName(string digest) =>
+        PlatformProviderAbiContract.ProviderSchemaResourcePrefix
+        + digest
+        + PlatformProviderAbiContract.ProviderSchemaResourceSuffix;
+
+    private static void AssertImmutable(Type type, IReadOnlyList<string> properties)
+    {
+        Assert.True(type.IsSealed);
+        Assert.Empty(type.GetConstructors(BindingFlags.Instance | BindingFlags.Public));
+        var actual = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(properties, actual.Select(property => property.Name));
+        Assert.All(actual, property => Assert.False(property.CanWrite));
+    }
+
+    private static string ProductionSourcePath([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(sourceFile)!,
+            "..",
+            "..",
+            "Jellyfin.Plugin.JellyfinCanopy",
+            "Platform",
+            "PlatformProviderEmbeddedSchemaAdmission.cs"));
+
+    private static string RepositoryRoot([CallerFilePath] string sourceFile = "") =>
+        Path.GetFullPath(Path.Combine(Path.GetDirectoryName(sourceFile)!, "..", ".."));
+
+    private sealed class ResourceAssembly : Assembly
+    {
+        private readonly string[] _names;
+        private readonly Func<string, Stream?> _open;
+        private readonly bool _throwInventory;
+        private readonly bool _returnNullInventory;
+
+        internal ResourceAssembly(
+            string[] names,
+            Func<string, Stream?> open,
+            bool throwInventory = false,
+            bool returnNullInventory = false)
+        {
+            _names = names;
+            _open = open;
+            _throwInventory = throwInventory;
+            _returnNullInventory = returnNullInventory;
+        }
+
+        internal static ResourceAssembly Empty { get; } = new([], _ => null);
+
+        internal int InventoryCount { get; private set; }
+
+        internal int OpenCount { get; private set; }
+
+        internal int BytesRead { get; private set; }
+
+        public override string[] GetManifestResourceNames()
+        {
+            InventoryCount++;
+            if (_throwInventory)
+            {
+                throw new InvalidOperationException("sensitive inventory failure");
+            }
+
+            if (_returnNullInventory)
+            {
+                return null!;
+            }
+
+            return _names.ToArray();
+        }
+
+        public override Stream? GetManifestResourceStream(string name)
+        {
+            OpenCount++;
+            return _open(name);
+        }
+
+        internal static ResourceAssembly WithSchemas(byte[] request, byte[] response) =>
+            WithResources(new Dictionary<string, byte[]>(StringComparer.Ordinal)
+            {
+                [ResourceName(Digest(request))] = request,
+                [ResourceName(Digest(response))] = response,
+            });
+
+        internal static ResourceAssembly WithResource(
+            string name,
+            byte[] bytes,
+            int bytesPerRead = int.MaxValue)
+        {
+            ResourceAssembly? assembly = null;
+            assembly = new ResourceAssembly(
+                new[] { name },
+                requested => string.Equals(requested, name, StringComparison.Ordinal)
+                    ? new TrackingReadStream(
+                        bytes,
+                        bytesPerRead,
+                        count => assembly!.BytesRead += count)
+                    : null);
+            return assembly;
+        }
+
+        internal static ResourceAssembly ThrowingInventory() =>
+            new([], _ => null, throwInventory: true);
+
+        internal static ResourceAssembly NullInventory() =>
+            new([], _ => null, returnNullInventory: true);
+
+        private static ResourceAssembly WithResources(IReadOnlyDictionary<string, byte[]> resources) =>
+            new(
+                resources.Keys.ToArray(),
+                name => resources.TryGetValue(name, out var bytes)
+                    ? new MemoryStream(bytes, writable: false)
+                    : null);
+
+    }
+
+    private sealed class TrackingReadStream : MemoryStream
+    {
+        private readonly int _bytesPerRead;
+        private readonly Action<int> _record;
+
+        internal TrackingReadStream(byte[] bytes, int bytesPerRead, Action<int> record)
+            : base(bytes, writable: false)
+        {
+            _bytesPerRead = bytesPerRead;
+            _record = record;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = base.Read(buffer, offset, Math.Min(count, _bytesPerRead));
+            _record(read);
+            return read;
+        }
+    }
+
+    private sealed class ThrowingReadStream : MemoryStream
+    {
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new IOException("sensitive read failure");
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderOperationBindingClaimTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderOperationBindingClaimTests.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
+
+public sealed class PlatformProviderOperationBindingClaimTests
+{
+    private const string OperationId = "org.example.provider.hello";
+    private const string AssemblyIdentity = "Example.Provider, Version=1.2.3.4";
+    private const string ItemLookup = "jellyfin.canopy.items.lookup";
+    private const string StorageRead = "jellyfin.canopy.storage.read";
+    private static readonly Guid PluginId = new("11111111-2222-3333-4444-555555555555");
+    private static readonly Guid AdminId = new("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static readonly DateTimeOffset Now = new(2026, 8, 4, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ExactCurrentEnabledOperationProducesImmutableBindingFacts()
+    {
+        var registry = EnabledRegistry(new[] { StorageRead, ItemLookup });
+        var entry = Assert.Single(registry.Snapshot.Entries);
+
+        var result = registry.ClaimOperationBinding(PluginId, OperationId, negotiatedProtocol: 1);
+
+        Assert.Equal(PlatformProviderOperationBindingClaimStatus.Claimed, result.Status);
+        var claim = Assert.IsType<PlatformProviderOperationBindingClaim>(result.Claim);
+        Assert.Equal(PluginId, claim.PluginId);
+        Assert.Equal(entry.Fingerprint, claim.Fingerprint);
+        Assert.Equal(entry.Generation, claim.Generation);
+        Assert.Equal(new Version(1, 2, 3, 4), claim.HostVersion);
+        Assert.Equal(AssemblyIdentity, claim.AssemblyIdentity);
+        Assert.Equal(1, claim.NegotiatedProtocol);
+        Assert.Equal(OperationId, claim.Operation.Id);
+        Assert.Equal(1, claim.Operation.ProtocolRange.Min);
+        Assert.Equal(1, claim.Operation.ProtocolRange.Max);
+        Assert.Equal(new[] { ItemLookup }, CapabilityIds(claim.Operation));
+        Assert.Equal(new[] { ItemLookup, StorageRead }, claim.GrantedCapabilityIds);
+        Assert.Equal(
+            "urn:jellyfin-canopy:provider-schema:org.example.provider:org.example.provider.hello:request:1",
+            claim.Operation.RequestSchemaId);
+        Assert.Equal(new string('a', 64), claim.Operation.RequestSchemaSha256);
+        Assert.Equal(
+            "urn:jellyfin-canopy:provider-schema:org.example.provider:org.example.provider.hello:response:1",
+            claim.Operation.ResponseSchemaId);
+        Assert.Equal(new string('b', 64), claim.Operation.ResponseSchemaSha256);
+        Assert.True(registry.RevalidateOperationBindingClaim(claim));
+
+        var copy = claim.GrantedCapabilityIds;
+        copy = copy.SetItem(0, StorageRead);
+        Assert.Equal(new[] { ItemLookup, StorageRead }, claim.GrantedCapabilityIds);
+    }
+
+    [Fact]
+    public void ClaimAndResultShapesAreClosedAndNonPubliclyConstructible()
+    {
+        Assert.True(typeof(PlatformProviderOperationBindingClaim).IsSealed);
+        Assert.Empty(typeof(PlatformProviderOperationBindingClaim).GetConstructors());
+        Assert.True(typeof(PlatformProviderOperationBindingClaimResult).IsValueType);
+        Assert.Equal(
+            new[]
+            {
+                PlatformProviderOperationBindingClaimStatus.Claimed,
+                PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable,
+                PlatformProviderOperationBindingClaimStatus.OperationUnavailable,
+                PlatformProviderOperationBindingClaimStatus.ProtocolUnsupported,
+                PlatformProviderOperationBindingClaimStatus.GrantInsufficient,
+            },
+            Enum.GetValues<PlatformProviderOperationBindingClaimStatus>());
+    }
+
+    [Fact]
+    public void NonCurrentAndIdentityOnlyProvidersAreNotCallable()
+    {
+        var pending = Registry(new RecordingStore());
+        Reconcile(pending, Acquired(hasOperation: true));
+        AssertRefused(
+            pending.ClaimOperationBinding(PluginId, OperationId, 1),
+            PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable);
+
+        var identityOnly = EnabledRegistry(new[] { ItemLookup }, hasOperation: false);
+        AssertRefused(
+            identityOnly.ClaimOperationBinding(PluginId, OperationId, 1),
+            PlatformProviderOperationBindingClaimStatus.OperationUnavailable);
+        AssertRefused(
+            identityOnly.ClaimOperationBinding(PluginId, "", 1),
+            PlatformProviderOperationBindingClaimStatus.OperationUnavailable);
+        AssertRefused(
+            identityOnly.ClaimOperationBinding(Guid.Empty, OperationId, 1),
+            PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable);
+    }
+
+    [Fact]
+    public void OperationProtocolAndGrantAreEvaluatedIndependently()
+    {
+        var fullGrant = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        AssertRefused(
+            fullGrant.ClaimOperationBinding(PluginId, "org.example.provider.unknown", 1),
+            PlatformProviderOperationBindingClaimStatus.OperationUnavailable);
+        AssertRefused(
+            fullGrant.ClaimOperationBinding(PluginId, OperationId, 2),
+            PlatformProviderOperationBindingClaimStatus.ProtocolUnsupported);
+        AssertRefused(
+            fullGrant.ClaimOperationBinding(PluginId, OperationId, 0),
+            PlatformProviderOperationBindingClaimStatus.ProtocolUnsupported);
+
+        var insufficientGrant = EnabledRegistry(new[] { StorageRead });
+        AssertRefused(
+            insufficientGrant.ClaimOperationBinding(PluginId, OperationId, 1),
+            PlatformProviderOperationBindingClaimStatus.GrantInsufficient);
+    }
+
+    [Fact]
+    public void ClaimCannotCrossRegistryEvenWhenEveryVisibleFactMatches()
+    {
+        var first = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var second = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var claim = AssertClaimed(first);
+        var secondClaim = AssertClaimed(second);
+
+        Assert.False(second.RevalidateOperationBindingClaim(claim));
+        Assert.False(first.RevalidateOperationBindingClaim(secondClaim));
+        Assert.True(first.RevalidateOperationBindingClaim(claim));
+        Assert.True(second.RevalidateOperationBindingClaim(secondClaim));
+    }
+
+    [Fact]
+    public void ReconciliationFencePermanentlyInvalidatesEarlierClaimEvenWhenFactsAreUnchanged()
+    {
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var claim = AssertClaimed(registry);
+
+        var epoch = registry.BeginReconciliation();
+        Assert.False(registry.RevalidateOperationBindingClaim(claim));
+        AssertRefused(
+            registry.ClaimOperationBinding(PluginId, OperationId, 1),
+            PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable);
+
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.Applied,
+            registry.Reconcile(epoch, Completed(Acquired(hasOperation: true))).Status);
+        Assert.False(registry.RevalidateOperationBindingClaim(claim));
+
+        var replacement = AssertClaimed(registry);
+        Assert.True(registry.RevalidateOperationBindingClaim(replacement));
+    }
+
+    [Theory]
+    [InlineData((int)PlatformProviderAdminOperation.ReplaceGrant)]
+    [InlineData((int)PlatformProviderAdminOperation.Disable)]
+    [InlineData((int)PlatformProviderAdminOperation.Revoke)]
+    public void EverySuccessfulAdministratorMutationInvalidatesEarlierClaim(
+        int operationValue)
+    {
+        var operation = (PlatformProviderAdminOperation)operationValue;
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var claim = AssertClaimed(registry);
+        var entry = Assert.Single(registry.Snapshot.Entries);
+        var command = operation switch
+        {
+            PlatformProviderAdminOperation.ReplaceGrant => PlatformProviderAdminCommand.ReplaceGrant(
+                registry.Snapshot.Revision,
+                PluginId,
+                entry.Generation,
+                entry.Fingerprint!,
+                new[] { ItemLookup },
+                "Replace grant in claim test"),
+            PlatformProviderAdminOperation.Disable => PlatformProviderAdminCommand.Disable(
+                registry.Snapshot.Revision,
+                PluginId,
+                entry.Generation,
+                entry.Fingerprint!,
+                "Disable in claim test"),
+            PlatformProviderAdminOperation.Revoke => PlatformProviderAdminCommand.Revoke(
+                registry.Snapshot.Revision,
+                PluginId,
+                entry.Generation,
+                entry.Fingerprint!,
+                "Revoke in claim test"),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation)),
+        };
+
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.Applied,
+            registry.Apply(command, AdminAuthorization()).Status);
+        Assert.False(registry.RevalidateOperationBindingClaim(claim));
+    }
+
+    [Fact]
+    public void FailedAdministratorAttemptDoesNotInvalidateUnchangedAuthority()
+    {
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var claim = AssertClaimed(registry);
+        var entry = Assert.Single(registry.Snapshot.Entries);
+        var stale = PlatformProviderAdminCommand.Disable(
+            registry.Snapshot.Revision + 1,
+            PluginId,
+            entry.Generation,
+            entry.Fingerprint!,
+            "Stale claim test command");
+
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.StaleRevision,
+            registry.Apply(stale, AdminAuthorization()).Status);
+        Assert.True(registry.RevalidateOperationBindingClaim(claim));
+    }
+
+    [Fact]
+    public void AbandonedAndFailedReconciliationsKeepClaimsInvalid()
+    {
+        var registry = EnabledRegistry(new[] { ItemLookup, StorageRead });
+        var abandonedClaim = AssertClaimed(registry);
+        var abandonedEpoch = registry.BeginReconciliation();
+        registry.AbandonReconciliation(abandonedEpoch);
+
+        Assert.False(registry.RevalidateOperationBindingClaim(abandonedClaim));
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.StaleReconciliation,
+            registry.Reconcile(abandonedEpoch, Completed(Acquired(hasOperation: true))).Status);
+
+        var restoredEpoch = registry.BeginReconciliation();
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.Applied,
+            registry.Reconcile(restoredEpoch, Completed(Acquired(hasOperation: true))).Status);
+        var failedClaim = AssertClaimed(registry);
+        var failedEpoch = registry.BeginReconciliation();
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.InvalidSweep,
+            registry.Reconcile(
+                failedEpoch,
+                Completed(Acquired(hasOperation: true), Acquired(hasOperation: true))).Status);
+        Assert.False(registry.RevalidateOperationBindingClaim(failedClaim));
+    }
+
+    private static PlatformProviderRegistry EnabledRegistry(
+        IReadOnlyList<string> grantedCapabilities,
+        bool hasOperation = true)
+    {
+        var registry = Registry(new RecordingStore());
+        Reconcile(registry, Acquired(hasOperation));
+        var entry = Assert.Single(registry.Snapshot.Entries);
+        var result = registry.Apply(
+            PlatformProviderAdminCommand.Approve(
+                registry.Snapshot.Revision,
+                PluginId,
+                entry.Generation,
+                entry.Fingerprint!,
+                grantedCapabilities,
+                "Approve provider binding claim test"),
+            AdminAuthorization());
+        Assert.Equal(PlatformProviderRegistryMutationStatus.Applied, result.Status);
+        Assert.Equal(
+            PlatformProviderLifecycleState.Enabled,
+            Assert.Single(registry.Snapshot.Entries).State);
+        return registry;
+    }
+
+    private static PlatformProviderOperationBindingClaim AssertClaimed(
+        PlatformProviderRegistry registry)
+    {
+        var result = registry.ClaimOperationBinding(PluginId, OperationId, 1);
+        Assert.Equal(PlatformProviderOperationBindingClaimStatus.Claimed, result.Status);
+        return Assert.IsType<PlatformProviderOperationBindingClaim>(result.Claim);
+    }
+
+    private static void AssertRefused(
+        PlatformProviderOperationBindingClaimResult result,
+        PlatformProviderOperationBindingClaimStatus expected)
+    {
+        Assert.Equal(expected, result.Status);
+        Assert.Null(result.Claim);
+    }
+
+    private static string[] CapabilityIds(PlatformProviderOperationDeclaration operation) =>
+        operation.RequiredCapabilities.Capabilities.Select(value => value.Id.Value).ToArray();
+
+    private static PlatformProviderRegistry Registry(RecordingStore store) =>
+        new(store, new FixedTimeProvider(Now));
+
+    private static void Reconcile(
+        PlatformProviderRegistry registry,
+        PlatformInstalledManifestObservation observation)
+    {
+        Assert.Equal(
+            PlatformProviderRegistryMutationStatus.Applied,
+            registry.Reconcile(registry.BeginReconciliation(), Completed(observation)).Status);
+    }
+
+    private static PlatformInstalledManifestSweep Completed(
+        params PlatformInstalledManifestObservation[] observations) =>
+        PlatformInstalledManifestSweep.EstablishCompleted(observations.ToImmutableArray());
+
+    private static PlatformInstalledManifestObservation Acquired(bool hasOperation)
+    {
+        var snapshot = PlatformInstalledManifestBindingTests.Snapshot(
+            pluginId: PluginId,
+            version: new Version(1, 2, 3, 4));
+        return PlatformInstalledManifestBinder.Bind(
+            snapshot,
+            PlatformInstalledManifestBindingTests.Snapshot(
+                pluginId: PluginId,
+                version: new Version(1, 2, 3, 4)),
+            PlatformInstalledManifestReadResult.Acquired(
+                ManifestBytes(hasOperation),
+                AssemblyIdentity));
+    }
+
+    private static byte[] ManifestBytes(bool hasOperation)
+    {
+        var providerOperations = hasOperation
+            ? ",\"providerOperations\":[{"
+                + "\"id\":\"" + OperationId + "\""
+                + ",\"protocol\":{\"min\":1,\"max\":1}"
+                + ",\"requiredCapabilities\":[\"" + ItemLookup + "\"]"
+                + ",\"requestSchemaId\":\"urn:jellyfin-canopy:provider-schema:org.example.provider:"
+                + OperationId + ":request:1\""
+                + ",\"requestSchemaSha256\":\"" + new string('a', 64) + "\""
+                + ",\"responseSchemaId\":\"urn:jellyfin-canopy:provider-schema:org.example.provider:"
+                + OperationId + ":response:1\""
+                + ",\"responseSchemaSha256\":\"" + new string('b', 64) + "\"}]"
+            : string.Empty;
+        return Encoding.UTF8.GetBytes("{"
+            + "\"schemaVersion\":1"
+            + ",\"id\":\"org.example.provider\""
+            + ",\"pluginId\":\"" + PluginId.ToString("D") + "\""
+            + ",\"version\":\"1.2.3.4\""
+            + ",\"kind\":\"installed-provider\""
+            + ",\"displayName\":\"Example Provider\""
+            + ",\"platform\":{\"min\":1,\"max\":1}"
+            + ",\"host\":{\"minMajor\":12,\"maxMajor\":12}"
+            + ",\"requestedCapabilities\":[\"" + ItemLookup + "\",\"" + StorageRead + "\"]"
+            + providerOperations
+            + "}");
+    }
+
+    private static PlatformProviderAdminAuthorization AdminAuthorization()
+    {
+        var boundaryActor = PlatformActorTestFactory.Create(
+            AdminId,
+            isElevated: true,
+            "provider-binding-claim-test",
+            "test-client",
+            "test-device");
+        return Assert.IsType<PlatformProviderAdminAuthorization>(
+            PlatformProviderRegistryAdminBoundary.ReauthorizeElevatedAdministrator(
+                boundaryActor,
+                new ReauthorizationHost()));
+    }
+
+    private sealed class RecordingStore : IPlatformProviderRegistryStateStore
+    {
+        private PlatformProviderRegistryDurableState _state = PlatformProviderRegistryDurableState.Empty;
+
+        public PlatformProviderRegistryStoreLoadResult Load() =>
+            PlatformProviderRegistryStoreLoadResult.Healthy(_state);
+
+        public void Save(PlatformProviderRegistryDurableState state) => _state = state;
+
+        public void ResetQuarantined(Guid administratorId, string reason, DateTimeOffset decidedAtUtc) =>
+            _state = PlatformProviderRegistryDurableState.Empty;
+
+        public void FenceQuarantined()
+        {
+        }
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+
+        internal FixedTimeProvider(DateTimeOffset now) => _now = now;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+
+    private sealed class ReauthorizationHost : IPlatformHost, IHostUsers
+    {
+        public IHostUsers Users => this;
+
+        public IHostLibrary Library => throw new NotSupportedException();
+
+        public IHostSessions Sessions => throw new NotSupportedException();
+
+        public IHostPlugins Plugins => throw new NotSupportedException();
+
+        public HostUser? Find(Guid id) => id == AdminId
+            ? new HostUser(AdminId, "Registry admin", true)
+            : null;
+
+        public IReadOnlyList<HostUser> All() => [];
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderRegistryArchitectureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Platform/PlatformProviderRegistryArchitectureTests.cs
@@ -191,6 +191,7 @@ public sealed class PlatformProviderRegistryArchitectureTests
         Assert.Equal(
             new[]
             {
+                "PlatformProviderBindingService.cs",
                 RegistryFile,
                 "PlatformProviderRegistryAdminBoundary.cs",
                 DomainFile,

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/IPlatformProviderBindingHost.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/IPlatformProviderBindingHost.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Reflection;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting
+{
+    /// <summary>Closed host-adapter outcomes for lazy foreign provider binding.</summary>
+    internal enum PlatformProviderHostBindingStatus
+    {
+        Bound = 1,
+        ProviderAbsent = 2,
+        ProviderNotActive = 3,
+        HostIdentityChanged = 4,
+        ProviderInstanceUnavailable = 5,
+        EntrypointMissing = 6,
+        AbiMismatch = 7,
+        ServiceUnavailable = 8,
+        ServiceResolutionFailed = 9,
+        BindingFailed = 10,
+    }
+
+    /// <summary>
+    /// Exact inert registry facts the Jellyfin adapter must re-observe before it may
+    /// resolve a foreign concrete service. No caller-selected CLR selector crosses here.
+    /// </summary>
+    internal readonly record struct PlatformProviderHostBindingRequest
+    {
+        internal PlatformProviderHostBindingRequest(Guid pluginId, Version hostVersion)
+        {
+            if (pluginId == Guid.Empty)
+            {
+                throw new ArgumentException("A provider plugin id cannot be empty.", nameof(pluginId));
+            }
+
+            ArgumentNullException.ThrowIfNull(hostVersion);
+            PluginId = pluginId;
+            HostVersion = new Version(hostVersion.ToString());
+        }
+
+        internal Guid PluginId { get; }
+
+        internal Version HostVersion { get; }
+    }
+
+    /// <summary>
+    /// One ephemeral foreign concrete binding. The BCL reflection objects are safe across
+    /// load contexts; no Canopy model or interface is implemented by the provider.
+    /// </summary>
+    internal sealed class PlatformProviderForeignEntrypoint
+    {
+        internal PlatformProviderForeignEntrypoint(
+            Assembly assembly,
+            object hostPluginInstance,
+            Type entrypointType,
+            object instance,
+            MethodInfo invocationMethod)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+            ArgumentNullException.ThrowIfNull(hostPluginInstance);
+            ArgumentNullException.ThrowIfNull(entrypointType);
+            ArgumentNullException.ThrowIfNull(instance);
+            ArgumentNullException.ThrowIfNull(invocationMethod);
+            if (!ReferenceEquals(hostPluginInstance.GetType().Assembly, assembly)
+                || !ReferenceEquals(entrypointType.Assembly, assembly)
+                || instance.GetType() != entrypointType
+                || !ReferenceEquals(invocationMethod.DeclaringType, entrypointType))
+            {
+                throw new ArgumentException("The foreign entrypoint binding is inconsistent.");
+            }
+
+            Assembly = assembly;
+            EntrypointType = entrypointType;
+            Instance = instance;
+            InvocationMethod = invocationMethod;
+            _hostPluginInstance = hostPluginInstance;
+        }
+
+        internal Assembly Assembly { get; }
+
+        internal Type EntrypointType { get; }
+
+        internal object Instance { get; }
+
+        internal MethodInfo InvocationMethod { get; }
+
+        private readonly object _hostPluginInstance;
+
+        internal bool IsBoundToHostPluginInstance(object instance) =>
+            ReferenceEquals(_hostPluginInstance, instance);
+    }
+
+    /// <summary>One redaction-safe result from the Jellyfin binding adapter.</summary>
+    internal readonly record struct PlatformProviderHostBindingResult
+    {
+        private PlatformProviderHostBindingResult(
+            PlatformProviderHostBindingStatus status,
+            PlatformProviderForeignEntrypoint? binding)
+        {
+            if (!Enum.IsDefined(status)
+                || (status == PlatformProviderHostBindingStatus.Bound) != (binding is not null))
+            {
+                throw new ArgumentException("The provider host binding result is inconsistent.", nameof(status));
+            }
+
+            Status = status;
+            Binding = binding;
+        }
+
+        internal PlatformProviderHostBindingStatus Status { get; }
+
+        internal PlatformProviderForeignEntrypoint? Binding { get; }
+
+        internal static PlatformProviderHostBindingResult Bound(PlatformProviderForeignEntrypoint binding) =>
+            new(PlatformProviderHostBindingStatus.Bound, binding);
+
+        internal static PlatformProviderHostBindingResult Rejected(PlatformProviderHostBindingStatus status) =>
+            new(status, null);
+    }
+
+    /// <summary>
+    /// Host-neutral seam for the only production owner allowed to inspect a live Jellyfin
+    /// plugin instance and resolve its foreign concrete entrypoint from shared DI.
+    /// </summary>
+    internal interface IPlatformProviderBindingHost
+    {
+        PlatformProviderHostBindingResult Bind(PlatformProviderHostBindingRequest request);
+
+        PlatformProviderHostBindingStatus Revalidate(
+            PlatformProviderHostBindingRequest request,
+            PlatformProviderForeignEntrypoint binding);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/Jellyfin/JellyfinPlatformProviderBindingHost.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/Hosting/Jellyfin/JellyfinPlatformProviderBindingHost.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin
+{
+    /// <summary>
+    /// Lazily joins an exact registry-approved plugin id to its live foreign concrete
+    /// entrypoint in Jellyfin's shared service container. It never loads an assembly,
+    /// follows a path, or invokes the provider operation.
+    /// </summary>
+    internal sealed class JellyfinPlatformProviderBindingHost : IPlatformProviderBindingHost
+    {
+        private readonly Func<IEnumerable<LocalPlugin>> _installed;
+        private readonly Func<Type, object?> _resolve;
+
+        public JellyfinPlatformProviderBindingHost(
+            IPluginManager pluginManager,
+            IServiceProvider serviceProvider)
+            : this(
+                () => pluginManager.Plugins,
+                serviceProvider.GetService)
+        {
+        }
+
+        internal JellyfinPlatformProviderBindingHost(
+            Func<IEnumerable<LocalPlugin>> installed,
+            Func<Type, object?> resolve)
+        {
+            ArgumentNullException.ThrowIfNull(installed);
+            ArgumentNullException.ThrowIfNull(resolve);
+            _installed = installed;
+            _resolve = resolve;
+        }
+
+        public PlatformProviderHostBindingResult Bind(PlatformProviderHostBindingRequest request)
+        {
+            try
+            {
+                var matches = _installed()
+                    .Where(candidate => candidate.Id == request.PluginId)
+                    .Take(2)
+                    .ToList();
+                if (matches.Count == 0)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.ProviderAbsent);
+                }
+
+                if (matches.Count != 1)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.HostIdentityChanged);
+                }
+
+                var plugin = matches[0];
+                if (plugin.Manifest.Status != PluginStatus.Active)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.ProviderNotActive);
+                }
+
+                if (plugin.Version is null || plugin.Version != request.HostVersion)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.HostIdentityChanged);
+                }
+
+                var pluginInstance = plugin.Instance;
+                if (pluginInstance is null)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.ProviderInstanceUnavailable);
+                }
+
+                var assembly = pluginInstance.GetType().Assembly;
+                var entrypointType = assembly.GetType(
+                    PlatformProviderAbiContract.EntrypointTypeName,
+                    throwOnError: false,
+                    ignoreCase: false);
+                if (entrypointType is null)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.EntrypointMissing);
+                }
+
+                if (!TryResolveInvocationMethod(entrypointType, out var invocationMethod))
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.AbiMismatch);
+                }
+
+                object? entrypoint;
+                try
+                {
+                    entrypoint = _resolve(entrypointType);
+                }
+                catch (Exception)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.ServiceResolutionFailed);
+                }
+
+                if (entrypoint is null)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.ServiceUnavailable);
+                }
+
+                if (entrypoint.GetType() != entrypointType)
+                {
+                    return Rejected(PlatformProviderHostBindingStatus.ServiceResolutionFailed);
+                }
+
+                var binding = new PlatformProviderForeignEntrypoint(
+                        assembly,
+                        pluginInstance,
+                        entrypointType,
+                        entrypoint,
+                        invocationMethod!);
+                var revalidation = Revalidate(request, binding);
+                return revalidation == PlatformProviderHostBindingStatus.Bound
+                    ? PlatformProviderHostBindingResult.Bound(binding)
+                    : Rejected(revalidation);
+            }
+            catch (Exception)
+            {
+                return Rejected(PlatformProviderHostBindingStatus.BindingFailed);
+            }
+        }
+
+        public PlatformProviderHostBindingStatus Revalidate(
+            PlatformProviderHostBindingRequest request,
+            PlatformProviderForeignEntrypoint binding)
+        {
+            ArgumentNullException.ThrowIfNull(binding);
+            try
+            {
+                var matches = _installed()
+                    .Where(candidate => candidate.Id == request.PluginId)
+                    .Take(2)
+                    .ToList();
+                if (matches.Count == 0)
+                {
+                    return PlatformProviderHostBindingStatus.ProviderAbsent;
+                }
+
+                if (matches.Count != 1)
+                {
+                    return PlatformProviderHostBindingStatus.HostIdentityChanged;
+                }
+
+                var plugin = matches[0];
+                if (plugin.Manifest.Status != PluginStatus.Active)
+                {
+                    return PlatformProviderHostBindingStatus.ProviderNotActive;
+                }
+
+                if (plugin.Version is null || plugin.Version != request.HostVersion)
+                {
+                    return PlatformProviderHostBindingStatus.HostIdentityChanged;
+                }
+
+                var pluginInstance = plugin.Instance;
+                if (pluginInstance is null)
+                {
+                    return PlatformProviderHostBindingStatus.ProviderInstanceUnavailable;
+                }
+
+                return binding.IsBoundToHostPluginInstance(pluginInstance)
+                    && ReferenceEquals(pluginInstance.GetType().Assembly, binding.Assembly)
+                    ? PlatformProviderHostBindingStatus.Bound
+                    : PlatformProviderHostBindingStatus.HostIdentityChanged;
+            }
+            catch (Exception)
+            {
+                return PlatformProviderHostBindingStatus.BindingFailed;
+            }
+        }
+
+        internal static bool TryResolveInvocationMethod(
+            Type entrypointType,
+            out MethodInfo? invocationMethod)
+        {
+            ArgumentNullException.ThrowIfNull(entrypointType);
+            invocationMethod = null;
+            if (!entrypointType.IsClass
+                || entrypointType.IsAbstract
+                || entrypointType.IsGenericTypeDefinition
+                || !(entrypointType.IsPublic || entrypointType.IsNestedPublic))
+            {
+                return false;
+            }
+
+            var candidates = entrypointType
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(method => string.Equals(
+                    method.Name,
+                    PlatformProviderAbiContract.InvocationMethodName,
+                    StringComparison.Ordinal))
+                .ToArray();
+            if (candidates.Length != 1)
+            {
+                return false;
+            }
+
+            var allNamedCandidates = entrypointType
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Count(method => string.Equals(
+                    method.Name,
+                    PlatformProviderAbiContract.InvocationMethodName,
+                    StringComparison.Ordinal));
+            if (allNamedCandidates != 1)
+            {
+                return false;
+            }
+
+            var method = candidates[0];
+            var callingConvention = method.CallingConvention;
+            if (method.IsStatic
+                || method.IsGenericMethod
+                || method.IsGenericMethodDefinition
+                || (callingConvention & CallingConventions.Any) != CallingConventions.Standard
+                || (callingConvention & CallingConventions.HasThis) == 0
+                || (callingConvention & CallingConventions.ExplicitThis) != 0
+                || method.ReturnType != typeof(Task<string>))
+            {
+                return false;
+            }
+
+            var parameters = method.GetParameters();
+            if (parameters.Length != 3
+                || parameters[0].ParameterType != typeof(string)
+                || parameters[1].ParameterType != typeof(string)
+                || parameters[2].ParameterType != typeof(CancellationToken)
+                || parameters.Any(parameter =>
+                    parameter.IsOut
+                    || parameter.ParameterType.IsByRef
+                    || parameter.IsOptional
+                    || parameter.GetCustomAttribute<ParamArrayAttribute>() is not null))
+            {
+                return false;
+            }
+
+            invocationMethod = method;
+            return true;
+        }
+
+        private static PlatformProviderHostBindingResult Rejected(
+            PlatformProviderHostBindingStatus status) =>
+            PlatformProviderHostBindingResult.Rejected(status);
+
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderBindingService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderBindingService.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Reflection;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Closed, redaction-safe outcomes for lazy provider binding.</summary>
+    internal enum PlatformProviderBindingStatus
+    {
+        Bound = 1,
+        AuthorityUnavailable = 2,
+        OperationUnavailable = 3,
+        ProtocolUnsupported = 4,
+        GrantInsufficient = 5,
+        ProviderAbsent = 6,
+        ProviderNotActive = 7,
+        HostIdentityChanged = 8,
+        ProviderInstanceUnavailable = 9,
+        EntrypointMissing = 10,
+        AbiMismatch = 11,
+        ServiceUnavailable = 12,
+        ServiceResolutionFailed = 13,
+        SchemaMissing = 14,
+        SchemaResourceAmbiguous = 15,
+        SchemaReadFailed = 16,
+        SchemaTooLarge = 17,
+        SchemaHashMismatch = 18,
+        SchemaInvalidUtf8 = 19,
+        SchemaInvalidJson = 20,
+        SchemaBoundsExceeded = 21,
+        SchemaIdentityMismatch = 22,
+        SchemaDialectUnsupported = 23,
+        SchemaExternalReference = 24,
+        SchemaVocabularyUnsupported = 25,
+        AuthorityChanged = 26,
+        BindingFailed = 27,
+    }
+
+    /// <summary>
+    /// One ephemeral pre-invocation binding. It proves only that exact registry, host,
+    /// ABI and embedded-schema checks agreed during this bind. A later invocation owner
+    /// must acquire and revalidate its own bounded authority/release leases.
+    /// </summary>
+    internal sealed class PlatformProviderBoundOperation
+    {
+        internal PlatformProviderBoundOperation(
+            PlatformProviderOperationBindingClaim claim,
+            PlatformProviderForeignEntrypoint entrypoint,
+            PlatformProviderEmbeddedSchemaPair schemas)
+        {
+            ArgumentNullException.ThrowIfNull(claim);
+            ArgumentNullException.ThrowIfNull(entrypoint);
+            ArgumentNullException.ThrowIfNull(schemas);
+            Claim = claim;
+            Entrypoint = entrypoint;
+            Schemas = schemas;
+        }
+
+        internal PlatformProviderOperationBindingClaim Claim { get; }
+
+        internal PlatformProviderForeignEntrypoint Entrypoint { get; }
+
+        internal PlatformProviderEmbeddedSchemaPair Schemas { get; }
+    }
+
+    /// <summary>One atomic provider-binding result; failures never publish partial state.</summary>
+    internal readonly record struct PlatformProviderBindingResult
+    {
+        private PlatformProviderBindingResult(
+            PlatformProviderBindingStatus status,
+            PlatformProviderBoundOperation? binding)
+        {
+            if (!Enum.IsDefined(status)
+                || (status == PlatformProviderBindingStatus.Bound) != (binding is not null))
+            {
+                throw new ArgumentException("The provider binding result is inconsistent.", nameof(status));
+            }
+
+            Status = status;
+            Binding = binding;
+        }
+
+        internal PlatformProviderBindingStatus Status { get; }
+
+        internal PlatformProviderBoundOperation? Binding { get; }
+
+        internal static PlatformProviderBindingResult Bound(PlatformProviderBoundOperation binding) =>
+            new(PlatformProviderBindingStatus.Bound, binding);
+
+        internal static PlatformProviderBindingResult Rejected(PlatformProviderBindingStatus status) =>
+            new(status, null);
+    }
+
+    /// <summary>
+    /// Coordinates exact registry admission, lazy Jellyfin binding and embedded-schema
+    /// admission. It deliberately contains no provider invocation, cache, timer or route.
+    /// </summary>
+    internal sealed class PlatformProviderBindingService
+    {
+        private readonly Lazy<PlatformProviderRegistry> _registry;
+        private readonly IPlatformProviderBindingHost _host;
+        private readonly Func<Assembly, string, string, string, string,
+            PlatformProviderEmbeddedSchemaAdmissionResult> _admitSchemas;
+
+        internal PlatformProviderBindingService(
+            Lazy<PlatformProviderRegistry> registry,
+            IPlatformProviderBindingHost host)
+            : this(registry, host, PlatformProviderEmbeddedSchemaAdmission.Admit)
+        {
+        }
+
+        internal PlatformProviderBindingService(
+            Lazy<PlatformProviderRegistry> registry,
+            IPlatformProviderBindingHost host,
+            Func<Assembly, string, string, string, string,
+                PlatformProviderEmbeddedSchemaAdmissionResult> admitSchemas)
+        {
+            ArgumentNullException.ThrowIfNull(registry);
+            ArgumentNullException.ThrowIfNull(host);
+            ArgumentNullException.ThrowIfNull(admitSchemas);
+            _registry = registry;
+            _host = host;
+            _admitSchemas = admitSchemas;
+        }
+
+        internal PlatformProviderBindingResult Bind(
+            Guid pluginId,
+            string operationId,
+            int negotiatedProtocol)
+        {
+            PlatformProviderRegistry registry;
+            PlatformProviderOperationBindingClaimResult claimResult;
+            try
+            {
+                registry = _registry.Value;
+                claimResult = registry.ClaimOperationBinding(
+                    pluginId,
+                    operationId,
+                    negotiatedProtocol);
+            }
+            catch (Exception)
+            {
+                return Rejected(PlatformProviderBindingStatus.BindingFailed);
+            }
+
+            if (claimResult.Status != PlatformProviderOperationBindingClaimStatus.Claimed
+                || claimResult.Claim is null)
+            {
+                return Rejected(Map(claimResult.Status));
+            }
+
+            var claim = claimResult.Claim;
+            var hostRequest = new PlatformProviderHostBindingRequest(
+                claim.PluginId,
+                claim.HostVersion);
+            PlatformProviderHostBindingResult hostResult;
+            try
+            {
+                hostResult = _host.Bind(hostRequest);
+            }
+            catch (Exception)
+            {
+                return Rejected(PlatformProviderBindingStatus.BindingFailed);
+            }
+
+            if (hostResult.Status != PlatformProviderHostBindingStatus.Bound
+                || hostResult.Binding is null)
+            {
+                return Rejected(Map(hostResult.Status));
+            }
+
+            if (!registry.RevalidateOperationBindingClaim(claim))
+            {
+                return Rejected(PlatformProviderBindingStatus.AuthorityChanged);
+            }
+
+            var operation = claim.Operation;
+            PlatformProviderEmbeddedSchemaAdmissionResult schemas;
+            try
+            {
+                schemas = _admitSchemas(
+                    hostResult.Binding.Assembly,
+                    operation.RequestSchemaId,
+                    operation.RequestSchemaSha256,
+                    operation.ResponseSchemaId,
+                    operation.ResponseSchemaSha256);
+            }
+            catch (Exception)
+            {
+                return Rejected(PlatformProviderBindingStatus.BindingFailed);
+            }
+            if (schemas.Status != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted
+                || schemas.Schemas is null)
+            {
+                return Rejected(Map(schemas.Status));
+            }
+
+            PlatformProviderHostBindingStatus hostRevalidation;
+            try
+            {
+                hostRevalidation = _host.Revalidate(hostRequest, hostResult.Binding);
+            }
+            catch (Exception)
+            {
+                return Rejected(PlatformProviderBindingStatus.BindingFailed);
+            }
+
+            if (hostRevalidation != PlatformProviderHostBindingStatus.Bound)
+            {
+                return Rejected(Map(hostRevalidation));
+            }
+
+            if (!registry.RevalidateOperationBindingClaim(claim))
+            {
+                return Rejected(PlatformProviderBindingStatus.AuthorityChanged);
+            }
+
+            return PlatformProviderBindingResult.Bound(
+                new PlatformProviderBoundOperation(
+                    claim,
+                    hostResult.Binding,
+                    schemas.Schemas));
+        }
+
+        private static PlatformProviderBindingStatus Map(
+            PlatformProviderOperationBindingClaimStatus status) => status switch
+            {
+                PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable =>
+                    PlatformProviderBindingStatus.AuthorityUnavailable,
+                PlatformProviderOperationBindingClaimStatus.OperationUnavailable =>
+                    PlatformProviderBindingStatus.OperationUnavailable,
+                PlatformProviderOperationBindingClaimStatus.ProtocolUnsupported =>
+                    PlatformProviderBindingStatus.ProtocolUnsupported,
+                PlatformProviderOperationBindingClaimStatus.GrantInsufficient =>
+                    PlatformProviderBindingStatus.GrantInsufficient,
+                _ => PlatformProviderBindingStatus.BindingFailed,
+            };
+
+        private static PlatformProviderBindingStatus Map(
+            PlatformProviderHostBindingStatus status) => status switch
+            {
+                PlatformProviderHostBindingStatus.ProviderAbsent => PlatformProviderBindingStatus.ProviderAbsent,
+                PlatformProviderHostBindingStatus.ProviderNotActive => PlatformProviderBindingStatus.ProviderNotActive,
+                PlatformProviderHostBindingStatus.HostIdentityChanged => PlatformProviderBindingStatus.HostIdentityChanged,
+                PlatformProviderHostBindingStatus.ProviderInstanceUnavailable =>
+                    PlatformProviderBindingStatus.ProviderInstanceUnavailable,
+                PlatformProviderHostBindingStatus.EntrypointMissing => PlatformProviderBindingStatus.EntrypointMissing,
+                PlatformProviderHostBindingStatus.AbiMismatch => PlatformProviderBindingStatus.AbiMismatch,
+                PlatformProviderHostBindingStatus.ServiceUnavailable => PlatformProviderBindingStatus.ServiceUnavailable,
+                PlatformProviderHostBindingStatus.ServiceResolutionFailed =>
+                    PlatformProviderBindingStatus.ServiceResolutionFailed,
+                _ => PlatformProviderBindingStatus.BindingFailed,
+            };
+
+        private static PlatformProviderBindingStatus Map(
+            PlatformProviderEmbeddedSchemaAdmissionStatus status) => status switch
+            {
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaMissing => PlatformProviderBindingStatus.SchemaMissing,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaResourceAmbiguous =>
+                    PlatformProviderBindingStatus.SchemaResourceAmbiguous,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed =>
+                    PlatformProviderBindingStatus.SchemaReadFailed,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaTooLarge => PlatformProviderBindingStatus.SchemaTooLarge,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaHashMismatch =>
+                    PlatformProviderBindingStatus.SchemaHashMismatch,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidUtf8 =>
+                    PlatformProviderBindingStatus.SchemaInvalidUtf8,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson =>
+                    PlatformProviderBindingStatus.SchemaInvalidJson,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded =>
+                    PlatformProviderBindingStatus.SchemaBoundsExceeded,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaIdentityMismatch =>
+                    PlatformProviderBindingStatus.SchemaIdentityMismatch,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaDialectUnsupported =>
+                    PlatformProviderBindingStatus.SchemaDialectUnsupported,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaExternalReference =>
+                    PlatformProviderBindingStatus.SchemaExternalReference,
+                PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaVocabularyUnsupported =>
+                    PlatformProviderBindingStatus.SchemaVocabularyUnsupported,
+                _ => PlatformProviderBindingStatus.BindingFailed,
+            };
+
+        private static PlatformProviderBindingResult Rejected(PlatformProviderBindingStatus status) =>
+            PlatformProviderBindingResult.Rejected(status);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderEmbeddedSchemaAdmission.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderEmbeddedSchemaAdmission.cs
@@ -1,0 +1,698 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Platform
+{
+    /// <summary>Closed, redaction-safe outcomes for one atomic embedded-schema admission.</summary>
+    internal enum PlatformProviderEmbeddedSchemaAdmissionStatus
+    {
+        Admitted = 0,
+        InvalidInput = 1,
+        SchemaMissing = 2,
+        SchemaResourceAmbiguous = 3,
+        SchemaReadFailed = 4,
+        SchemaTooLarge = 5,
+        SchemaHashMismatch = 6,
+        SchemaInvalidUtf8 = 7,
+        SchemaInvalidJson = 8,
+        SchemaBoundsExceeded = 9,
+        SchemaIdentityMismatch = 10,
+        SchemaDialectUnsupported = 11,
+        SchemaExternalReference = 12,
+        SchemaVocabularyUnsupported = 13,
+    }
+
+    /// <summary>
+    /// One immutable admitted request/response schema pair. Elements are cloned at
+    /// publication and on access, so no source document or caller owns their lifetime.
+    /// </summary>
+    internal sealed class PlatformProviderEmbeddedSchemaPair
+    {
+        private readonly JsonElement _requestSchema;
+        private readonly JsonElement _responseSchema;
+
+        private PlatformProviderEmbeddedSchemaPair(
+            JsonElement requestSchema,
+            JsonElement responseSchema)
+        {
+            _requestSchema = requestSchema.Clone();
+            _responseSchema = responseSchema.Clone();
+        }
+
+        internal JsonElement RequestSchema => _requestSchema.Clone();
+
+        internal JsonElement ResponseSchema => _responseSchema.Clone();
+
+        internal static PlatformProviderEmbeddedSchemaPair EstablishAdmitted(
+            JsonElement requestSchema,
+            JsonElement responseSchema) => new(requestSchema, responseSchema);
+    }
+
+    /// <summary>One atomic admission result. Failed results never publish half a pair.</summary>
+    internal sealed class PlatformProviderEmbeddedSchemaAdmissionResult
+    {
+        private PlatformProviderEmbeddedSchemaAdmissionResult(
+            PlatformProviderEmbeddedSchemaAdmissionStatus status,
+            PlatformProviderEmbeddedSchemaPair? schemas)
+        {
+            Status = status;
+            Schemas = schemas;
+        }
+
+        internal PlatformProviderEmbeddedSchemaAdmissionStatus Status { get; }
+
+        internal PlatformProviderEmbeddedSchemaPair? Schemas { get; }
+
+        internal static PlatformProviderEmbeddedSchemaAdmissionResult Admitted(
+            PlatformProviderEmbeddedSchemaPair schemas)
+        {
+            ArgumentNullException.ThrowIfNull(schemas);
+            return new PlatformProviderEmbeddedSchemaAdmissionResult(
+                PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted,
+                schemas);
+        }
+
+        internal static PlatformProviderEmbeddedSchemaAdmissionResult Rejected(
+            PlatformProviderEmbeddedSchemaAdmissionStatus status)
+        {
+            if (status == PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+            {
+                throw new ArgumentOutOfRangeException(nameof(status));
+            }
+
+            return new PlatformProviderEmbeddedSchemaAdmissionResult(status, null);
+        }
+    }
+
+    /// <summary>
+    /// Admits only fixed, content-addressed schemas embedded in one already-loaded
+    /// foreign assembly. This owner performs no provider invocation, path lookup,
+    /// external resolution, caching, logging, or authority decision.
+    /// </summary>
+    internal static class PlatformProviderEmbeddedSchemaAdmission
+    {
+        internal const int MaximumDocumentBytes = 64 * 1024;
+        internal const int MaximumJsonDepth = 12;
+        internal const int MaximumObjectProperties = 64;
+        internal const int MaximumArrayItems = 64;
+        internal const int MaximumPropertyNameBytes = 256;
+        internal const int MaximumStringBytes = 4 * 1024;
+        internal const int MaximumResourceCount = 1024;
+        internal const int MaximumResourceNameBytes = 512;
+
+        internal const string JsonSchemaDialect =
+            "https://json-schema.org/draft/2020-12/schema";
+
+        private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+
+        private static readonly ImmutableHashSet<string> SupportedRequiredVocabularies =
+            ImmutableHashSet.Create(
+                StringComparer.Ordinal,
+                "https://json-schema.org/draft/2020-12/vocab/core",
+                "https://json-schema.org/draft/2020-12/vocab/applicator",
+                "https://json-schema.org/draft/2020-12/vocab/unevaluated",
+                "https://json-schema.org/draft/2020-12/vocab/validation",
+                "https://json-schema.org/draft/2020-12/vocab/meta-data",
+                "https://json-schema.org/draft/2020-12/vocab/format-annotation",
+                "https://json-schema.org/draft/2020-12/vocab/content");
+
+        internal static PlatformProviderEmbeddedSchemaAdmissionResult Admit(
+            Assembly foreignAssembly,
+            string requestSchemaId,
+            string requestSchemaSha256,
+            string responseSchemaId,
+            string responseSchemaSha256)
+        {
+            if (foreignAssembly is null
+                || !IsValidSchemaId(requestSchemaId)
+                || !IsValidSha256(requestSchemaSha256)
+                || !IsValidSchemaId(responseSchemaId)
+                || !IsValidSha256(responseSchemaSha256))
+            {
+                return Rejected(PlatformProviderEmbeddedSchemaAdmissionStatus.InvalidInput);
+            }
+
+            string[] resourceNames;
+            try
+            {
+                resourceNames = foreignAssembly.GetManifestResourceNames();
+            }
+            catch (Exception)
+            {
+                return Rejected(PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed);
+            }
+
+            if (resourceNames is null)
+            {
+                return Rejected(PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed);
+            }
+
+            if (resourceNames.Length > MaximumResourceCount
+                || resourceNames.Any(name => !IsBoundedResourceName(name)))
+            {
+                return Rejected(PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded);
+            }
+
+            var admittedByDigest = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+            var request = AdmitOne(
+                foreignAssembly,
+                resourceNames,
+                requestSchemaId,
+                requestSchemaSha256,
+                admittedByDigest);
+            if (request.Status != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+            {
+                return Rejected(request.Status);
+            }
+
+            var response = AdmitOne(
+                foreignAssembly,
+                resourceNames,
+                responseSchemaId,
+                responseSchemaSha256,
+                admittedByDigest);
+            if (response.Status != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+            {
+                return Rejected(response.Status);
+            }
+
+            return PlatformProviderEmbeddedSchemaAdmissionResult.Admitted(
+                PlatformProviderEmbeddedSchemaPair.EstablishAdmitted(
+                    request.Schema,
+                    response.Schema));
+        }
+
+        private static SingleSchemaAdmission AdmitOne(
+            Assembly assembly,
+            IReadOnlyList<string> resourceNames,
+            string expectedSchemaId,
+            string expectedSha256,
+            IDictionary<string, JsonElement> admittedByDigest)
+        {
+            if (admittedByDigest.TryGetValue(expectedSha256, out var admitted))
+            {
+                return HasExpectedIdentity(admitted, expectedSchemaId)
+                    ? SingleSchemaAdmission.Admitted(admitted)
+                    : SingleSchemaAdmission.Rejected(
+                        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaIdentityMismatch);
+            }
+
+            var resourceName = PlatformProviderAbiContract.ProviderSchemaResourcePrefix
+                + expectedSha256
+                + PlatformProviderAbiContract.ProviderSchemaResourceSuffix;
+            var matches = resourceNames.Count(name =>
+                string.Equals(name, resourceName, StringComparison.Ordinal));
+            if (matches == 0)
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaMissing);
+            }
+
+            if (matches != 1)
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaResourceAmbiguous);
+            }
+
+            byte[] bytes;
+            try
+            {
+                using var stream = assembly.GetManifestResourceStream(resourceName);
+                if (stream is null)
+                {
+                    return SingleSchemaAdmission.Rejected(
+                        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaMissing);
+                }
+
+                var read = ReadBounded(stream);
+                if (read.Status != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+                {
+                    return SingleSchemaAdmission.Rejected(read.Status);
+                }
+
+                bytes = read.Bytes;
+            }
+            catch (Exception)
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaReadFailed);
+            }
+
+            var actualSha256 = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+            if (!string.Equals(actualSha256, expectedSha256, StringComparison.Ordinal))
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaHashMismatch);
+            }
+
+            if (bytes.Length >= 3
+                && bytes[0] == 0xEF
+                && bytes[1] == 0xBB
+                && bytes[2] == 0xBF)
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidUtf8);
+            }
+
+            try
+            {
+                _ = StrictUtf8.GetString(bytes);
+            }
+            catch (DecoderFallbackException)
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidUtf8);
+            }
+
+            var structure = ValidateStructure(bytes);
+            if (structure != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+            {
+                return SingleSchemaAdmission.Rejected(structure);
+            }
+
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(
+                    bytes,
+                    new JsonDocumentOptions
+                    {
+                        AllowTrailingCommas = false,
+                        CommentHandling = JsonCommentHandling.Disallow,
+                        MaxDepth = MaximumJsonDepth,
+                    });
+            }
+            catch (JsonException)
+            {
+                return SingleSchemaAdmission.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson);
+            }
+
+            using (document)
+            {
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    return SingleSchemaAdmission.Rejected(
+                        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson);
+                }
+
+                if (!root.TryGetProperty("$schema", out var dialect)
+                    || dialect.ValueKind != JsonValueKind.String
+                    || !string.Equals(
+                        dialect.GetString(),
+                        JsonSchemaDialect,
+                        StringComparison.Ordinal))
+                {
+                    return SingleSchemaAdmission.Rejected(
+                        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaDialectUnsupported);
+                }
+
+                if (!HasExpectedIdentity(root, expectedSchemaId))
+                {
+                    return SingleSchemaAdmission.Rejected(
+                        PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaIdentityMismatch);
+                }
+
+                var semanticStatus = ValidateSchemaSemantics(root);
+                if (semanticStatus != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+                {
+                    return SingleSchemaAdmission.Rejected(semanticStatus);
+                }
+
+                var schema = root.Clone();
+                admittedByDigest.Add(expectedSha256, schema);
+                return SingleSchemaAdmission.Admitted(schema);
+            }
+        }
+
+        private static BoundedRead ReadBounded(Stream stream)
+        {
+            var buffer = new byte[MaximumDocumentBytes + 1];
+            var total = 0;
+            while (total < buffer.Length)
+            {
+                var count = stream.Read(buffer, total, buffer.Length - total);
+                if (count == 0)
+                {
+                    break;
+                }
+
+                total += count;
+            }
+
+            if (total > MaximumDocumentBytes)
+            {
+                return BoundedRead.Rejected(
+                    PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaTooLarge);
+            }
+
+            return BoundedRead.Admitted(buffer.AsSpan(0, total).ToArray());
+        }
+
+        private static PlatformProviderEmbeddedSchemaAdmissionStatus ValidateStructure(
+            ReadOnlySpan<byte> bytes)
+        {
+            var stack = new List<ContainerState>(MaximumJsonDepth);
+            var reader = new Utf8JsonReader(
+                bytes,
+                new JsonReaderOptions
+                {
+                    AllowTrailingCommas = false,
+                    CommentHandling = JsonCommentHandling.Disallow,
+                    MaxDepth = 64,
+                });
+
+            try
+            {
+                while (reader.Read())
+                {
+                    switch (reader.TokenType)
+                    {
+                        case JsonTokenType.StartObject:
+                            if (!TryCountArrayValue(stack)
+                                || stack.Count >= MaximumJsonDepth)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            stack.Add(ContainerState.Object());
+                            break;
+
+                        case JsonTokenType.StartArray:
+                            if (!TryCountArrayValue(stack)
+                                || stack.Count >= MaximumJsonDepth)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            stack.Add(ContainerState.Array());
+                            break;
+
+                        case JsonTokenType.EndObject:
+                        case JsonTokenType.EndArray:
+                            if (stack.Count == 0)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson;
+                            }
+
+                            stack.RemoveAt(stack.Count - 1);
+                            break;
+
+                        case JsonTokenType.PropertyName:
+                            if (stack.Count == 0 || stack[^1].IsArray)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson;
+                            }
+
+                            var propertyName = reader.GetString();
+                            if (propertyName is null
+                                || StrictUtf8.GetByteCount(propertyName) > MaximumPropertyNameBytes)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            var propertyStatus = stack[^1].TryAddProperty(
+                                propertyName,
+                                MaximumObjectProperties);
+                            if (propertyStatus == PropertyAddStatus.Duplicate)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson;
+                            }
+
+                            if (propertyStatus == PropertyAddStatus.TooMany)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            break;
+
+                        case JsonTokenType.String:
+                            var value = reader.GetString();
+                            if (value is null
+                                || StrictUtf8.GetByteCount(value) > MaximumStringBytes)
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            if (!TryCountArrayValue(stack))
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            break;
+
+                        case JsonTokenType.Number:
+                        case JsonTokenType.True:
+                        case JsonTokenType.False:
+                        case JsonTokenType.Null:
+                            if (!TryCountArrayValue(stack))
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaBoundsExceeded;
+                            }
+
+                            break;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson;
+            }
+            catch (DecoderFallbackException)
+            {
+                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidUtf8;
+            }
+
+            return stack.Count == 0
+                ? PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted
+                : PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaInvalidJson;
+        }
+
+        private static bool TryCountArrayValue(IReadOnlyList<ContainerState> stack)
+        {
+            if (stack.Count == 0 || !stack[^1].IsArray)
+            {
+                return true;
+            }
+
+            return stack[^1].TryAddArrayItem(MaximumArrayItems);
+        }
+
+        private static PlatformProviderEmbeddedSchemaAdmissionStatus ValidateSchemaSemantics(
+            JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        if (property.Name is "$recursiveRef" or "$recursiveAnchor")
+                        {
+                            return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaVocabularyUnsupported;
+                        }
+
+                        if (property.Name == "$schema"
+                            && (property.Value.ValueKind != JsonValueKind.String
+                                || !string.Equals(
+                                    property.Value.GetString(),
+                                    JsonSchemaDialect,
+                                    StringComparison.Ordinal)))
+                        {
+                            return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaDialectUnsupported;
+                        }
+
+                        if (property.Name is "$ref" or "$dynamicRef")
+                        {
+                            if (property.Value.ValueKind != JsonValueKind.String
+                                || property.Value.GetString() is not { } reference
+                                || reference.Length == 0
+                                || reference[0] != '#')
+                            {
+                                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaExternalReference;
+                            }
+                        }
+
+                        if (property.Name == "$vocabulary")
+                        {
+                            var vocabularyStatus = ValidateVocabulary(property.Value);
+                            if (vocabularyStatus != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+                            {
+                                return vocabularyStatus;
+                            }
+                        }
+
+                        var childStatus = ValidateSchemaSemantics(property.Value);
+                        if (childStatus != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+                        {
+                            return childStatus;
+                        }
+                    }
+
+                    break;
+
+                case JsonValueKind.Array:
+                    foreach (var item in element.EnumerateArray())
+                    {
+                        var childStatus = ValidateSchemaSemantics(item);
+                        if (childStatus != PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted)
+                        {
+                            return childStatus;
+                        }
+                    }
+
+                    break;
+            }
+
+            return PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted;
+        }
+
+        private static PlatformProviderEmbeddedSchemaAdmissionStatus ValidateVocabulary(
+            JsonElement vocabulary)
+        {
+            if (vocabulary.ValueKind != JsonValueKind.Object)
+            {
+                return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaVocabularyUnsupported;
+            }
+
+            foreach (var declaration in vocabulary.EnumerateObject())
+            {
+                if (declaration.Value.ValueKind is not (
+                        JsonValueKind.True or JsonValueKind.False))
+                {
+                    return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaVocabularyUnsupported;
+                }
+
+                if (declaration.Value.GetBoolean()
+                    && !SupportedRequiredVocabularies.Contains(declaration.Name))
+                {
+                    return PlatformProviderEmbeddedSchemaAdmissionStatus.SchemaVocabularyUnsupported;
+                }
+            }
+
+            return PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted;
+        }
+
+        private static bool HasExpectedIdentity(JsonElement schema, string expectedSchemaId) =>
+            schema.ValueKind == JsonValueKind.Object
+            && schema.TryGetProperty("$id", out var id)
+            && id.ValueKind == JsonValueKind.String
+            && string.Equals(id.GetString(), expectedSchemaId, StringComparison.Ordinal);
+
+        private static bool IsValidSchemaId(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            try
+            {
+                return StrictUtf8.GetByteCount(value)
+                    <= PlatformExtensionManifestBounds.MaximumProviderSchemaIdBytes;
+            }
+            catch (EncoderFallbackException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsValidSha256(string? value) =>
+            value is { Length: PlatformProviderAbiContract.ProviderSchemaSha256Characters }
+            && value.All(character => character is >= '0' and <= '9' or >= 'a' and <= 'f');
+
+        private static bool IsBoundedResourceName(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            try
+            {
+                return StrictUtf8.GetByteCount(value) <= MaximumResourceNameBytes;
+            }
+            catch (EncoderFallbackException)
+            {
+                return false;
+            }
+        }
+
+        private static PlatformProviderEmbeddedSchemaAdmissionResult Rejected(
+            PlatformProviderEmbeddedSchemaAdmissionStatus status) =>
+            PlatformProviderEmbeddedSchemaAdmissionResult.Rejected(status);
+
+        private sealed class ContainerState
+        {
+            private readonly HashSet<string>? _propertyNames;
+            private int _count;
+
+            private ContainerState(bool isArray)
+            {
+                IsArray = isArray;
+                _propertyNames = isArray ? null : new HashSet<string>(StringComparer.Ordinal);
+            }
+
+            internal bool IsArray { get; }
+
+            internal static ContainerState Object() => new(false);
+
+            internal static ContainerState Array() => new(true);
+
+            internal PropertyAddStatus TryAddProperty(string name, int maximum)
+            {
+                if (_propertyNames is null || !_propertyNames.Add(name))
+                {
+                    return PropertyAddStatus.Duplicate;
+                }
+
+                _count++;
+                return _count <= maximum
+                    ? PropertyAddStatus.Added
+                    : PropertyAddStatus.TooMany;
+            }
+
+            internal bool TryAddArrayItem(int maximum)
+            {
+                _count++;
+                return _count <= maximum;
+            }
+        }
+
+        private enum PropertyAddStatus
+        {
+            Added = 0,
+            Duplicate = 1,
+            TooMany = 2,
+        }
+
+        private readonly record struct SingleSchemaAdmission(
+            PlatformProviderEmbeddedSchemaAdmissionStatus Status,
+            JsonElement Schema)
+        {
+            internal static SingleSchemaAdmission Admitted(JsonElement schema) =>
+                new(PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted, schema.Clone());
+
+            internal static SingleSchemaAdmission Rejected(
+                PlatformProviderEmbeddedSchemaAdmissionStatus status) => new(status, default);
+        }
+
+        private readonly record struct BoundedRead(
+            PlatformProviderEmbeddedSchemaAdmissionStatus Status,
+            byte[] Bytes)
+        {
+            internal static BoundedRead Admitted(byte[] bytes) =>
+                new(PlatformProviderEmbeddedSchemaAdmissionStatus.Admitted, bytes);
+
+            internal static BoundedRead Rejected(
+                PlatformProviderEmbeddedSchemaAdmissionStatus status) => new(status, Array.Empty<byte>());
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderRegistry.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderRegistry.cs
@@ -32,6 +32,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         private PlatformProviderRegistrySnapshot _snapshot;
         private IPlatformProviderRegistryReconciliationEpoch? _currentReconciliationEpoch;
         private bool _authorityReleaseFenced = true;
+        private object _operationBindingClaimEpoch = new();
 
         /// <summary>
         /// Opaque one-use registry-owned reconciliation authority. Reference identity is
@@ -93,7 +94,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         {
             lock (_gate)
             {
-                _authorityReleaseFenced = true;
+                FenceAuthorityRelease();
                 _currentReconciliationEpoch = new ReconciliationEpoch();
                 return _currentReconciliationEpoch;
             }
@@ -115,7 +116,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 }
 
                 _currentReconciliationEpoch = null;
-                _authorityReleaseFenced = true;
+                FenceAuthorityRelease();
             }
         }
 
@@ -145,7 +146,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                     || observations.Any(value => value is null || value.PluginId == Guid.Empty)
                     || observations.GroupBy(value => value.PluginId).Any(group => group.Count() != 1))
                 {
-                    _authorityReleaseFenced = true;
+                    FenceAuthorityRelease();
                     return Result(PlatformProviderRegistryMutationStatus.InvalidSweep);
                 }
 
@@ -195,7 +196,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                         PlatformProviderRegistryStoreHealth.Healthy);
                     if (!TrySave(nextDurable))
                     {
-                        _authorityReleaseFenced = true;
+                        FenceAuthorityRelease();
                         return Result(PlatformProviderRegistryMutationStatus.PersistenceFailed);
                     }
 
@@ -207,7 +208,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 }
                 catch (InvalidOperationException)
                 {
-                    _authorityReleaseFenced = true;
+                    FenceAuthorityRelease();
                     return Result(PlatformProviderRegistryMutationStatus.PersistenceFailed);
                 }
             }
@@ -381,6 +382,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 }
 
                 _durable = nextDurable;
+                RotateOperationBindingClaims();
                 Volatile.Write(ref _snapshot, nextSnapshot);
                 return Result(PlatformProviderRegistryMutationStatus.Applied);
             }
@@ -423,7 +425,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                 _durable = PlatformProviderRegistryDurableState.Empty;
                 _current = ImmutableDictionary<Guid, PlatformInstalledManifestObservation>.Empty;
                 _currentReconciliationEpoch = null;
-                _authorityReleaseFenced = true;
+                FenceAuthorityRelease();
                 Volatile.Write(
                     ref _snapshot,
                     new PlatformProviderRegistrySnapshot(
@@ -488,6 +490,123 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
                         generation),
                     record.GrantedCapabilityIds,
                     generation);
+            }
+        }
+
+        /// <summary>
+        /// Selects one operation from exact current enabled registry authority. The returned
+        /// claim is inert and must be revalidated after foreign binding.
+        /// </summary>
+        internal PlatformProviderOperationBindingClaimResult ClaimOperationBinding(
+            Guid pluginId,
+            string operationId,
+            int negotiatedProtocol)
+        {
+            if (pluginId == Guid.Empty)
+            {
+                return ClaimRefused(PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable);
+            }
+
+            if (string.IsNullOrEmpty(operationId))
+            {
+                return ClaimRefused(PlatformProviderOperationBindingClaimStatus.OperationUnavailable);
+            }
+
+            if (negotiatedProtocol <= 0)
+            {
+                return ClaimRefused(PlatformProviderOperationBindingClaimStatus.ProtocolUnsupported);
+            }
+
+            lock (_gate)
+            {
+                if (!TryGetCurrentApprovedProvider(
+                        pluginId,
+                        out var entry,
+                        out _,
+                        out var manifest,
+                        out var currentGrant))
+                {
+                    return ClaimRefused(PlatformProviderOperationBindingClaimStatus.AuthorityUnavailable);
+                }
+
+                var operation = manifest.Manifest.ProviderOperations.FirstOrDefault(value =>
+                    string.Equals(value.Id, operationId, StringComparison.Ordinal));
+                if (operation is null)
+                {
+                    return ClaimRefused(PlatformProviderOperationBindingClaimStatus.OperationUnavailable);
+                }
+
+                if (negotiatedProtocol < operation.ProtocolRange.Min
+                    || negotiatedProtocol > operation.ProtocolRange.Max)
+                {
+                    return ClaimRefused(PlatformProviderOperationBindingClaimStatus.ProtocolUnsupported);
+                }
+
+                var grantedIds = currentGrant.ToHashSet(StringComparer.Ordinal);
+                if (operation.RequiredCapabilities.Capabilities.Any(required =>
+                        !grantedIds.Contains(required.Id.Value)))
+                {
+                    return ClaimRefused(PlatformProviderOperationBindingClaimStatus.GrantInsufficient);
+                }
+
+                var claim = PlatformProviderOperationBindingClaim.EstablishCurrentRegistryClaim(
+                    _gate,
+                    _operationBindingClaimEpoch,
+                    pluginId,
+                    entry.Fingerprint!,
+                    entry.Generation,
+                    manifest.HostVersion,
+                    manifest.AssemblyIdentity,
+                    negotiatedProtocol,
+                    operation,
+                    currentGrant);
+                return PlatformProviderOperationBindingClaimResult.Claimed(claim);
+            }
+        }
+
+        /// <summary>
+        /// Revalidates every authority-bearing fact after foreign binding. Cross-registry,
+        /// pre-fence and otherwise stale claims fail closed even when facts later return to
+        /// the same visible values.
+        /// </summary>
+        internal bool RevalidateOperationBindingClaim(
+            PlatformProviderOperationBindingClaim claim)
+        {
+            ArgumentNullException.ThrowIfNull(claim);
+            lock (_gate)
+            {
+                if (!claim.IsOwnedBy(_gate, _operationBindingClaimEpoch)
+                    || !TryGetCurrentApprovedProvider(
+                        claim.PluginId,
+                        out var entry,
+                        out _,
+                        out var manifest,
+                        out var currentGrant)
+                    || entry.Generation != claim.Generation
+                    || !string.Equals(entry.Fingerprint, claim.Fingerprint, StringComparison.Ordinal)
+                    || !Equals(manifest.HostVersion, claim.HostVersion)
+                    || !string.Equals(
+                        manifest.AssemblyIdentity,
+                        claim.AssemblyIdentity,
+                        StringComparison.Ordinal)
+                    || !currentGrant.SequenceEqual(claim.GrantedCapabilityIds, StringComparer.Ordinal))
+                {
+                    return false;
+                }
+
+                var operation = manifest.Manifest.ProviderOperations.FirstOrDefault(value =>
+                    string.Equals(value.Id, claim.Operation.Id, StringComparison.Ordinal));
+                if (operation is null
+                    || claim.NegotiatedProtocol < operation.ProtocolRange.Min
+                    || claim.NegotiatedProtocol > operation.ProtocolRange.Max
+                    || !SameOperation(operation, claim.Operation))
+                {
+                    return false;
+                }
+
+                var grantedIds = currentGrant.ToHashSet(StringComparer.Ordinal);
+                return operation.RequiredCapabilities.Capabilities.All(required =>
+                    grantedIds.Contains(required.Id.Value));
             }
         }
 
@@ -666,6 +785,77 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             return true;
         }
 
+        private bool TryGetCurrentApprovedProvider(
+            Guid pluginId,
+            out PlatformProviderRegistryEntry entry,
+            out PlatformProviderRegistryDurableRecord record,
+            out HostBoundInstalledManifest manifest,
+            out ImmutableArray<string> currentGrant)
+        {
+            entry = null!;
+            record = null!;
+            manifest = null!;
+            currentGrant = ImmutableArray<string>.Empty;
+            if (_snapshot.StoreHealth != PlatformProviderRegistryStoreHealth.Healthy
+                || _authorityReleaseFenced)
+            {
+                return false;
+            }
+
+            entry = _snapshot.Entries.FirstOrDefault(value => value.PluginId == pluginId)!;
+            if (entry is null
+                || entry.State != PlatformProviderLifecycleState.Enabled
+                || string.IsNullOrEmpty(entry.Fingerprint))
+            {
+                return false;
+            }
+
+            record = _durable.Records.FirstOrDefault(value => value.PluginId == pluginId)!;
+            if (record is null
+                || record.Generation != entry.Generation
+                || record.Disposition != PlatformProviderDurableDisposition.Approved
+                || !string.Equals(record.ApprovedFingerprint, entry.Fingerprint, StringComparison.Ordinal)
+                || !_current.TryGetValue(pluginId, out var observation)
+                || observation.Outcome != PlatformInstalledManifestOutcome.Acquired
+                || observation.Compatibility != PlatformInstalledManifestCompatibility.Compatible
+                || observation.HostStatus != PlatformInstalledPluginHostStatus.Active
+                || observation.BoundManifest is not { } boundManifest
+                || !string.Equals(
+                    boundManifest.Fingerprint.Value,
+                    entry.Fingerprint,
+                    StringComparison.Ordinal)
+                || !TryValidateGrant(boundManifest, record.GrantedCapabilityIds, out currentGrant)
+                || !currentGrant.SequenceEqual(record.GrantedCapabilityIds, StringComparer.Ordinal))
+            {
+                return false;
+            }
+
+            manifest = boundManifest;
+            return true;
+        }
+
+        private static bool SameOperation(
+            PlatformProviderOperationDeclaration current,
+            PlatformProviderOperationDeclaration claimed) =>
+            string.Equals(current.Id, claimed.Id, StringComparison.Ordinal)
+            && current.ProtocolRange.Min == claimed.ProtocolRange.Min
+            && current.ProtocolRange.Max == claimed.ProtocolRange.Max
+            && current.RequiredCapabilities.Capabilities
+                .Select(value => value.Id.Value)
+                .SequenceEqual(
+                    claimed.RequiredCapabilities.Capabilities.Select(value => value.Id.Value),
+                    StringComparer.Ordinal)
+            && string.Equals(current.RequestSchemaId, claimed.RequestSchemaId, StringComparison.Ordinal)
+            && string.Equals(
+                current.RequestSchemaSha256,
+                claimed.RequestSchemaSha256,
+                StringComparison.Ordinal)
+            && string.Equals(current.ResponseSchemaId, claimed.ResponseSchemaId, StringComparison.Ordinal)
+            && string.Equals(
+                current.ResponseSchemaSha256,
+                claimed.ResponseSchemaSha256,
+                StringComparison.Ordinal);
+
         private bool TrySave(PlatformProviderRegistryDurableState state)
         {
             try
@@ -687,13 +877,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
             }
             catch (Exception)
             {
-                _authorityReleaseFenced = true;
+                FenceAuthorityRelease();
                 return Result(PlatformProviderRegistryMutationStatus.PersistenceFailed);
             }
 
             _durable = PlatformProviderRegistryDurableState.Empty;
             _current = ImmutableDictionary<Guid, PlatformInstalledManifestObservation>.Empty;
-            _authorityReleaseFenced = true;
+            FenceAuthorityRelease();
             Volatile.Write(
                 ref _snapshot,
                 new PlatformProviderRegistrySnapshot(
@@ -816,6 +1006,18 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
 
             return true;
         }
+
+        private void FenceAuthorityRelease()
+        {
+            _authorityReleaseFenced = true;
+            RotateOperationBindingClaims();
+        }
+
+        private void RotateOperationBindingClaims() => _operationBindingClaimEpoch = new object();
+
+        private static PlatformProviderOperationBindingClaimResult ClaimRefused(
+            PlatformProviderOperationBindingClaimStatus status) =>
+            PlatformProviderOperationBindingClaimResult.Refused(status);
 
         private static long CheckedIncrement(long value) => value == long.MaxValue
             ? throw new InvalidOperationException("Registry revision or generation is exhausted.")

--- a/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderRegistryDomain.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Platform/PlatformProviderRegistryDomain.cs
@@ -362,6 +362,145 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Platform
         internal long Generation { get; }
     }
 
+    /// <summary>Closed outcomes for exact provider-operation binding admission.</summary>
+    internal enum PlatformProviderOperationBindingClaimStatus
+    {
+        Claimed = 1,
+        AuthorityUnavailable = 2,
+        OperationUnavailable = 3,
+        ProtocolUnsupported = 4,
+        GrantInsufficient = 5,
+    }
+
+    /// <summary>
+    /// One immutable, inert description of an exact current provider operation. A claim
+    /// carries no provider object or reusable authority: the registry must revalidate it
+    /// after foreign binding before anything may be published.
+    /// </summary>
+    internal sealed class PlatformProviderOperationBindingClaim
+    {
+        private readonly object _registryOwner;
+        private readonly object _claimEpoch;
+
+        private PlatformProviderOperationBindingClaim(
+            object registryOwner,
+            object claimEpoch,
+            Guid pluginId,
+            string fingerprint,
+            long generation,
+            Version hostVersion,
+            string assemblyIdentity,
+            int negotiatedProtocol,
+            PlatformProviderOperationDeclaration operation,
+            ImmutableArray<string> grantedCapabilityIds)
+        {
+            _registryOwner = registryOwner;
+            _claimEpoch = claimEpoch;
+            PluginId = pluginId;
+            Fingerprint = fingerprint;
+            Generation = generation;
+            HostVersion = hostVersion;
+            AssemblyIdentity = assemblyIdentity;
+            NegotiatedProtocol = negotiatedProtocol;
+            Operation = operation;
+            GrantedCapabilityIds = ImmutableArray.CreateRange(grantedCapabilityIds);
+        }
+
+        internal Guid PluginId { get; }
+
+        internal string Fingerprint { get; }
+
+        internal long Generation { get; }
+
+        internal Version HostVersion { get; }
+
+        internal string AssemblyIdentity { get; }
+
+        internal int NegotiatedProtocol { get; }
+
+        internal PlatformProviderOperationDeclaration Operation { get; }
+
+        internal ImmutableArray<string> GrantedCapabilityIds { get; }
+
+        internal bool IsOwnedBy(object registryOwner, object claimEpoch) =>
+            ReferenceEquals(_registryOwner, registryOwner)
+            && ReferenceEquals(_claimEpoch, claimEpoch);
+
+        internal static PlatformProviderOperationBindingClaim EstablishCurrentRegistryClaim(
+            object registryOwner,
+            object claimEpoch,
+            Guid pluginId,
+            string fingerprint,
+            long generation,
+            Version hostVersion,
+            string assemblyIdentity,
+            int negotiatedProtocol,
+            PlatformProviderOperationDeclaration operation,
+            ImmutableArray<string> grantedCapabilityIds)
+        {
+            ArgumentNullException.ThrowIfNull(registryOwner);
+            ArgumentNullException.ThrowIfNull(claimEpoch);
+            ArgumentNullException.ThrowIfNull(hostVersion);
+            ArgumentNullException.ThrowIfNull(operation);
+            if (pluginId == Guid.Empty
+                || generation <= 0
+                || string.IsNullOrEmpty(fingerprint)
+                || string.IsNullOrWhiteSpace(assemblyIdentity)
+                || negotiatedProtocol <= 0
+                || grantedCapabilityIds.IsDefault)
+            {
+                throw new ArgumentException("A binding claim requires exact bounded current facts.");
+            }
+
+            return new PlatformProviderOperationBindingClaim(
+                registryOwner,
+                claimEpoch,
+                pluginId,
+                fingerprint,
+                generation,
+                hostVersion,
+                assemblyIdentity,
+                negotiatedProtocol,
+                operation,
+                grantedCapabilityIds);
+        }
+    }
+
+    /// <summary>One closed result from a registry-owned operation-binding claim attempt.</summary>
+    internal readonly record struct PlatformProviderOperationBindingClaimResult
+    {
+        private PlatformProviderOperationBindingClaimResult(
+            PlatformProviderOperationBindingClaimStatus status,
+            PlatformProviderOperationBindingClaim? claim)
+        {
+            if (!Enum.IsDefined(status)
+                || (status == PlatformProviderOperationBindingClaimStatus.Claimed) != (claim is not null))
+            {
+                throw new ArgumentOutOfRangeException(nameof(status));
+            }
+
+            Status = status;
+            Claim = claim;
+        }
+
+        internal PlatformProviderOperationBindingClaimStatus Status { get; }
+
+        internal PlatformProviderOperationBindingClaim? Claim { get; }
+
+        internal static PlatformProviderOperationBindingClaimResult Claimed(
+            PlatformProviderOperationBindingClaim claim)
+        {
+            ArgumentNullException.ThrowIfNull(claim);
+            return new PlatformProviderOperationBindingClaimResult(
+                PlatformProviderOperationBindingClaimStatus.Claimed,
+                claim);
+        }
+
+        internal static PlatformProviderOperationBindingClaimResult Refused(
+            PlatformProviderOperationBindingClaimStatus status) =>
+            new(status, null);
+    }
+
     /// <summary>One immutable persisted provider record with no reusable authority proof.</summary>
     internal sealed class PlatformProviderRegistryDurableRecord
     {

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -6,6 +6,8 @@ using Jellyfin.Plugin.JellyfinCanopy.EventHandlers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.ScheduledTasks;
 using Jellyfin.Plugin.JellyfinCanopy.Platform;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting;
+using Jellyfin.Plugin.JellyfinCanopy.Platform.Hosting.Jellyfin;
 using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Plugins;
@@ -308,6 +310,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton(serviceProvider => new Lazy<PlatformProviderRegistry>(
                 () => serviceProvider.GetRequiredService<PlatformProviderRegistry>(),
                 LazyThreadSafetyMode.ExecutionAndPublication));
+            serviceCollection.AddSingleton<IPlatformProviderBindingHost, JellyfinPlatformProviderBindingHost>();
+            serviceCollection.AddSingleton(serviceProvider => new PlatformProviderBindingService(
+                serviceProvider.GetRequiredService<Lazy<PlatformProviderRegistry>>(),
+                serviceProvider.GetRequiredService<IPlatformProviderBindingHost>()));
             serviceCollection.AddSingleton(serviceProvider => new PlatformProviderRegistryOrchestrator(
                 serviceProvider.GetRequiredService<IPlatformInstalledManifestSweepSource>(),
                 serviceProvider.GetRequiredService<Lazy<PlatformProviderRegistry>>(),

--- a/research/extension-platform/README.md
+++ b/research/extension-platform/README.md
@@ -47,8 +47,8 @@ not claims that a route already ships.
 |---|---|---|
 | [0001](adr/0001-route-prefix-and-namespace.md) | route prefix and namespace | accepted and implemented (EP-01) |
 | [0002](adr/0002-protocol-and-version-negotiation.md) | protocol, version negotiation, error envelope | accepted and implemented (EP-01) |
-| [0003](adr/0003-json-abi.md) | the load-context-safe JSON ABI | accepted; ABI and envelope contract frozen by EP-04.1, binding pending |
-| [0004](adr/0004-provider-invocation.md) | provider binding and failure isolation | accepted; ABI/envelope contract frozen by EP-04.1, invocation and resilience pending |
+| [0003](adr/0003-json-abi.md) | the load-context-safe JSON ABI | accepted; ABI frozen by EP-04.1, exact binding/schema admission implemented by EP-04.2, invocation pending |
+| [0004](adr/0004-provider-invocation.md) | provider binding and failure isolation | accepted; lazy binding/schema admission implemented by EP-04.2, invocation and resilience pending |
 | [0005](adr/0005-manifest-discovery.md) | manifest discovery and registry binding | manifest/acquisition, authoritative approval/grant/generation/lifecycle registry, orchestration and independent fixtures implemented |
 | [0006](adr/0006-client-event-transport.md) | client event transport | accepted for the registry/provider C5 subset; EP-05 implementation pending |
 | [0007](adr/0007-declarative-web-contributions.md) | declarative web contributions | proposed (1–6); the sandboxed-frame decision **deferred, not in v1** |

--- a/research/extension-platform/adr/0003-json-abi.md
+++ b/research/extension-platform/adr/0003-json-abi.md
@@ -1,6 +1,6 @@
 # ADR-0003 — The load-context-safe JSON ABI
 
-Status: **accepted; provider contract frozen by EP-04.1, binding pending** · Owner: platform kernel · Evidence: [S1](../spike-evidence.md#s1--one-collectible-assemblyloadcontext-per-plugin), [S2](../spike-evidence.md#s2--no-shared-type-identity-and-the-failure-is-silent), [S3](../spike-evidence.md#s3--cross-plugin-di-works-but-only-by-foreign-concrete-type)
+Status: **accepted; ABI frozen by EP-04.1 and exact binding/schema admission implemented by EP-04.2; invocation pending** · Owner: platform kernel · Evidence: [S1](../spike-evidence.md#s1--one-collectible-assemblyloadcontext-per-plugin), [S2](../spike-evidence.md#s2--no-shared-type-identity-and-the-failure-is-silent), [S3](../spike-evidence.md#s3--cross-plugin-di-works-but-only-by-foreign-concrete-type)
 
 ## Context
 
@@ -57,6 +57,15 @@ Concretely:
    and digest; the kernel-owned resource name is always
    `JellyfinCanopy.ProviderSchemas.{sha256}.json`. No manifest path, URL, CLR
    type, or resource name is executable or selectable.
+
+EP-04.2 implements only the exact lazy binding and embedded-schema acquisition
+portion of this decision. It publishes an ephemeral, non-authoritative binding,
+caches no foreign reflection/service/schema state, and invokes no provider
+method. Payload evaluation and invocation/result-release authority remain with
+the later bounded invocation owner. Schema acquisition rejects an inventory over
+1,024 resources or a resource name over 512 UTF-8 bytes before scanning for the
+two fixed digest-derived names; each admitted document retains its separate
+64 KiB and structural bounds.
 
 ## Rationale
 

--- a/research/extension-platform/adr/0004-provider-invocation.md
+++ b/research/extension-platform/adr/0004-provider-invocation.md
@@ -1,6 +1,6 @@
 # ADR-0004 — Provider invocation, binding and failure isolation
 
-Status: **accepted; ABI/envelope contract frozen by EP-04.1, invocation pending** · Owner: platform kernel · Evidence: [S3](../spike-evidence.md#s3--cross-plugin-di-works-but-only-by-foreign-concrete-type), [S6](../spike-evidence.md#s6--provider-failure-modes-all-map-to-bounded-host-errors), [S13](../spike-evidence.md#s13--lifecycle-matrix), [S14](../spike-evidence.md#s14--forged-identity-is-fully-resisted-but-the-token-is-in-the-claims)
+Status: **accepted; ABI/envelopes frozen by EP-04.1 and lazy binding/schema admission implemented by EP-04.2; invocation and resilience pending** · Owner: platform kernel · Evidence: [S3](../spike-evidence.md#s3--cross-plugin-di-works-but-only-by-foreign-concrete-type), [S6](../spike-evidence.md#s6--provider-failure-modes-all-map-to-bounded-host-errors), [S13](../spike-evidence.md#s13--lifecycle-matrix), [S14](../spike-evidence.md#s14--forged-identity-is-fully-resisted-but-the-token-is-in-the-claims)
 
 ## Context
 
@@ -29,6 +29,28 @@ ask Jellyfin's shared container for that `Type`, and invoke reflectively.
    the fixed content-addressed resource convention frozen by ADR-0003, and their
    bytes must hash to the manifest digest before use. Binding never follows a
    manifest-selected path or CLR selector.
+
+EP-04.2 implements these five binding rules behind an explicit internal bind
+request. The registry mints and revalidates an exact operation claim around
+foreign concrete-DI resolution and bounded schema admission; authority drift
+publishes nothing. The Jellyfin adapter repeats the exact GUID, Active status,
+version and same live plugin-instance/assembly observation after DI resolution,
+and the coordinator repeats that host check after schema admission. Resolving
+that concrete service may run trusted provider
+constructor code, so this is lazy construction, not containment or a claim that
+zero provider code can execute. The result is not reusable invocation authority,
+does not establish provider health, and must not be invoked until the later owner
+acquires its own generation/cancellation and protected result-release leases.
+
+`AssemblyIdentity` is the descriptor-verified installed DLL-set observation from
+ADR-0005. It fences generations when a completed reconciliation observes drift;
+it is not a content digest or attestation of the assembly Jellyfin already loaded.
+EP-04.2 trusts Jellyfin's `LocalPlugin.Instance` association and proves the exact
+live instance and `Assembly` reference across binding/schema work. Stronger
+loaded-code-to-disk byte equivalence would require a bounded measurement retained
+by the host at load time and is not claimed here; comparing `Assembly.FullName`,
+`Location` or MVID with the descriptor-set fingerprint would provide false
+assurance.
 
 ### Provider context
 
@@ -122,8 +144,10 @@ document in this program may claim otherwise.
 
 ## Consequences
 
-- Reflection on every call. Method handles are cached per bound assembly version
-  and invalidated on rebind.
+- EP-04.2 deliberately caches no assembly, type, method, service instance or
+  schema state; every explicit bind re-observes the live provider. A later
+  invocation owner may introduce a bounded per-assembly-version method cache
+  only with exact generation invalidation and equivalent revalidation.
 - The kernel must distinguish `disabled` from `absent`, which it can: a disabled
   plugin is still in `IPluginManager.Plugins` with `Manifest.Status = Disabled`,
   an uninstalled one is gone entirely.

--- a/research/extension-platform/adr/0005-manifest-discovery.md
+++ b/research/extension-platform/adr/0005-manifest-discovery.md
@@ -60,6 +60,10 @@ declared scopes — are each a distinct vulnerability.
    Windows roots fail closed.
    Successful output is an immutable observation only; it still carries no
    approval, grant, lifecycle, persistence or invocation authority.
+   Its assembly-set identity fingerprints descriptor-verified DLL inventory and
+   fences drift observed by a completed reconciliation. It is deliberately not a
+   digest or load-time attestation of already-loaded code; ADR-0004 records the
+   narrower live-instance/assembly provenance used by EP-04.2.
 6. **A manifest is never a grant.** It states what an extension *requests*. An
    administrator approves. Requested and granted scopes are stored separately.
 7. **Fingerprint changes revoke approval.** Any change to the manifest
@@ -134,9 +138,12 @@ declared scopes — are each a distinct vulnerability.
    cooperative cancellation and joins the retained worker. Absolute termination
    for a kernel or storage operation that never returns remains #648.
    The fence governs subsequent registry release attempts; an immutable release
-   object already returned to a future consumer is not remotely revocable. EP-04
-   must therefore acquire or revalidate exact current authority at its final
-   admission boundary before provider work begins.
+   object already returned to a future consumer is not remotely revocable. EP-04.2
+   therefore added registry-owned, epoch-fenced operation claims and revalidates
+   them after foreign binding and again after schema admission. Those ephemeral
+   results remain non-authoritative: the later invocation owner must acquire its
+   own exact generation/cancellation and protected result-release leases before
+   provider method invocation or protected publication.
 
 ## Rationale
 

--- a/research/extension-platform/adr/0013-server-platform-tranche.md
+++ b/research/extension-platform/adr/0013-server-platform-tranche.md
@@ -267,3 +267,9 @@ load-context-safe provider ABI, operation declarations and bounded envelopes,
 content-addressed embedded payload schemas, and turns Alpha into the independent
 Hello contract fixture without adding a
 production reflection binder or invocation path.
+Issue #656 adds the next bounded EP-04 layer: exact registry operation claims,
+lazy live-plugin foreign concrete-DI binding, frozen ABI verification and bounded
+content-addressed schema admission. It adds no provider method invocation,
+health claim, route, worker, cache or client behavior; generation cancellation,
+payload evaluation and protected result-release leases remain the next EP-04
+invocation slice.

--- a/research/extension-platform/v1-capability-freeze.md
+++ b/research/extension-platform/v1-capability-freeze.md
@@ -81,12 +81,15 @@ A convention-based entrypoint invoked over the JSON ABI with a derived context,
 a kernel-owned deadline, concurrency caps, bulkheads, circuit breakers, a
 response size cap, and stable failure codes.
 
-**Activated for the server tranche; contract foundation delivered by #654,
-runtime not yet delivered.** The exact foreign concrete-type convention,
+**Activated for the server tranche; contract foundation delivered by #654 and
+exact lazy binding/schema admission delivered by #656; invocation not yet
+delivered.** The exact foreign concrete-type convention,
 string/JSON/cancellation ABI, bounded operation declarations, request/response
 envelopes, content-addressed embedded payload schemas and independent Hello
-fixture are frozen. No reflection binder or
-provider invocation ships from that contract-only slice. Existing EP-06 pilot
+fixture are frozen. The internal binder revalidates current registry authority,
+resolves only the code-owned foreign concrete type from the live plugin assembly,
+checks the exact ABI and admits the two bounded content-addressed schemas. It
+invokes no provider method and publishes no reusable authority. Existing EP-06 pilot
 routes continue to call Canopy's in-process owning services and do not silently
 become provider routes. C3 delivery still requires the EP-04
 binding/failure/lifecycle/bounds gates. Provider-to-provider calls,
@@ -305,7 +308,7 @@ health/circuit contract and runtime.
 |---|---|---|
 | C1 discovery/negotiation | EP-01, EP-06 | **in** |
 | C2 registry + lifecycle | EP-02, EP-03 | **active server tranche; manifest, host binding, authoritative lifecycle registry and lazy single-flight orchestration delivered** |
-| C3 provider invocation | EP-04 | **active server tranche; ABI/operation/envelope/Hello-fixture contract delivered by #654; runtime pending** |
+| C3 provider invocation | EP-04 | **active server tranche; #654 contract and #656 exact binding/schema admission delivered; invocation/runtime resilience pending** |
 | C4 namespaced state | EP-05 | **active server tranche; not yet delivered** |
 | C5 events | EP-05 | **registry/provider lifecycle-health-invalidation subset active; broader Jellyfin/Canopy events deferred** |
 | C6 opaque actions | EP-02, EP-06 | **in** |

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 41753, totalLines: 51374 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 41758, totalLines: 51374 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
+        cleanRuns: 4,
         minimumCoveredLines: 41751,
-        maximumCoveredLines: 41753,
+        maximumCoveredLines: 41758,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2808, totalLines: 3201 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 40990, totalLines: 50558 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 41753, totalLines: 51374 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2808,
         maximumCoveredLines: 2808,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 5,
-        minimumCoveredLines: 40985,
-        maximumCoveredLines: 40990,
+        cleanRuns: 3,
+        minimumCoveredLines: 41751,
+        maximumCoveredLines: 41753,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 40990,
-        "totalLines": 50558
+        "coveredLines": 41753,
+        "totalLines": 51374
       },
       "observations": {
-        "cleanRuns": 5,
-        "minimumCoveredLines": 40985,
-        "maximumCoveredLines": 40990
+        "cleanRuns": 3,
+        "minimumCoveredLines": 41751,
+        "maximumCoveredLines": 41753
       },
       "tolerance": {
-        "missingCoveredLines": 5,
-        "rationale": "The #654 EP-04.1 contract slice freezes provider operation declarations, the load-context-safe string/JSON/cancellation ABI, bounded request and response envelopes, content-addressed embedded payload schemas, and an independent deterministic Alpha Hello provider fixture without adding reflection binding, invocation routes, automatic approval, deployment, or Android/client work. Four clean local .NET 10.0.9 Coverlet runs and the clean GitHub Actions .NET 10.0.9 run on 2026-08-04 against the identical final 50,558-line production source and 3,940-test scope measured 40,988, 40,986, 40,987, 40,985 and 40,990 covered lines. The reviewed observed high-water is therefore 40,990/50,558 (81.075%) and the exact observed floor is 40,985/50,558 (81.065%); the five-line schedule-dependent concurrency instrumentation spread is bounded to 0.010 percentage points. Relative to the #652 baseline of 40,797/50,352 (81.024%), the change adds 206 instrumented lines and at least 188 covered lines while increasing overall coverage. Independent manifest, schema, fingerprint, resource-byte, package-shape, ABI and disposable Jellyfin 12 conformance tests cover the contract-critical paths. Production schema loading/validation, reflection invocation and resilience remain explicitly deferred by #654, while #648 remains the explicit nonreturning-filesystem isolation residual. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "The #656 EP-04.2 slice adds exact epoch-fenced registry operation claims, lazy current-LocalPlugin foreign concrete-DI binding, exact reflective ABI admission, repeated host and registry revalidation, and bounded content-addressed embedded-schema acquisition without invoking a provider method or adding routes, workers, caches, deployment, or Android/client behavior. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-04 against the identical final 51,374-line production source and 4,025-test scope measured 41,753, 41,751 and 41,752 covered lines. The reviewed observed high-water is therefore 41,753/51,374 (81.273%) and the exact observed floor is 41,751/51,374 (81.269%); the two-line schedule-dependent instrumentation spread is bounded to 0.004 percentage points. Relative to the #654 baseline of 40,990/50,558 (81.075%), the change adds 816 instrumented lines and at least 761 covered lines while increasing overall coverage. Focused authority-race, lifecycle-race, concrete-DI, collectible-load-context, ABI-near-miss, schema-byte/structure/inventory and architecture tests cover the new binding-critical paths. Provider method invocation, payload evaluation, generation cancellation, resilience and protected result-release leases remain explicitly deferred to the next EP-04 child; #648 remains the nonreturning-filesystem isolation residual. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 41753,
+        "coveredLines": 41758,
         "totalLines": 51374
       },
       "observations": {
-        "cleanRuns": 3,
+        "cleanRuns": 4,
         "minimumCoveredLines": 41751,
-        "maximumCoveredLines": 41753
+        "maximumCoveredLines": 41758
       },
       "tolerance": {
-        "missingCoveredLines": 2,
-        "rationale": "The #656 EP-04.2 slice adds exact epoch-fenced registry operation claims, lazy current-LocalPlugin foreign concrete-DI binding, exact reflective ABI admission, repeated host and registry revalidation, and bounded content-addressed embedded-schema acquisition without invoking a provider method or adding routes, workers, caches, deployment, or Android/client behavior. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-04 against the identical final 51,374-line production source and 4,025-test scope measured 41,753, 41,751 and 41,752 covered lines. The reviewed observed high-water is therefore 41,753/51,374 (81.273%) and the exact observed floor is 41,751/51,374 (81.269%); the two-line schedule-dependent instrumentation spread is bounded to 0.004 percentage points. Relative to the #654 baseline of 40,990/50,558 (81.075%), the change adds 816 instrumented lines and at least 761 covered lines while increasing overall coverage. Focused authority-race, lifecycle-race, concrete-DI, collectible-load-context, ABI-near-miss, schema-byte/structure/inventory and architecture tests cover the new binding-critical paths. Provider method invocation, payload evaluation, generation cancellation, resilience and protected result-release leases remain explicitly deferred to the next EP-04 child; #648 remains the nonreturning-filesystem isolation residual. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 7,
+        "rationale": "The #656 EP-04.2 slice adds exact epoch-fenced registry operation claims, lazy current-LocalPlugin foreign concrete-DI binding, exact reflective ABI admission, repeated host and registry revalidation, and bounded content-addressed embedded-schema acquisition without invoking a provider method or adding routes, workers, caches, deployment, or Android/client behavior. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-04 against the identical final 51,374-line production source and 4,025-test scope measured 41,753, 41,751 and 41,752 covered lines; the first clean GitHub Actions run on the same commit and scope measured 41,758 after all 4,025 tests passed. The reviewed observed high-water is therefore 41,758/51,374 (81.282%) and the exact observed floor is 41,751/51,374 (81.269%); the seven-line schedule-dependent instrumentation spread is bounded to 0.014 percentage points. Relative to the #654 baseline of 40,990/50,558 (81.075%), the change adds 816 instrumented lines and at least 761 covered lines while increasing overall coverage. Focused authority-race, lifecycle-race, concrete-DI, collectible-load-context, ABI-near-miss, schema-byte/structure/inventory and architecture tests cover the new binding-critical paths. Provider method invocation, payload evaluation, generation cancellation, resilience and protected result-release leases remain explicitly deferred to the next EP-04 child; #648 remains the nonreturning-filesystem isolation residual. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- add immutable, epoch-fenced registry claims for a negotiated provider operation
- bind only the exact active Jellyfin `LocalPlugin.Instance` assembly and exact frozen `InvokeAsync` ABI through concrete DI
- admit the two content-addressed embedded schemas with bounded resource, UTF-8, JSON, vocabulary, and local-reference validation
- revalidate both live host identity and registry authority before releasing a binding
- document the descriptor-set identity limitation and explicitly defer provider invocation and result-release authority

## Why

EP-04.2 needs a safe lazy boundary between the reconciled provider registry and future invocation work. Previously the registry could describe a provider, but Canopy had no authority-fenced way to bind the current Jellyfin instance or admit its schemas without reopening path-based loading and TOCTOU risks.

## Impact

This is server-only platform groundwork. It adds no routes, workers, caches, provider method invocation, payload evaluation, deployment, release, Android behavior, or client production changes. The next EP-04 child remains responsible for invocation, cancellation, resilience, and protected result-release leases.

## Validation

- 4,025/4,025 full server tests
- 85/85 focused EP-04.2 tests
- three clean Coverlet runs: 41,751–41,753 / 51,374 lines; ratchet passes at 81.271%
- 2,041/2,041 unchanged client tests (single-worker isolation)
- 645/645 script tests
- type checks, syntax/performance guards, translations, deterministic bundle
- strict documentation/MkDocs build
- disposable Jellyfin 12 provider-conformance lifecycle matrix
- independent multi-agent whole-diff review: APPROVE

Closes #656
Advances #43
Advances #41
Advances #42

Related: #648, #654