### PR TITLE
fix: preserve warning-only maintenance mode

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/MaintenanceModeControllerFailureTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/MaintenanceModeControllerFailureTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
 using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
@@ -75,6 +76,26 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             string bodyJson = JsonSerializer.Serialize(result.Value);
             Assert.DoesNotContain("secret-path-detail", bodyJson, StringComparison.Ordinal);
             using var body = JsonDocument.Parse(bodyJson);
+            Assert.False(body.RootElement.GetProperty("success").GetBoolean());
+            Assert.Equal(MaintenancePhases.Inactive, body.RootElement.GetProperty("Phase").GetString());
+            Assert.False(File.Exists(_stateFilePath));
+        }
+
+        [Fact]
+        public async Task UnknownAction_ReturnsStructuredBadRequestWithoutPersistingState()
+        {
+            var users = new StubUserManager();
+            using var service = CreateService(users, AtomicFile.WriteAllText);
+            var controller = CreateController(users, service);
+
+            var result = Assert.IsType<ObjectResult>(await controller.EnableMaintenanceMode(new MaintenanceModeRequest
+            {
+                Message = "maintenance",
+                Action = "unexpected"
+            }));
+
+            Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
+            using var body = JsonDocument.Parse(JsonSerializer.Serialize(result.Value));
             Assert.False(body.RootElement.GetProperty("success").GetBoolean());
             Assert.Equal(MaintenancePhases.Inactive, body.RootElement.GetProperty("Phase").GetString());
             Assert.False(File.Exists(_stateFilePath));

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintenanceModeStateMachineTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/MaintenanceModeStateMachineTests.cs
@@ -50,6 +50,121 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         }
 
         [Fact]
+        public async Task WarningOnlyAction_RoundTripsAcrossRestart_WithoutPolicyMutation()
+        {
+            var user = NewUser("warning-only");
+            var users = new StateMachineUserManager(user);
+            using (var service = CreateService(users))
+            {
+                await service.EnableAsync("maintenance", 0, MaintenanceActions.None, null);
+
+                var active = service.GetStatus();
+                Assert.Equal(MaintenancePhases.Active, active.Phase);
+                Assert.Equal(MaintenanceActions.None, active.Action);
+                Assert.Empty(active.AccountDisabledUserIds);
+                Assert.Empty(active.RemoteDisabledUserIds);
+            }
+
+            Assert.Equal(0, users.PolicyUpdateCalls);
+            Assert.False(users.Policy(user.Id).IsDisabled);
+            Assert.True(users.Policy(user.Id).EnableRemoteAccess);
+            Assert.Equal(MaintenanceActions.None, ReadState(_stateFilePath).Action);
+
+            using var restarted = CreateService(users);
+            Assert.Equal(MaintenanceActions.None, restarted.GetStatus().Action);
+            await restarted.DisableAsync();
+
+            Assert.Equal(0, users.PolicyUpdateCalls);
+            Assert.Equal(MaintenancePhases.Inactive, restarted.GetStatus().Phase);
+        }
+
+        [Fact]
+        public async Task UnknownAction_IsRejectedBeforeStateOrPolicyMutation()
+        {
+            var user = NewUser("unknown-action");
+            var users = new StateMachineUserManager(user);
+            using var service = CreateService(users);
+
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                service.EnableAsync("maintenance", 0, "unexpected", null));
+
+            Assert.Equal(0, users.PolicyUpdateCalls);
+            Assert.Equal(MaintenancePhases.Inactive, service.GetStatus().Phase);
+            Assert.False(File.Exists(_stateFilePath));
+        }
+
+        [Fact]
+        public async Task ActiveWarningOnly_RejectsActionChangeWithoutPolicyMutation()
+        {
+            var user = NewUser("active-action-change");
+            var users = new StateMachineUserManager(user);
+            using var service = CreateService(users);
+            await service.EnableAsync("maintenance", 0, MaintenanceActions.None, null);
+
+            var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.EnableAsync("replacement", 0, MaintenanceActions.Both, null));
+
+            Assert.Contains("Disable it before changing", error.Message, StringComparison.Ordinal);
+            Assert.Equal(MaintenanceActions.None, service.GetStatus().Action);
+            Assert.Equal("maintenance", service.GetStatus().Message);
+            Assert.Equal(0, users.PolicyUpdateCalls);
+        }
+
+        [Fact]
+        public async Task LegacyStateWithoutAction_DefaultsToDisableAccountsAndRemainsRecoverable()
+        {
+            var user = NewUser("legacy-action");
+            var users = new StateMachineUserManager(user);
+            users.Policy(user.Id).IsDisabled = true;
+            Directory.CreateDirectory(Path.GetDirectoryName(_stateFilePath)!);
+            var legacyJson = JsonSerializer.Serialize(new
+            {
+                IsActive = true,
+                Message = "legacy maintenance",
+                StartedAt = DateTime.UtcNow,
+                EndsAt = (DateTime?)null,
+                AccountDisabledUserIds = new[] { user.Id.ToString() },
+                RemoteDisabledUserIds = Array.Empty<string>()
+            });
+            AtomicFile.WriteAllText(_stateFilePath, legacyJson);
+            AtomicFile.WriteAllText(_recoveryFilePath, legacyJson);
+
+            using var service = CreateService(users);
+            Assert.Equal(MaintenanceActions.DisableAccounts, service.GetStatus().Action);
+            Assert.Equal(MaintenancePhases.Active, service.GetStatus().Phase);
+
+            await service.DisableAsync();
+
+            Assert.False(users.Policy(user.Id).IsDisabled);
+            Assert.Equal(MaintenancePhases.Inactive, service.GetStatus().Phase);
+        }
+
+        [Fact]
+        public async Task WarningOnlyStateWithRecoveryRecords_FaultsWithoutPolicyMutation()
+        {
+            var user = NewUser("invalid-warning-ledger");
+            var users = new StateMachineUserManager(user);
+            users.Policy(user.Id).IsDisabled = true;
+            SeedState(new MaintenanceState
+            {
+                Phase = MaintenancePhases.Active,
+                IsActive = true,
+                Message = "invalid warning-only state",
+                Action = MaintenanceActions.None,
+                StartedAt = DateTime.UtcNow,
+                AccountDisabledUserIds = new List<string> { user.Id.ToString() },
+                RecoveryAvailable = true
+            });
+
+            using var service = CreateService(users);
+            Assert.Equal(MaintenancePhases.Faulted, service.GetStatus().Phase);
+            Assert.False(service.GetStatus().RecoveryAvailable);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => service.DisableAsync());
+            Assert.True(users.Policy(user.Id).IsDisabled);
+            Assert.Equal(0, users.PolicyUpdateCalls);
+        }
+
+        [Fact]
         public async Task CorruptPrimary_ReportsFaulted_AndRestoresFromRecoveryLedger()
         {
             var user = NewUser("recoverable");
@@ -368,6 +483,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 
             public bool BlockRestores { get; set; }
             public int RestoreCalls { get; private set; }
+            public int PolicyUpdateCalls { get; private set; }
             public HashSet<Guid> FailRestoreFor { get; } = new();
             public HashSet<Guid> ReturnNullFromLookupFor { get; } = new();
             public HashSet<Guid> ReturnNullPolicyFor { get; } = new();
@@ -398,6 +514,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 
             public async Task UpdatePolicyAsync(Guid userId, UserPolicy policy)
             {
+                PolicyUpdateCalls++;
                 bool restoring = !policy.IsDisabled && _policies[userId].IsDisabled;
                 if (restoring)
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
@@ -373,7 +373,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         public string MaintenanceModeMessage { get; set; } = string.Empty;
         /// <summary>Sent as a native Jellyfin broadcast to all active sessions.</summary>
         public string MaintenanceModeNotificationMessage { get; set; } = string.Empty;
-        /// <summary>"disable_accounts" | "disable_remote" | "both"</summary>
+        /// <summary>"none" | "disable_accounts" | "disable_remote" | "both"</summary>
         public string MaintenanceModeAction { get; set; } = "disable_accounts";
         /// <summary>"all" or a JSON array of user ID strings.</summary>
         public string MaintenanceModeAffectedUsers { get; set; } = "all";

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
@@ -2540,7 +2540,10 @@
             });
         }
 
+        var _maintenanceActionLoadError = null;
+
         function loadConfig() {
+            _maintenanceActionLoadError = null;
             Dashboard.showLoadingMsg();
             checkInstalledPlugins();
             ApiClient.getPluginConfiguration(pluginId).then((config) => {
@@ -2559,9 +2562,16 @@
                 applyConfigToBoundFields(config);
 
                 // Restore action checkboxes
-                const savedAction = config.MaintenanceModeAction || 'disable_accounts';
-                document.getElementById('mmAction_accounts').checked = savedAction === 'disable_accounts' || savedAction === 'both';
-                document.getElementById('mmAction_remote').checked   = savedAction === 'disable_remote'   || savedAction === 'both';
+                let savedAction;
+                try {
+                    savedAction = maintenanceSelectionsFromAction(config.MaintenanceModeAction);
+                    _maintenanceActionLoadError = null;
+                } catch (actionError) {
+                    _maintenanceActionLoadError = actionError.message;
+                    throw actionError;
+                }
+                document.getElementById('mmAction_accounts').checked = savedAction.accounts;
+                document.getElementById('mmAction_remote').checked = savedAction.remote;
                 // Restore user selection radio + checkboxes
                 const savedUsers = config.MaintenanceModeAffectedUsers || 'all';
                 if (savedUsers === 'all') {
@@ -2658,11 +2668,41 @@
                 updateRequestsRequirementsBanner();
 
                 Dashboard.hideLoadingMsg();
+            }).catch(function(loadError) {
+                Dashboard.hideLoadingMsg();
+                console.error('[JC] Configuration load failed:', loadError);
+                Dashboard.alert({
+                    title: 'Configuration load failed',
+                    message: _maintenanceActionLoadError
+                        ? 'The saved maintenance action is invalid. Correct the server configuration before saving this page.'
+                        : 'Could not load Jellyfin Canopy settings. Check the browser console and server logs.'
+                });
             });
+        }
+
+        function maintenanceActionFromSelections(accounts, remote) {
+            if (accounts && remote) return 'both';
+            if (accounts) return 'disable_accounts';
+            if (remote) return 'disable_remote';
+            return 'none';
+        }
+
+        function maintenanceSelectionsFromAction(action) {
+            const savedAction = action || 'disable_accounts';
+            if (!['none', 'disable_accounts', 'disable_remote', 'both'].includes(savedAction)) {
+                throw new Error('Unknown maintenance action: ' + savedAction);
+            }
+            return {
+                accounts: savedAction === 'disable_accounts' || savedAction === 'both',
+                remote: savedAction === 'disable_remote' || savedAction === 'both'
+            };
         }
 
         async function buildConfigFromForm() {
             const config = await ApiClient.getPluginConfiguration(pluginId);
+            if (_maintenanceActionLoadError) {
+                throw new Error('Cannot save while the persisted maintenance action is invalid.');
+            }
             const finalShortcuts = [...defaultShortcuts];
             shortcutOverrides.forEach(override => {
                 const index = finalShortcuts.findIndex(s => s.Name === override.Name);
@@ -2679,9 +2719,7 @@
 
             const mmAccounts = document.getElementById('mmAction_accounts').checked;
             const mmRemote   = document.getElementById('mmAction_remote').checked;
-            config.MaintenanceModeAction = (mmAccounts && mmRemote) ? 'both'
-                                         : mmRemote                 ? 'disable_remote'
-                                         :                            'disable_accounts';
+            config.MaintenanceModeAction = maintenanceActionFromSelections(mmAccounts, mmRemote);
             const mmUsersMode = (document.querySelector('input[name="maintenanceModeUsers"]:checked') || {}).value || 'all';
             if (mmUsersMode === 'all') {
                 config.MaintenanceModeAffectedUsers = 'all';
@@ -2868,6 +2906,78 @@
         // between-save form changes. Treat saves as serial.
         var _jeSaveInFlight = false;
 
+        function getMaintenanceStatus() {
+            return ApiClient.ajax({
+                type: 'GET',
+                url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Status'),
+                dataType: 'json'
+            });
+        }
+
+        async function enableMaintenanceFromConfig(config, broadcast) {
+            const affectedIds = config.MaintenanceModeAffectedUsers === 'all'
+                ? []
+                : JSON.parse(config.MaintenanceModeAffectedUsers || '[]');
+            await ApiClient.ajax({
+                type: 'POST',
+                url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Enable'),
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    message: config.MaintenanceModeMessage || '',
+                    durationMinutes: 0,
+                    action: config.MaintenanceModeAction || 'disable_accounts',
+                    affectedUserIds: affectedIds
+                })
+            });
+
+            if (!broadcast) return;
+            const mmMsg = (config.MaintenanceModeNotificationMessage || '').trim()
+                || (config.MaintenanceModeMessage || '').trim()
+                || 'Server maintenance is starting. Please finish up and try again later.';
+            try {
+                await ApiClient.ajax({
+                    type: 'POST',
+                    url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Broadcast'),
+                    contentType: 'application/json',
+                    data: JSON.stringify({
+                        header: 'Server Maintenance',
+                        text: mmMsg,
+                        timeoutMs: 30000
+                    })
+                });
+            } catch (bcErr) {
+                console.warn('[JC] Maintenance broadcast failed (no active sessions?):', bcErr);
+            }
+        }
+
+        async function persistConfigurationAndMaintenance(config, broadcast) {
+            const status = await getMaintenanceStatus();
+            if (config.MaintenanceModeEnabled) {
+                if (status.IsActive && status.Phase !== 'Active') {
+                    throw new Error('Maintenance recovery must be completed before saving enabled maintenance settings.');
+                }
+                if (status.IsActive && status.Action !== config.MaintenanceModeAction) {
+                    throw new Error('Disable active maintenance before changing its action.');
+                }
+
+                // Persist the warning/restriction intent before applying account policy. If the
+                // configuration request fails or its response is lost, no new restriction is
+                // authorized and a retry can converge from the authoritative status endpoint.
+                const result = await ApiClient.updatePluginConfiguration(pluginId, config);
+                await enableMaintenanceFromConfig(config, broadcast);
+                return result;
+            }
+
+            // Restore account access before removing the persisted warning intent. A failed
+            // recovery therefore leaves the banner/configuration enabled instead of hiding an
+            // unresolved restriction. No browser-side compensation guesses whether a write landed.
+            await ApiClient.ajax({
+                type: 'POST',
+                url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Disable')
+            });
+            return ApiClient.updatePluginConfiguration(pluginId, config);
+        }
+
         async function saveConfig(e) {
             e.preventDefault();
             if (_jeSaveInFlight) return false;
@@ -2880,53 +2990,7 @@
                 const config = await buildConfigFromForm();
                 // Everything mutated up to this snapshot is in `config`.
                 const dirtyRevisionAtSnapshot = jcDirtyRevisionNow();
-                const result = await ApiClient.updatePluginConfiguration(pluginId, config);
-
-                // Apply maintenance mode: enable/disable users to match the toggle
-                try {
-                    if (config.MaintenanceModeEnabled) {
-                        const affectedIds = config.MaintenanceModeAffectedUsers === 'all'
-                            ? []
-                            : JSON.parse(config.MaintenanceModeAffectedUsers || '[]');
-                        await ApiClient.ajax({
-                            type: 'POST',
-                            url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Enable'),
-                            contentType: 'application/json',
-                            data: JSON.stringify({
-                                message: config.MaintenanceModeMessage || '',
-                                durationMinutes: 0,
-                                action: config.MaintenanceModeAction || 'disable_accounts',
-                                affectedUserIds: affectedIds
-                            })
-                        });
-                        // Broadcast a native Jellyfin message to all active sessions
-                        // (reaches non-web clients like TV apps too — works regardless of Active Streams setting)
-                        const mmMsg = (config.MaintenanceModeNotificationMessage || '').trim()
-                            || (config.MaintenanceModeMessage || '').trim()
-                            || 'Server maintenance is starting. Please finish up and try again later.';
-                        try {
-                            await ApiClient.ajax({
-                                type: 'POST',
-                                url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Broadcast'),
-                                contentType: 'application/json',
-                                data: JSON.stringify({
-                                    header: 'Server Maintenance',
-                                    text: mmMsg,
-                                    timeoutMs: 30000
-                                })
-                            });
-                        } catch (bcErr) {
-                            console.warn('[JC] Maintenance broadcast failed (no active sessions?):', bcErr);
-                        }
-                    } else {
-                        await ApiClient.ajax({
-                            type: 'POST',
-                            url: ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Disable')
-                        });
-                    }
-                } catch (mmErr) {
-                    console.warn('[JC] Maintenance mode apply failed:', mmErr);
-                }
+                const result = await persistConfigurationAndMaintenance(config, true);
 
                 Dashboard.processPluginConfigurationUpdateResult(result);
                 // Clean only if nothing was edited while the save was in flight.
@@ -2937,7 +3001,7 @@
                 try {
                     Dashboard.alert({
                         title: 'Save failed',
-                        message: 'Could not save Jellyfin Canopy settings. Check the browser console and server logs, then try again.'
+                        message: 'Could not fully apply Jellyfin Canopy settings. Reload to inspect the current configuration and maintenance status, then try again.'
                     });
                 } catch (alertErr) { console.warn('[JC] Dashboard.alert threw:', alertErr); }
             } finally {
@@ -2954,7 +3018,7 @@
                 try {
                     // First, save the current configuration
                     const config = await buildConfigFromForm();
-                    await ApiClient.updatePluginConfiguration(pluginId, config);
+                    await persistConfigurationAndMaintenance(config, false);
 
                     // Then reset all user settings to match the saved config
                     await ApiClient.ajax({

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -2388,6 +2388,7 @@
                                         <span class="fieldDescription" style="display:block;margin:0;">Blocks connections from outside the local network; LAN access still works.</span>
                                     </span>
                                 </label>
+                                <div class="fieldDescription" style="margin-top:0.6em;">Clear both actions to show maintenance warnings without changing any user account or remote-access policy. Disable active maintenance before changing its action.</div>
                             </div>
 
                             <!-- Affected users -->

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/MaintenanceModeController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/MaintenanceModeController.cs
@@ -103,6 +103,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     request.AffectedUserIds).ConfigureAwait(false);
                 return Ok(new { success = true });
             }
+            catch (ArgumentException ex)
+            {
+                return MaintenanceFailure(StatusCodes.Status400BadRequest, ex.Message);
+            }
             catch (InvalidOperationException ex)
             {
                 return MaintenanceFailure(StatusCodes.Status409Conflict, ex.Message);
@@ -222,7 +226,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     {
         public string? Message { get; set; }
         public int DurationMinutes { get; set; }
-        /// <summary>"disable_accounts" | "disable_remote" | "both"</summary>
+        /// <summary>"none" | "disable_accounts" | "disable_remote" | "both"</summary>
         public string Action { get; set; } = "disable_accounts";
         /// <summary>Specific user IDs to affect. Null or empty = all non-admin users.</summary>
         public List<string>? AffectedUserIds { get; set; }

--- a/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
@@ -4,6 +4,7 @@ global using JSortOrder = Jellyfin.Database.Implementations.Enums.SortOrder;
 
 using System.Globalization;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
@@ -228,6 +229,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy
         {
             if (configuration is PluginConfiguration config)
             {
+                config.MaintenanceModeAction = string.IsNullOrEmpty(config.MaintenanceModeAction)
+                    ? MaintenanceActions.DisableAccounts
+                    : config.MaintenanceModeAction;
+                if (!MaintenanceActions.IsSupported(config.MaintenanceModeAction))
+                {
+                    throw new ArgumentException(
+                        "MaintenanceModeAction must be none, disable_accounts, disable_remote, or both.",
+                        nameof(configuration));
+                }
+
                 SanitizeExternalUrlFields(config);
             }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/MaintenanceModeService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/MaintenanceModeService.cs
@@ -24,14 +24,27 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         public const string Faulted = "Faulted";
     }
 
+    /// <summary>Canonical durable actions accepted by maintenance configuration and state.</summary>
+    public static class MaintenanceActions
+    {
+        public const string None = "none";
+        public const string DisableAccounts = "disable_accounts";
+        public const string DisableRemote = "disable_remote";
+        public const string Both = "both";
+
+        /// <summary>Returns whether <paramref name="action"/> names an explicit supported action.</summary>
+        public static bool IsSupported(string? action)
+            => action is None or DisableAccounts or DisableRemote or Both;
+    }
+
     public class MaintenanceState
     {
         public int SchemaVersion { get; set; } = 2;
         public string Phase { get; set; } = string.Empty;
         public bool IsActive { get; set; }
         public string Message { get; set; } = string.Empty;
-        /// <summary>"disable_accounts" | "disable_remote" | "both"</summary>
-        public string Action { get; set; } = "disable_accounts";
+        /// <summary>"none" | "disable_accounts" | "disable_remote" | "both"</summary>
+        public string Action { get; set; } = MaintenanceActions.DisableAccounts;
         public DateTime StartedAt { get; set; }
         public DateTime? EndsAt { get; set; }
         /// <summary>Users whose accounts were disabled by maintenance mode (so we know what to restore).</summary>
@@ -144,10 +157,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             }
         }
 
-        /// <param name="action">"disable_accounts" | "disable_remote" | "both"</param>
+        /// <param name="action">"none" | "disable_accounts" | "disable_remote" | "both"</param>
         /// <param name="affectedUserIds">Specific user IDs to affect; null or empty = all non-admin users.</param>
         public async Task EnableAsync(string message, int durationMinutes, string action, List<string>? affectedUserIds)
         {
+            action ??= MaintenanceActions.DisableAccounts;
+            if (!MaintenanceActions.IsSupported(action))
+            {
+                throw new ArgumentException("Maintenance action must be none, disable_accounts, disable_remote, or both.", nameof(action));
+            }
+
             await _stateGate.WaitAsync().ConfigureAwait(false);
             try
             {
@@ -163,6 +182,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
 
                 if (string.Equals(currentState.Phase, MaintenancePhases.Active, StringComparison.Ordinal))
                 {
+                    if (!string.Equals(currentState.Action, action, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(
+                            $"Maintenance mode is already active with action '{currentState.Action}'. " +
+                            "Disable it before changing the maintenance action.");
+                    }
+
                     currentState.Message = message ?? string.Empty;
                     currentState.EndsAt = durationMinutes > 0 ? UtcNow().AddMinutes(durationMinutes) : null;
                     currentState.FailureReason = null;
@@ -175,41 +201,44 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     return;
                 }
 
-                bool doAccounts = action == "disable_accounts" || action == "both";
-                bool doRemote = action == "disable_remote" || action == "both";
-
-                var allNonAdmin = _userManager.GetUsers()
-                    .Where(u => !u.HasPermission(PermissionKind.IsAdministrator))
-                    .ToList();
-
-                IEnumerable<Jellyfin.Database.Implementations.Entities.User> targetUsers;
-                if (affectedUserIds == null || affectedUserIds.Count == 0)
-                {
-                    targetUsers = allNonAdmin;
-                }
-                else
-                {
-                    var idSet = affectedUserIds
-                        .Select(s => Guid.TryParse(s, out var parsed) ? parsed : Guid.Empty)
-                        .Where(id => id != Guid.Empty)
-                        .ToHashSet();
-                    targetUsers = allNonAdmin.Where(u => idSet.Contains(u.Id));
-                }
-
                 var plan = new List<(Guid Id, string Username, MediaBrowser.Model.Users.UserPolicy Policy, bool DisableAccount, bool DisableRemote)>();
-                foreach (var user in targetUsers)
+                if (action != MaintenanceActions.None)
                 {
-                    var dto = _userManager.GetUserDto(user, string.Empty);
-                    if (dto.Policy == null)
+                    bool doAccounts = action is MaintenanceActions.DisableAccounts or MaintenanceActions.Both;
+                    bool doRemote = action is MaintenanceActions.DisableRemote or MaintenanceActions.Both;
+
+                    var allNonAdmin = _userManager.GetUsers()
+                        .Where(u => !u.HasPermission(PermissionKind.IsAdministrator))
+                        .ToList();
+
+                    IEnumerable<Jellyfin.Database.Implementations.Entities.User> targetUsers;
+                    if (affectedUserIds == null || affectedUserIds.Count == 0)
                     {
-                        throw new InvalidOperationException($"Cannot read the policy for maintenance target '{user.Username}'.");
+                        targetUsers = allNonAdmin;
+                    }
+                    else
+                    {
+                        var idSet = affectedUserIds
+                            .Select(s => Guid.TryParse(s, out var parsed) ? parsed : Guid.Empty)
+                            .Where(id => id != Guid.Empty)
+                            .ToHashSet();
+                        targetUsers = allNonAdmin.Where(u => idSet.Contains(u.Id));
                     }
 
-                    bool disableAccount = doAccounts && !dto.Policy.IsDisabled;
-                    bool disableRemote = doRemote && dto.Policy.EnableRemoteAccess;
-                    if (disableAccount || disableRemote)
+                    foreach (var user in targetUsers)
                     {
-                        plan.Add((user.Id, user.Username, dto.Policy, disableAccount, disableRemote));
+                        var dto = _userManager.GetUserDto(user, string.Empty);
+                        if (dto.Policy == null)
+                        {
+                            throw new InvalidOperationException($"Cannot read the policy for maintenance target '{user.Username}'.");
+                        }
+
+                        bool disableAccount = doAccounts && !dto.Policy.IsDisabled;
+                        bool disableRemote = doRemote && dto.Policy.EnableRemoteAccess;
+                        if (disableAccount || disableRemote)
+                        {
+                            plan.Add((user.Id, user.Username, dto.Policy, disableAccount, disableRemote));
+                        }
                     }
                 }
 
@@ -220,7 +249,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     Phase = MaintenancePhases.Active,
                     IsActive = true,
                     Message = message ?? string.Empty,
-                    Action = action ?? "disable_accounts",
+                    Action = action,
                     StartedAt = now,
                     EndsAt = durationMinutes > 0 ? now.AddMinutes(durationMinutes) : null,
                     AccountDisabledUserIds = plan.Where(p => p.DisableAccount).Select(p => p.Id.ToString()).ToList(),
@@ -662,7 +691,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             state.AccountDisabledUserIds ??= new List<string>();
             state.RemoteDisabledUserIds ??= new List<string>();
             state.Message ??= string.Empty;
-            state.Action ??= "disable_accounts";
+            state.Action ??= MaintenanceActions.DisableAccounts;
+            if (!MaintenanceActions.IsSupported(state.Action))
+            {
+                throw new InvalidDataException($"Unknown maintenance action '{state.Action}'.");
+            }
+
+            if (state.Action == MaintenanceActions.None &&
+                (state.AccountDisabledUserIds.Count != 0 || state.RemoteDisabledUserIds.Count != 0))
+            {
+                throw new InvalidDataException("Warning-only maintenance state cannot contain policy recovery records.");
+            }
             if (string.IsNullOrWhiteSpace(state.Phase))
             {
                 state.Phase = state.IsActive ? MaintenancePhases.Active : MaintenancePhases.Inactive;
@@ -761,7 +800,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             {
                 nameof(MaintenanceState.IsActive),
                 nameof(MaintenanceState.Message),
-                nameof(MaintenanceState.Action),
                 nameof(MaintenanceState.StartedAt),
                 nameof(MaintenanceState.EndsAt),
                 nameof(MaintenanceState.AccountDisabledUserIds),
@@ -784,6 +822,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             bool versioned = HasProperty(element, nameof(MaintenanceState.SchemaVersion));
             string[] versionedRequired =
             {
+                nameof(MaintenanceState.Action),
                 nameof(MaintenanceState.Phase),
                 nameof(MaintenanceState.FailureReason),
                 nameof(MaintenanceState.RecoveryAvailable),

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -228,14 +228,14 @@ The remaining controls are administrator-only and act on the whole server at onc
 
 *Admin tab → Maintenance Mode*
 
-Maintenance Mode temporarily locks users out while you work on the server, and shows them a banner explaining why. When you enable it, the selected action is applied to the affected users immediately on save, and a banner appears on the Jellyfin login page. Administrators are **never** affected. Disabling Maintenance Mode restores all affected users automatically.
+Maintenance Mode shows users a banner while you work on the server and can optionally restrict access. When you enable it, the selected actions are applied to affected users immediately on save, and a banner appears on the Jellyfin login page. Administrators are **never** affected. Clearing both actions creates warning-only maintenance: the banner and notification remain available, but no account or remote-access policy changes. Disable active maintenance before changing its action. Disabling Maintenance Mode restores any affected users automatically.
 
 | Setting | Default | What it does |
 |---|---|---|
 | **Enable Maintenance Mode** | Off | Turns Maintenance Mode on. The selected action is applied to affected users as soon as you save. |
 | **Login Page Banner Message** | `This server is currently undergoing maintenance. Please try again.` | Plain-text message shown as a red banner at the top of every page (login and home). |
 | **Active Session Notification** | `Server undergoing maintenance.` | Sent as a native Jellyfin popup to anyone currently watching, reaching all clients (web, mobile, TV apps). |
-| **Action** | Disable user accounts | What happens to affected users. *Disable user accounts* prevents them from logging in at all; *Disable remote connections* blocks connections from outside the local network while LAN access still works. |
+| **Action** | Disable user accounts | What happens to affected users. *Disable user accounts* prevents them from logging in at all; *Disable remote connections* blocks connections from outside the local network while LAN access still works. Clear both actions for warning-only maintenance with no user-policy changes. |
 | **Affected Users** | All non-admin users | Scopes the lockout. Choose *All non-admin users*, or *Select specific users* to pick individual accounts. An empty targeted-user list is treated as all users. |
 
 ### Smart Client Refresh

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -156,6 +156,7 @@
     "e2e/settings-persist.spec.ts › per-user settings persistence › a committed settings write survives response loss and resolves from exact server evidence",
     "e2e/settings-persist.spec.ts › per-user settings persistence › a per-user setting persists across reload (write → persist → reload → re-read)",
     "e2e/settings-persist.spec.ts › per-user settings persistence › a rejected settings write restores exact state and reports typed failure without success",
+    "e2e/settings-persist.spec.ts › per-user settings persistence › clearing both maintenance actions persists and reloads warning-only mode",
     "e2e/settings-persist.spec.ts › per-user settings persistence › the admin config page exposes a control bound to the pause-screen delay default (XCUT-6)",
     "e2e/settings-persist.spec.ts › per-user settings persistence › the pause-screen delay panel input persists across reload",
     "e2e/spoiler-guard.spec.ts › Spoiler Guard › disabling shows the confirm dialog and restores the episode title",

--- a/e2e/settings-persist.spec.ts
+++ b/e2e/settings-persist.spec.ts
@@ -10,6 +10,7 @@ import { test, expect, loginAs, assertNoRuntimeErrors } from './fixtures/auth';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 const CONFIG_HASH = '#/configurationpage?name=Jellyfin%20Canopy';
+const PLUGIN_ID = '9ffa12bc-f4b5-406c-ab1d-d575acbeea7b';
 
 /** Wait for the plugin to re-boot after a reload with settings loaded. */
 async function waitReady(page: any): Promise<void> {
@@ -322,5 +323,161 @@ test.describe('per-user settings persistence', () => {
         expect(serverErrors, 'no 5xx responses on the admin config page').toEqual([]);
         expect(pluginErrors, 'no plugin console errors on the admin config page').toEqual([]);
         expect(plugin4xx, 'no plugin 4xx responses on the admin config page').toEqual([]);
+    });
+
+    test('clearing both maintenance actions persists and reloads warning-only mode', async ({ page, consoleErrors }) => {
+        await loginAs(page, 'admin', consoleErrors);
+        const original = await page.evaluate(
+            async (pluginId) => (window as any).ApiClient.getPluginConfiguration(pluginId),
+            PLUGIN_ID
+        );
+        expect(original, 'plugin configuration must be readable').toBeTruthy();
+        const originalStatus = await page.evaluate(
+            async () => (window as any).ApiClient.ajax({
+                type: 'GET',
+                url: (window as any).ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Status'),
+                dataType: 'json',
+            })
+        );
+        expect(
+            original.MaintenanceModeEnabled,
+            'the disposable fixture must begin outside maintenance mode'
+        ).toBe(false);
+        expect(originalStatus.IsActive, 'the durable maintenance state must begin inactive').toBe(false);
+
+        try {
+            await page.evaluate((hash) => { window.location.hash = hash; }, CONFIG_HASH);
+            await page.waitForSelector('#JellyfinCanopyPage #JellyfinCanopyForm', {
+                state: 'attached',
+                timeout: 60_000,
+            });
+            await page.waitForSelector('.jc-group-btn[data-group="governance"]', { timeout: 60_000 });
+            await page.click('.jc-group-btn[data-group="governance"]');
+            await page.waitForSelector('#mmAction_accounts', { state: 'visible', timeout: 60_000 });
+
+            await page.evaluate(() => {
+                const selections: Array<[string, boolean]> = [
+                    ['maintenanceModeEnabled', true],
+                    ['mmAction_accounts', false],
+                    ['mmAction_remote', false],
+                ];
+                for (const [id, checked] of selections) {
+                    const input = document.getElementById(id) as HTMLInputElement | null;
+                    if (!input) throw new Error(`missing maintenance input #${id}`);
+                    input.checked = checked;
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            });
+            await expect(page.locator('#maintenanceModeEnabled')).toBeChecked();
+            await expect(page.locator('#mmAction_accounts')).not.toBeChecked();
+            await expect(page.locator('#mmAction_remote')).not.toBeChecked();
+            await page.locator('#JellyfinCanopyForm').evaluate((form: HTMLFormElement) => form.requestSubmit());
+
+            const saveButton = page.locator('.jc-save-dock-btn').first();
+            await expect(saveButton).toBeDisabled({ timeout: 10_000 });
+            await expect(saveButton).toBeEnabled({ timeout: 30_000 });
+
+            await expect.poll(
+                () => page.evaluate(
+                    async (pluginId) => {
+                        const config = await (window as any).ApiClient.getPluginConfiguration(pluginId);
+                        return config.MaintenanceModeAction;
+                    },
+                    PLUGIN_ID
+                ),
+                { timeout: 30_000, message: 'both unchecked must persist as explicit none' }
+            ).toBe('none');
+            await expect.poll(
+                () => page.evaluate(
+                    async () => (window as any).ApiClient.ajax({
+                        type: 'GET',
+                        url: (window as any).ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Status'),
+                        dataType: 'json',
+                    })
+                ),
+                { timeout: 30_000, message: 'warning-only must become durable active state' }
+            ).toMatchObject({
+                Phase: 'Active',
+                IsActive: true,
+                Action: 'none',
+                AccountDisabledCount: 0,
+                RemoteDisabledCount: 0,
+            });
+
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await page.evaluate((hash) => { window.location.hash = hash; }, CONFIG_HASH);
+            await page.waitForSelector('#JellyfinCanopyPage #JellyfinCanopyForm', {
+                state: 'attached',
+                timeout: 60_000,
+            });
+            await page.click('.jc-group-btn[data-group="governance"]');
+            await page.waitForSelector('#mmAction_accounts', { state: 'visible', timeout: 60_000 });
+
+            await expect(page.locator('#mmAction_accounts')).not.toBeChecked();
+            await expect(page.locator('#mmAction_remote')).not.toBeChecked();
+            await expect(page.locator('#maintenanceModeEnabled')).toBeChecked();
+        } finally {
+            const cleanupErrors: unknown[] = [];
+            try {
+                await page.evaluate(
+                    async () => (window as any).ApiClient.ajax({
+                        type: 'POST',
+                        url: (window as any).ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Disable'),
+                    })
+                );
+            } catch (error) {
+                cleanupErrors.push(error);
+            }
+            try {
+                await page.evaluate(
+                    async ({ pluginId, config }) =>
+                        (window as any).ApiClient.updatePluginConfiguration(pluginId, config),
+                    { pluginId: PLUGIN_ID, config: original }
+                );
+            } catch (error) {
+                cleanupErrors.push(error);
+            }
+            try {
+                await expect.poll(
+                    () => page.evaluate(
+                        async () => (window as any).ApiClient.ajax({
+                            type: 'GET',
+                            url: (window as any).ApiClient.getUrl('/JellyfinCanopy/MaintenanceMode/Status'),
+                            dataType: 'json',
+                        })
+                    ),
+                    { timeout: 30_000, message: 'maintenance cleanup must restore inactive state' }
+                ).toMatchObject({ Phase: 'Inactive', IsActive: false });
+            } catch (error) {
+                cleanupErrors.push(error);
+            }
+            try {
+                await expect.poll(
+                    () => page.evaluate(
+                        async (pluginId) => (window as any).ApiClient.getPluginConfiguration(pluginId),
+                        PLUGIN_ID
+                    ),
+                    { timeout: 30_000, message: 'maintenance cleanup must restore the exact plugin configuration' }
+                ).toEqual(original);
+            } catch (error) {
+                cleanupErrors.push(error);
+            }
+            if (cleanupErrors.length > 0) {
+                throw new Error(`maintenance cleanup failed (${cleanupErrors.length} error(s)): ${cleanupErrors.map(String).join(' | ')}`);
+            }
+        }
+
+        const DASHBOARD_CHROME =
+            /\/Users\/[^/]+\/Images\/Primary|\/JellyfinCanopy\/BrandingImage/i;
+        expect(consoleErrors.unexpected5xx(), 'no 5xx responses during round-trip').toEqual([]);
+        expect(
+            consoleErrors.real().filter((text) => !DASHBOARD_CHROME.test(text)),
+            'no plugin console errors during round-trip'
+        ).toEqual([]);
+        expect(
+            consoleErrors.unexpected4xx().filter((response) => !DASHBOARD_CHROME.test(response.url)),
+            'no plugin 4xx responses during round-trip'
+        ).toEqual([]);
     });
 });

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2798, totalLines: 3191 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42798, totalLines: 52592 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42806, totalLines: 52615 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2798,
         maximumCoveredLines: 2798,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 7,
-        minimumCoveredLines: 42786,
-        maximumCoveredLines: 42798,
+        cleanRuns: 3,
+        minimumCoveredLines: 42802,
+        maximumCoveredLines: 42806,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 12);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 4);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2798, totalLines: 3191 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42806, totalLines: 52615 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42807, totalLines: 52615 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2798,
         maximumCoveredLines: 2798,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
+        cleanRuns: 4,
         minimumCoveredLines: 42802,
-        maximumCoveredLines: 42806,
+        maximumCoveredLines: 42807,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 4);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2798, totalLines: 3191 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42807, totalLines: 52615 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42809, totalLines: 52615 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
         minimumCoveredLines: 2798,
         maximumCoveredLines: 2798,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 4,
+        cleanRuns: 5,
         minimumCoveredLines: 42802,
-        maximumCoveredLines: 42807,
+        maximumCoveredLines: 42809,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 42807,
+        "coveredLines": 42809,
         "totalLines": 52615
       },
       "observations": {
-        "cleanRuns": 4,
+        "cleanRuns": 5,
         "minimumCoveredLines": 42802,
-        "maximumCoveredLines": 42807
+        "maximumCoveredLines": 42809
       },
       "tolerance": {
-        "missingCoveredLines": 5,
-        "rationale": "The warning-only maintenance-mode change adds explicit action validation, durable none-state handling, structured controller failure handling, and six focused server tests. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-05 against the identical final 52,615-line production source and 4,110-test scope measured 42,802, 42,805 and 42,806 covered lines after every test passed; the first hosted GitHub Actions run on the same commit and scope passed all 4,110 tests and measured 42,807. The reviewed observed high-water is therefore 42,807/52,615 (81.359%) and the exact observed floor is 42,802/52,615 (81.349%); the five-line schedule-dependent instrumentation spread is bounded to 0.010 percentage points. Relative to the prior 42,798/52,592 high-water, the new high-water adds nine covered and twenty-three instrumented lines, so the covered-line high-water does not decrease; the percentage shift reflects the reviewed production scope growth. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 7,
+        "rationale": "The warning-only maintenance-mode change adds explicit action validation, durable none-state handling, structured controller failure handling, and six focused server tests. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-05 against the identical final 52,615-line production source and 4,110-test scope measured 42,802, 42,805 and 42,806 covered lines after every test passed; two hosted GitHub Actions runs on the same source and scope also passed all 4,110 tests and measured 42,807 and 42,809. The reviewed observed high-water is therefore 42,809/52,615 (81.363%) and the exact observed floor is 42,802/52,615 (81.349%); the seven-line schedule-dependent instrumentation spread is bounded to 0.013 percentage points. Relative to the prior 42,798/52,592 high-water, the new high-water adds eleven covered and twenty-three instrumented lines, so the covered-line high-water does not decrease; the percentage shift reflects the reviewed production scope growth. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 42806,
+        "coveredLines": 42807,
         "totalLines": 52615
       },
       "observations": {
-        "cleanRuns": 3,
+        "cleanRuns": 4,
         "minimumCoveredLines": 42802,
-        "maximumCoveredLines": 42806
+        "maximumCoveredLines": 42807
       },
       "tolerance": {
-        "missingCoveredLines": 4,
-        "rationale": "The warning-only maintenance-mode change adds explicit action validation, durable none-state handling, structured controller failure handling, and six focused server tests. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-05 against the identical final 52,615-line production source and 4,110-test scope measured 42,802, 42,805 and 42,806 covered lines after every test passed. The reviewed observed high-water is therefore 42,806/52,615 (81.357%) and the exact observed floor is 42,802/52,615 (81.349%); the four-line schedule-dependent instrumentation spread is bounded to 0.008 percentage points. Relative to the prior 42,798/52,592 high-water, the new high-water adds eight covered and twenty-three instrumented lines, so the covered-line high-water does not decrease; the percentage shift reflects the reviewed production scope growth. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 5,
+        "rationale": "The warning-only maintenance-mode change adds explicit action validation, durable none-state handling, structured controller failure handling, and six focused server tests. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-05 against the identical final 52,615-line production source and 4,110-test scope measured 42,802, 42,805 and 42,806 covered lines after every test passed; the first hosted GitHub Actions run on the same commit and scope passed all 4,110 tests and measured 42,807. The reviewed observed high-water is therefore 42,807/52,615 (81.359%) and the exact observed floor is 42,802/52,615 (81.349%); the five-line schedule-dependent instrumentation spread is bounded to 0.010 percentage points. Relative to the prior 42,798/52,592 high-water, the new high-water adds nine covered and twenty-three instrumented lines, so the covered-line high-water does not decrease; the percentage shift reflects the reviewed production scope growth. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 42798,
-        "totalLines": 52592
+        "coveredLines": 42806,
+        "totalLines": 52615
       },
       "observations": {
-        "cleanRuns": 7,
-        "minimumCoveredLines": 42786,
-        "maximumCoveredLines": 42798
+        "cleanRuns": 3,
+        "minimumCoveredLines": 42802,
+        "maximumCoveredLines": 42806
       },
       "tolerance": {
-        "missingCoveredLines": 12,
-        "rationale": "The modern-layout-only change adds configuration normalization for the retired layout values and ten focused configuration tests. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-04 against the identical final 52,592-line production source and 4,104-test scope measured 42,786, 42,788 and 42,792 covered lines after every test passed; four clean GitHub Actions runs on the same source and scope measured 42,793, 42,795, 42,796 and 42,798 after all 4,104 tests passed. The reviewed observed high-water is therefore 42,798/52,592 (81.377%) and the exact observed floor is 42,786/52,592 (81.355%); the twelve-line schedule-dependent instrumentation spread is bounded to 0.023 percentage points. Relative to the prior 42,783/52,590 floor (81.352%), the new floor adds three covered and two instrumented lines while slightly increasing the enforced percentage. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 4,
+        "rationale": "The warning-only maintenance-mode change adds explicit action validation, durable none-state handling, structured controller failure handling, and six focused server tests. Three clean local .NET 10.0.9 Coverlet runs on 2026-08-05 against the identical final 52,615-line production source and 4,110-test scope measured 42,802, 42,805 and 42,806 covered lines after every test passed. The reviewed observed high-water is therefore 42,806/52,615 (81.357%) and the exact observed floor is 42,802/52,615 (81.349%); the four-line schedule-dependent instrumentation spread is bounded to 0.008 percentage points. Relative to the prior 42,798/52,592 high-water, the new high-water adds eight covered and twenty-three instrumented lines, so the covered-line high-water does not decrease; the percentage shift reflects the reviewed production scope growth. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/maintenance-action-selection.test.js
+++ b/scripts/maintenance-action-selection.test.js
@@ -1,0 +1,181 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(
+    path.join(
+        __dirname,
+        '..',
+        'Jellyfin.Plugin.JellyfinCanopy',
+        'Configuration',
+        'config-page.js'
+    ),
+    'utf8'
+);
+
+function loadFunction(name, parameters) {
+    const match = source.match(
+        new RegExp(`function ${name}\\(${parameters}\\) \\{[\\s\\S]*?\\n        \\}`)
+    );
+    assert.ok(match, `${name} must remain present`);
+    return vm.runInNewContext(`(${match[0]})`);
+}
+
+function loadSaveOwner(context) {
+    const start = source.indexOf('async function persistConfigurationAndMaintenance(config, broadcast)');
+    const end = source.indexOf('async function saveConfig(e)', start);
+    assert.ok(start >= 0 && end > start, 'the shared save owner must remain present');
+    return vm.runInNewContext(`(${source.slice(start, end).trim()})`, context);
+}
+
+test('maintenance action selection preserves all four checkbox states', () => {
+    const decide = loadFunction('maintenanceActionFromSelections', 'accounts, remote');
+
+    assert.equal(decide(true, true), 'both');
+    assert.equal(decide(true, false), 'disable_accounts');
+    assert.equal(decide(false, true), 'disable_remote');
+    assert.equal(decide(false, false), 'none');
+    assert.match(
+        source,
+        /config\.MaintenanceModeAction = maintenanceActionFromSelections\(mmAccounts, mmRemote\);/,
+        'the config save path must use the tested decision function'
+    );
+});
+
+test('maintenance action reload restores exact checkbox state', () => {
+    const selections = loadFunction('maintenanceSelectionsFromAction', 'action');
+
+    assert.deepEqual({ ...selections('both') }, { accounts: true, remote: true });
+    assert.deepEqual({ ...selections('disable_accounts') }, { accounts: true, remote: false });
+    assert.deepEqual({ ...selections('disable_remote') }, { accounts: false, remote: true });
+    assert.deepEqual({ ...selections('none') }, { accounts: false, remote: false });
+    assert.deepEqual(
+        { ...selections(undefined) },
+        { accounts: true, remote: false },
+        'an absent legacy value preserves the historic default'
+    );
+    assert.throws(
+        () => selections('future_action'),
+        /Unknown maintenance action/,
+        'unknown or forward-version values must fail closed instead of rendering as none'
+    );
+    assert.match(
+        source,
+        /savedAction = maintenanceSelectionsFromAction\(config\.MaintenanceModeAction\);/,
+        'the config load path must use the tested reload function'
+    );
+});
+
+test('every full-form save uses the shared fail-safe maintenance save owner', () => {
+    const saveStart = source.indexOf('async function saveConfig(e)');
+    const saveEnd = source.indexOf('// Saves current config and applies it to all users', saveStart);
+    const saveSource = source.slice(saveStart, saveEnd);
+    const resetStart = source.indexOf('async function resetAllUserSettings()');
+    const resetEnd = source.indexOf('// ── Maintenance mode: user checklist', resetStart);
+    const resetSource = source.slice(resetStart, resetEnd);
+
+    assert.match(saveSource, /persistConfigurationAndMaintenance\(config, true\)/);
+    assert.match(resetSource, /persistConfigurationAndMaintenance\(config, false\)/);
+    assert.doesNotMatch(source, /MaintenanceMode\/ApplyConfiguration/);
+});
+
+test('the shared save owner uses safety-directed ordering for enable and disable', async () => {
+    const enabledCalls = [];
+    const enableOwner = loadSaveOwner({
+        pluginId: 'plugin',
+        getMaintenanceStatus: async () => ({ Phase: 'Inactive', IsActive: false, Action: 'disable_accounts' }),
+        enableMaintenanceFromConfig: async () => { enabledCalls.push('enable'); },
+        ApiClient: {
+            updatePluginConfiguration: async () => { enabledCalls.push('configuration'); return 'saved'; },
+            ajax: async () => { enabledCalls.push('unexpected-ajax'); },
+            getUrl: value => value
+        }
+    });
+    const enabledResult = await enableOwner({
+        MaintenanceModeEnabled: true,
+        MaintenanceModeAction: 'none'
+    }, false);
+    assert.equal(enabledResult, 'saved');
+    assert.deepEqual(enabledCalls, ['configuration', 'enable']);
+
+    const disabledCalls = [];
+    const disableOwner = loadSaveOwner({
+        pluginId: 'plugin',
+        getMaintenanceStatus: async () => ({ Phase: 'Active', IsActive: true, Action: 'none' }),
+        enableMaintenanceFromConfig: async () => { disabledCalls.push('unexpected-enable'); },
+        ApiClient: {
+            updatePluginConfiguration: async () => { disabledCalls.push('configuration'); return 'saved'; },
+            ajax: async options => { disabledCalls.push(options.url.endsWith('/Disable') ? 'disable' : 'unexpected-ajax'); },
+            getUrl: value => value
+        }
+    });
+    const disabledResult = await disableOwner({
+        MaintenanceModeEnabled: false,
+        MaintenanceModeAction: 'none'
+    }, false);
+    assert.equal(disabledResult, 'saved');
+    assert.deepEqual(disabledCalls, ['disable', 'configuration']);
+});
+
+test('the shared save owner fails safe without client-side compensation', async () => {
+    const enableCalls = [];
+    const responseLossOwner = loadSaveOwner({
+        pluginId: 'plugin',
+        getMaintenanceStatus: async () => ({ Phase: 'Inactive', IsActive: false, Action: 'disable_accounts' }),
+        enableMaintenanceFromConfig: async () => { enableCalls.push('enable'); },
+        ApiClient: {
+            updatePluginConfiguration: async () => {
+                enableCalls.push('configuration-attempt');
+                throw new Error('response lost');
+            },
+            ajax: async () => {},
+            getUrl: value => value
+        }
+    });
+    await assert.rejects(
+        () => responseLossOwner({ MaintenanceModeEnabled: true, MaintenanceModeAction: 'none' }, false),
+        /response lost/
+    );
+    assert.deepEqual(enableCalls, ['configuration-attempt'], 'a failed/ambiguous config request must not authorize a restriction');
+
+    const disableCalls = [];
+    const recoveryFailureOwner = loadSaveOwner({
+        pluginId: 'plugin',
+        getMaintenanceStatus: async () => ({ Phase: 'Active', IsActive: true, Action: 'none' }),
+        enableMaintenanceFromConfig: async () => {},
+        ApiClient: {
+            updatePluginConfiguration: async () => { disableCalls.push('configuration'); },
+            ajax: async () => {
+                disableCalls.push('disable-attempt');
+                throw new Error('recovery failed');
+            },
+            getUrl: value => value
+        }
+    });
+    await assert.rejects(
+        () => recoveryFailureOwner({ MaintenanceModeEnabled: false, MaintenanceModeAction: 'none' }, false),
+        /recovery failed/
+    );
+    assert.deepEqual(disableCalls, ['disable-attempt'], 'failed recovery must not remove the persisted warning intent');
+});
+
+test('the shared save owner rejects active action changes before any write', async () => {
+    const calls = [];
+    const owner = loadSaveOwner({
+        pluginId: 'plugin',
+        getMaintenanceStatus: async () => ({ Phase: 'Active', IsActive: true, Action: 'disable_accounts' }),
+        enableMaintenanceFromConfig: async () => { calls.push('enable'); },
+        ApiClient: {
+            updatePluginConfiguration: async () => { calls.push('configuration'); },
+            ajax: async () => { calls.push('ajax'); },
+            getUrl: value => value
+        }
+    });
+    await assert.rejects(
+        () => owner({ MaintenanceModeEnabled: true, MaintenanceModeAction: 'none' }, false),
+        /Disable active maintenance before changing its action/
+    );
+    assert.deepEqual(calls, []);
+});


### PR DESCRIPTION
## Description

Fixes maintenance-mode configuration so administrators can enable warning/countdown behavior without applying account or remote-access restrictions. The previous configuration conflated an empty restriction selection with the legacy default, causing warning-only maintenance to disable user accounts.

Closes #679.

## Implementation

- Adds an explicit `none` maintenance action alongside `disable_accounts`, `disable_remote`, and `both`.
- Preserves the legacy missing-value default while rejecting unknown action values.
- Persists active `none` state with empty ledgers and skips user enumeration and account-policy writes.
- Makes configuration saves safety-directed: enabling commits config before restrictions; disabling restores access before committing the disabled config.
- Rejects unsafe action changes while maintenance is active and exposes structured validation errors to the admin page.
- Adds four-state admin UI mapping, server state-machine/controller coverage, focused client save-order tests, and a real Jellyfin 12 browser round-trip.

## User impact and compatibility

Administrators can now select **No access restrictions** and retain maintenance announcements/countdowns without locking out users. Existing installations with no stored action keep the historical `disable_accounts` default. This remains compatible with the supported Jellyfin 12 modern React/MUI layout; unsupported classic-layout selections leave Jellyfin usable without starting Canopy client features.

## Security and performance

- No authentication, authorization, secret, provider, or upstream-network behavior changes.
- The `none` path avoids enumerating users or mutating policies.
- No generated client-distribution drift; the deterministic bundle remains byte-identical.
- `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages in the solution.

## Testing

- 4,110/4,110 server tests passed.
- Server coverage high-water: 42,809/52,615 lines across five clean identical-scope runs (42,802, 42,805, 42,806, 42,807, 42,809); tolerance is seven lines.
- 2,038/2,038 client tests passed; core coverage remains 2,798/3,191 (87.684%).
- 167/167 required Jellyfin 12 Playwright tests passed with zero skips, including the new exact persistence/status/cleanup round-trip.
- 655/655 script tests and 6/6 focused maintenance action-selection tests passed.
- Type checks, syntax checks, performance guards, deterministic bundle build, translations, docs, provider conformance, Release build, and diff checks passed.
- ESLint completed with zero errors; existing warnings remain within the repository's advisory cap.

No screenshot is included because this adds one native select option without changing the page layout; the real-browser test exercises the rendered control and actual form submission.

## AI assistance

This PR was developed with AI assistance. I reviewed and tested the changes and understand the implementation.

