### PR TITLE
fix(seerr): honor requestable Specials in Request More

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/item-details-specials.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/item-details-specials.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+
+describe('series details Request More lifecycle for Specials', () => {
+    let installSeerrItemDetails: () => () => void;
+    let resetDetailsViewTrackingForTests: () => void;
+    let uninstall: (() => void) | null = null;
+    let resolver: ReturnType<typeof vi.fn>;
+    let getItemCached: ReturnType<typeof vi.fn>;
+    let fetchTvShowDetails: ReturnType<typeof vi.fn>;
+    let onViewPage: ReturnType<typeof vi.fn>;
+    let originalNavigation: typeof JC.core.navigation;
+    let originalHelpers: typeof JC.helpers;
+
+    beforeAll(async () => {
+        originalNavigation = JC.core.navigation;
+        originalHelpers = JC.helpers;
+        ({ resetDetailsViewTrackingForTests } = await import('../core/details-view'));
+        ({ installSeerrItemDetails } = await import('./item-details'));
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.replaceChildren();
+        document.getElementById('jc-series-request-more-styles')?.remove();
+        window.history.replaceState(null, '', '/#/details?id=series-674');
+        resetDetailsViewTrackingForTests();
+
+        const page = document.createElement('div');
+        page.id = 'itemDetailPage';
+        page.innerHTML = `
+            <div id="listChildrenCollapsible">
+                <h2 class="sectionTitle sectionTitle-cards"><span>Seasons</span></h2>
+            </div>
+            <div id="similarCollapsible"></div>`;
+        document.body.appendChild(page);
+        page.dispatchEvent(new CustomEvent('viewshow', { bubbles: true }));
+
+        JC.identity.transition(
+            'specials-details-server',
+            `specials-details-user-${Math.random()}`,
+            'test setup',
+        );
+        JC.t = (key: string) => key;
+        JC.pluginConfig = {
+            SeerrEnabled: true,
+            SeerrShowRequestMoreOnSeries: true,
+            SeerrShowSimilar: false,
+            SeerrShowRecommended: false,
+        };
+
+        getItemCached = vi.fn().mockResolvedValue({
+            Type: 'Series',
+            Name: 'Specials fixture',
+            ProviderIds: { Tmdb: '674' },
+        });
+        JC.helpers = {
+            ...(originalHelpers || {}),
+            getItemCached,
+        } as NonNullable<typeof JC.helpers>;
+
+        fetchTvShowDetails = vi.fn().mockResolvedValue({
+            id: 674,
+            name: 'Specials fixture',
+            seasons: [{ seasonNumber: 0, episodeCount: 3 }],
+            mediaInfo: {
+                status: 5,
+                seasons: [{ seasonNumber: 0, status: 1 }],
+                requests: [],
+            },
+        });
+        JC.seerrAPI = {
+            checkUserStatus: vi.fn().mockResolvedValue({ active: true, userFound: true }),
+            fetchTvShowDetails,
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+        resolver = vi.fn();
+        JC.seerrMoreInfo = {
+            resolveUnrequestedSeasons: resolver,
+        } as NonNullable<typeof JC.seerrMoreInfo>;
+        JC.seerrUI = { showSeasonSelectionModal: vi.fn() };
+        onViewPage = vi.fn(() => () => undefined);
+        JC.core.navigation = {
+            onNavigate: vi.fn(() => () => undefined),
+            onViewPage,
+        } as unknown as NonNullable<typeof JC.core.navigation>;
+    });
+
+    afterEach(() => {
+        uninstall?.();
+        uninstall = null;
+        JC.core.navigation = originalNavigation;
+        JC.helpers = originalHelpers;
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        window.history.replaceState(null, '', '/');
+    });
+
+    async function flushRenderFrame(): Promise<void> {
+        await vi.advanceTimersByTimeAsync(20);
+        for (let index = 0; index < 8; index += 1) await Promise.resolve();
+    }
+
+    it('does not memoize an indeterminate result and renders after a bounded retry', async () => {
+        resolver
+            .mockResolvedValueOnce({ hasUnrequestedSeasons: false, definitive: false })
+            .mockResolvedValueOnce({ hasUnrequestedSeasons: true, definitive: true });
+
+        uninstall = installSeerrItemDetails();
+        await flushRenderFrame();
+
+        expect(resolver).toHaveBeenCalledOnce();
+        expect(document.querySelector('.jc-series-request-more-btn')).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(1_900);
+        expect(resolver).toHaveBeenCalledOnce();
+        await vi.advanceTimersByTimeAsync(100);
+        for (let index = 0; index < 8; index += 1) await Promise.resolve();
+
+        expect(resolver).toHaveBeenCalledTimes(2);
+        expect(getItemCached).toHaveBeenCalledTimes(2);
+        expect(fetchTvShowDetails).toHaveBeenCalledTimes(2);
+        expect(document.querySelector('.jc-series-request-more-btn')).not.toBeNull();
+    });
+
+    it('cancels an indeterminate retry when the details feature is uninstalled', async () => {
+        resolver.mockResolvedValue({ hasUnrequestedSeasons: false, definitive: false });
+
+        uninstall = installSeerrItemDetails();
+        await flushRenderFrame();
+        expect(resolver).toHaveBeenCalledOnce();
+
+        uninstall();
+        uninstall = null;
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        expect(resolver).toHaveBeenCalledOnce();
+        expect(document.querySelector('.jc-series-request-more-btn')).toBeNull();
+    });
+
+    it('memoizes a definitive negative for the current page identity', async () => {
+        resolver.mockResolvedValue({ hasUnrequestedSeasons: false, definitive: true });
+
+        uninstall = installSeerrItemDetails();
+        await flushRenderFrame();
+        expect(resolver).toHaveBeenCalledOnce();
+
+        const viewCallback = onViewPage.mock.calls[0]?.[0] as (() => void) | undefined;
+        expect(viewCallback).toBeTypeOf('function');
+        viewCallback!();
+        await flushRenderFrame();
+
+        expect(resolver).toHaveBeenCalledOnce();
+        expect(document.querySelector('.jc-series-request-more-btn')).toBeNull();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/item-details.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/item-details.ts
@@ -15,6 +15,8 @@ const requestMoreLogPrefix = '🪼 Jellyfin Canopy: Series Request More:';
 // Track processed items to avoid duplicate renders
 const processedItems = new Set();
 const processedRequestMoreItems = new Set();
+const requestMoreRetryTimers = new Set<number>();
+const REQUEST_MORE_RETRY_DELAYS_MS = [2_000, 5_000, 10_000] as const;
 
 // CSS class used to mark and dedupe the injected Request More button
 const REQUEST_MORE_BTN_CLASS = 'jc-series-request-more-btn';
@@ -568,7 +570,7 @@ function waitForSeasonsHeading(itemId: string, signal?: AbortSignal): Promise<an
 }
 
 /**
- * Waits for `JC.seerrMoreInfo.checkForUnrequestedSeasons` to become
+ * Waits for `JC.seerrMoreInfo.resolveUnrequestedSeasons` to become
  * available. The Seerr modules are loaded in parallel by plugin.js
  * via dynamically-inserted <script> tags, so on a cold page load
  * item-details.js may execute before more-info-modal.js has finished
@@ -580,13 +582,29 @@ function waitForSeasonsHeading(itemId: string, signal?: AbortSignal): Promise<an
 function waitForChecker(signal?: AbortSignal): Promise<any> {
     return pollUntil(
         () => {
-            const fn = JC.seerrMoreInfo && JC.seerrMoreInfo.checkForUnrequestedSeasons;
+            const fn = JC.seerrMoreInfo && JC.seerrMoreInfo.resolveUnrequestedSeasons;
             return typeof fn === 'function' ? fn : null;
         },
         // PERF(R9): on a slow connection the module scripts themselves load
         // slowly — 3s lost the button for the page view. Decayed poll + nav abort.
         { intervalMs: 50, maxIntervalMs: 500, timeoutMs: 30_000, signal }
     );
+}
+
+/**
+ * Retry an indeterminate Specials capability without turning a transient
+ * settings failure into a page-lifetime negative. The finite backoff is owned
+ * by the current details navigation and cleanup() cancels it synchronously.
+ */
+function scheduleRequestMoreRetry(itemId: string, attempt: number): void {
+    const delay = REQUEST_MORE_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) return;
+    const timer = window.setTimeout(() => {
+        requestMoreRetryTimers.delete(timer);
+        if (getItemIdFromUrl() !== itemId) return;
+        void renderSeriesRequestMoreButton(itemId, attempt + 1);
+    }, delay);
+    requestMoreRetryTimers.add(timer);
 }
 
 /**
@@ -649,11 +667,11 @@ function buildSeriesRequestMoreButton(tvDetails: any, context: IdentityContext):
 /**
  * Renders a "Request More" button next to the Seasons section heading on
  * a Series detail page when the show has unrequested seasons in Seerr.
- * Reuses checkForUnrequestedSeasons from more-info-modal.js so the
+ * Reuses resolveUnrequestedSeasons from the More Info owner so the
  * detection logic stays in one place.
  * @param {string} itemId - Jellyfin item ID
  */
-async function renderSeriesRequestMoreButton(itemId: string) {
+async function renderSeriesRequestMoreButton(itemId: string, retryAttempt = 0) {
     const context = JC.identity.capture();
     if (!context) return;
     if (processedRequestMoreItems.has(itemId)) return;
@@ -708,16 +726,24 @@ async function renderSeriesRequestMoreButton(itemId: string) {
         const checker = await waitForChecker(signal);
         if (!isCurrent(context, signal)) return;
         if (!checker) {
-            console.warn(`${requestMoreLogPrefix} checkForUnrequestedSeasons unavailable after 3s, skipping`);
+            console.warn(`${requestMoreLogPrefix} Request More resolver unavailable after 30s, skipping`);
             return;
         }
-        const hasUnrequested = await checker(tvDetails);
+        const resolution = await checker(tvDetails);
         if (!isCurrent(context, signal)) return;
-        if (!hasUnrequested) {
-            // Dedupe negative results too. Each call to checker() runs an
-            // HTTP request to /JellyfinCanopy/seerr/request, so we
-            // don't want to repeat it on every viewshow for the same item.
-            // cleanup() clears this set on real navigation.
+        if (!resolution
+            || typeof resolution.hasUnrequestedSeasons !== 'boolean'
+            || typeof resolution.definitive !== 'boolean') {
+            throw new TypeError('Request More resolver returned an invalid result.');
+        }
+        if (!resolution.definitive) {
+            scheduleRequestMoreRetry(itemId, retryAttempt);
+            console.debug(`${requestMoreLogPrefix} Request settings unavailable; retrying for "${tvDetails.name || tvDetails.title}"`);
+            return;
+        }
+        if (!resolution.hasUnrequestedSeasons) {
+            // Definitive negatives are safe to memoize for this page identity.
+            // Indeterminate settings failures take the bounded retry path above.
             processedRequestMoreItems.add(itemId);
             console.debug(`${requestMoreLogPrefix} No unrequested seasons for "${tvDetails.name || tvDetails.title}"`);
             return;
@@ -790,6 +816,8 @@ function handleItemDetailsPage() {
 function cleanup() {
     for (const frame of pendingFrames) cancelAnimationFrame(frame);
     pendingFrames.clear();
+    for (const timer of requestMoreRetryTimers) clearTimeout(timer);
+    requestMoreRetryTimers.clear();
     // Abort any in-flight requests
     if (currentAbortController) {
         currentAbortController.abort();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions-specials.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions-specials.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import { internal } from './internal';
+
+describe('More Info TV actions for Specials-only follow-up requests', () => {
+    let actionMount: HTMLElement;
+    let resolveUnrequestedSeasons: ReturnType<typeof vi.fn>;
+    let buildTvRequestMoreButton: ReturnType<typeof vi.fn>;
+    let buildTvActions: ReturnType<typeof vi.fn>;
+
+    beforeAll(async () => {
+        JC.t = (key: string) => key;
+        JC.escapeHtml = (value: unknown) => String(value);
+        JC.pluginConfig = {};
+        const { installSeerrStatus } = await import('../seerr-status');
+        installSeerrStatus();
+        await import('./actions');
+    });
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.replaceChildren();
+        const identity = JC.identity.transition(
+            'specials-actions-server',
+            `specials-actions-user-${Math.random()}`,
+            'test setup',
+        );
+        const modal = Object.assign(document.createElement('div'), {
+            _actionCleanups: new Set<() => void>(),
+        });
+        modal.innerHTML = `
+            <div data-mount="jc-actions"></div>
+            <div data-mount="jc-status-chip"></div>
+            <div data-mount="jc-downloads"></div>`;
+        JC.identity.own(modal, identity);
+        document.body.appendChild(modal);
+        internal.state.identity = identity;
+        internal.state.currentModal = modal;
+        actionMount = modal.querySelector('[data-mount="jc-actions"]')!;
+
+        resolveUnrequestedSeasons = vi.fn();
+        buildTvRequestMoreButton = vi.fn(() => {
+            const button = document.createElement('button');
+            button.className = 'request-more-fixture';
+            return button;
+        });
+        buildTvActions = vi.fn(() => {
+            const button = document.createElement('button');
+            button.className = 'whole-show-fixture';
+            return button;
+        });
+        internal.resolveUnrequestedSeasons = resolveUnrequestedSeasons;
+        internal.buildTvRequestMoreButton = buildTvRequestMoreButton;
+        internal.buildTvActions = buildTvActions;
+        internal.buildSingleTv4kButton = vi.fn(() => null);
+        internal.buildStatusChip = vi.fn(() => null);
+        internal.buildDownloadBars = vi.fn(() => null);
+        JC.seerrAPI = {
+            canRequest4k: () => false,
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+        JC.seerrUI = {};
+    });
+
+    afterEach(() => {
+        const modal = internal.state.currentModal as (HTMLElement & {
+            _actionCleanups?: Set<() => void>;
+        }) | null;
+        for (const cleanup of modal?._actionCleanups || []) cleanup();
+        internal.state.currentModal = null;
+        internal.state.identity = null;
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    const specialsOnlyData = {
+        id: 674,
+        name: 'Specials fixture',
+        seasons: [{ seasonNumber: 0, episodeCount: 3 }],
+        mediaInfo: { status: 5, status4k: 1 },
+    };
+
+    async function renderAndSettle(data: unknown = specialsOnlyData): Promise<void> {
+        internal.renderActions(data, 'tv');
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    it('renders Request More when enabled Specials are the only unrequested season', async () => {
+        resolveUnrequestedSeasons.mockResolvedValue({
+            hasUnrequestedSeasons: true,
+            definitive: true,
+        });
+
+        await renderAndSettle();
+
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledWith(specialsOnlyData);
+        expect(buildTvRequestMoreButton).toHaveBeenCalledOnce();
+        expect(actionMount.querySelector('.request-more-fixture')).not.toBeNull();
+        expect(buildTvActions).not.toHaveBeenCalled();
+    });
+
+    it('does not publish a normal request when Specials are disabled', async () => {
+        resolveUnrequestedSeasons.mockResolvedValue({
+            hasUnrequestedSeasons: false,
+            definitive: true,
+        });
+
+        await renderAndSettle();
+
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledOnce();
+        expect(actionMount.children).toHaveLength(0);
+        expect(buildTvRequestMoreButton).not.toHaveBeenCalled();
+        expect(buildTvActions).not.toHaveBeenCalled();
+    });
+
+    it('routes deleted parent status through the capability resolver', async () => {
+        resolveUnrequestedSeasons.mockResolvedValue({
+            hasUnrequestedSeasons: false,
+            definitive: true,
+        });
+
+        await renderAndSettle({
+            ...specialsOnlyData,
+            mediaInfo: { status: 7, status4k: 1 },
+        });
+
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledOnce();
+        expect(buildTvRequestMoreButton).not.toHaveBeenCalled();
+        expect(actionMount.children).toHaveLength(0);
+    });
+
+    it('retries an indeterminate capability and renders only after it becomes definitive', async () => {
+        resolveUnrequestedSeasons
+            .mockResolvedValueOnce({ hasUnrequestedSeasons: false, definitive: false })
+            .mockResolvedValueOnce({ hasUnrequestedSeasons: true, definitive: true });
+
+        await renderAndSettle();
+        expect(actionMount.children).toHaveLength(0);
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(1_999);
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledOnce();
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledTimes(2);
+        expect(actionMount.querySelector('.request-more-fixture')).not.toBeNull();
+        expect(internal.state.currentModal?._actionCleanups?.size).toBe(0);
+    });
+
+    it('cancels a pending retry when the modal action lifecycle is cleaned up', async () => {
+        resolveUnrequestedSeasons.mockResolvedValue({
+            hasUnrequestedSeasons: false,
+            definitive: false,
+        });
+
+        await renderAndSettle();
+        const cleanups = internal.state.currentModal?._actionCleanups;
+        expect(cleanups?.size).toBe(1);
+        for (const cleanup of cleanups || []) cleanup();
+        cleanups?.clear();
+
+        await vi.advanceTimersByTimeAsync(20_000);
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledOnce();
+        expect(actionMount.children).toHaveLength(0);
+    });
+
+    it('discards an older resolver result after the same modal mount is refreshed', async () => {
+        let resolveOlder!: (value: unknown) => void;
+        let resolveNewer!: (value: unknown) => void;
+        const older = new Promise((resolve) => { resolveOlder = resolve; });
+        const newer = new Promise((resolve) => { resolveNewer = resolve; });
+        resolveUnrequestedSeasons
+            .mockReturnValueOnce(older)
+            .mockReturnValueOnce(newer);
+
+        internal.renderActions(specialsOnlyData, 'tv');
+        internal.renderActions({ ...specialsOnlyData, name: 'Refreshed fixture' }, 'tv');
+        expect(resolveUnrequestedSeasons).toHaveBeenCalledTimes(2);
+
+        resolveNewer({ hasUnrequestedSeasons: false, definitive: true });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(actionMount.children).toHaveLength(0);
+
+        resolveOlder({ hasUnrequestedSeasons: true, definitive: true });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(buildTvRequestMoreButton).not.toHaveBeenCalled();
+        expect(actionMount.children).toHaveLength(0);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/actions.ts
@@ -52,6 +52,73 @@ function scheduleModalFrame(callback: () => void): void {
     cleanups?.add(cancel);
 }
 
+const TV_REQUESTABILITY_RETRY_DELAYS_MS = [2_000, 5_000, 10_000] as const;
+let tvActionRenderToken = 0;
+
+function isCurrentTvActionRender(actionMount: HTMLElement, renderToken: number): boolean {
+    return isLiveNode(actionMount)
+        && actionMount.dataset.tvActionRenderToken === String(renderToken);
+}
+
+/**
+ * Resolve and render TV follow-up actions. An unavailable Specials capability
+ * fails closed for the current paint and retries with bounded modal-owned
+ * backoff; it never becomes a permanent negative or outlives the modal.
+ */
+function renderTvFollowUpActions(
+    data: any,
+    actionMount: HTMLElement,
+    show4kTv: boolean,
+    canRequest4k: boolean,
+    renderToken: number,
+    attempt = 0,
+): void {
+    void internal.resolveUnrequestedSeasons(data).then((resolution: any) => {
+        if (!isCurrentTvActionRender(actionMount, renderToken)) return;
+        const validResolution = resolution
+            && typeof resolution.hasUnrequestedSeasons === 'boolean'
+            && typeof resolution.definitive === 'boolean';
+        if (!validResolution || !resolution.definitive) {
+            const delay = TV_REQUESTABILITY_RETRY_DELAYS_MS[attempt];
+            if (delay === undefined) return;
+            const timer = window.setTimeout(() => {
+                cleanup();
+                state.currentModal?._actionCleanups?.delete(cleanup);
+                if (isCurrentTvActionRender(actionMount, renderToken)) {
+                    renderTvFollowUpActions(
+                        data,
+                        actionMount,
+                        show4kTv,
+                        canRequest4k,
+                        renderToken,
+                        attempt + 1,
+                    );
+                }
+            }, delay);
+            const cleanup = () => clearTimeout(timer);
+            trackModalCleanup(cleanup);
+            return;
+        }
+
+        if (resolution.hasUnrequestedSeasons) {
+            const requestMoreButton = internal.buildTvRequestMoreButton(data, show4kTv, canRequest4k);
+            if (requestMoreButton) actionMount.appendChild(requestMoreButton);
+            void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
+            return;
+        }
+
+        if (show4kTv && canRequest4k) {
+            const followUp4k = internal.buildSingleTv4kButton(data);
+            if (followUp4k) actionMount.appendChild(followUp4k);
+            void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
+        }
+    }).catch((error: unknown) => {
+        if (isCurrentTvActionRender(actionMount, renderToken)) {
+            console.warn(`${logPrefix} TV Request More resolution failed:`, error);
+        }
+    });
+}
+
 function buildSingle4kButton(data: any) {
 const button = document.createElement('button');
 ownControl(button);
@@ -350,7 +417,11 @@ state.currentModal._actionCleanups?.clear?.();
 const actionMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-actions"]');
 const chipMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-status-chip"]');
 const downloadsMount = state.currentModal.querySelector<HTMLElement>('[data-mount="jc-downloads"]');
-if (actionMount) actionMount.innerHTML = '';
+const actionRenderToken = ++tvActionRenderToken;
+if (actionMount) {
+    actionMount.innerHTML = '';
+    actionMount.dataset.tvActionRenderToken = String(actionRenderToken);
+}
 if (chipMount) chipMount.innerHTML = '';
 if (downloadsMount) downloadsMount.innerHTML = '';
 
@@ -468,42 +539,21 @@ if (mediaType === 'movie') {
 
     const canRequestNormal = JC.seerrStatus!.isRequestable(effectiveStatus);
     const canRequest4k = JC.seerrStatus!.isRequestable(effectiveStatus4k);
-    if (canRequestNormal) {
+    const hasRegularEpisodes = Array.isArray(data.seasons)
+        && data.seasons.some((season: any) => Number.isInteger(season?.seasonNumber)
+            && season.seasonNumber > 0
+            && Number.isInteger(season?.episodeCount)
+            && season.episodeCount > 0);
+    if (canRequestNormal && hasRegularEpisodes) {
         const actions = internal.buildTvActions(data, show4kTv);
         if (actions && actionMount) actionMount.appendChild(actions);
         void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
         return;
     }
 
-    const hasStatus = hasNormalStatus || has4kStatus;
-    const hasDeletedStatus = effectiveStatus === 7 || effectiveStatus4k === 7;
-
-    // Check if there are unrequested seasons
-    if (hasStatus) {
-        if (hasDeletedStatus && actionMount) {
-            const requestMoreButton = internal.buildTvRequestMoreButton(data, show4kTv, canRequest4k);
-            if (requestMoreButton) actionMount.appendChild(requestMoreButton);
-            void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
-            return;
-        }
-        void internal.checkForUnrequestedSeasons(data).then((hasUnrequestedSeasons: any) => {
-            if (!isLiveNode(actionMount)) return;
-            if (hasUnrequestedSeasons && actionMount) {
-                const requestMoreButton = internal.buildTvRequestMoreButton(data, show4kTv, canRequest4k);
-                if (requestMoreButton) actionMount.appendChild(requestMoreButton);
-                void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
-            } else if (show4kTv && canRequest4k && actionMount) {
-                const followUp4k = internal.buildSingleTv4kButton(data);
-                if (followUp4k) actionMount.appendChild(followUp4k);
-                void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
-            }
-        });
-        return;
+    if (actionMount) {
+        renderTvFollowUpActions(data, actionMount, show4kTv, canRequest4k, actionRenderToken);
     }
-
-    const actions = internal.buildTvActions(data);
-    if (actions && actionMount) actionMount.appendChild(actions);
-    void maybeRenderMoreInfoQuotaChip(actionMount, 'tv');
 }
 }
 internal.buildSingle4kButton = buildSingle4kButton;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/init.ts
@@ -4,6 +4,7 @@
 import { JC } from '../../globals';
 import { installModalA11y, type ModalA11yHandle } from '../../core/modal-a11y';
 import type { IdentityContext } from '../../types/jc';
+import type { UnrequestedSeasonsResolution } from './seasons';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 /* eslint-disable @typescript-eslint/no-misused-promises -- legacy async event listeners with fire-and-forget bodies; semantics preserved verbatim */
@@ -23,6 +24,7 @@ interface MoreInfoModalApi {
     open: (tmdbId: any, mediaType: any) => Promise<void>;
     close: (immediate?: boolean) => void;
     checkForUnrequestedSeasons?: (data: any) => Promise<boolean>;
+    resolveUnrequestedSeasons?: (data: any) => Promise<UnrequestedSeasonsResolution>;
 }
 
 const moreInfoModal = {} as MoreInfoModalApi;
@@ -347,3 +349,4 @@ export function installSeerrMoreInfo(): () => void {
 // Series page "Request More" button) so the unrequested-seasons check
 // logic does not need to be duplicated.
 moreInfoModal.checkForUnrequestedSeasons = internal.checkForUnrequestedSeasons;
+moreInfoModal.resolveUnrequestedSeasons = internal.resolveUnrequestedSeasons;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/seasons-pagination.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/seasons-pagination.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
 
 describe('more-info unrequested-season per-title request state', () => {
     let ajax: ReturnType<typeof vi.fn>;
     let checkForUnrequestedSeasons: (data: unknown) => Promise<boolean>;
+    let resolveUnrequestedSeasons: (data: unknown) => Promise<{
+        hasUnrequestedSeasons: boolean;
+        definitive: boolean;
+    }>;
+    let fetchRequestSettings: ReturnType<typeof vi.fn>;
     let buildSeasonAvailabilityLinks: (seasonInfo: unknown, normalId?: string | null, fourKId?: string | null) => string;
     let getSeasonStatusInfo: (data: unknown, seasonNumber: unknown) => any;
     let fetchJellyfinSeasonMap: (seriesId: unknown) => Promise<Record<number, any>>;
@@ -15,12 +21,23 @@ describe('more-info unrequested-season per-title request state', () => {
         client.ajax = ajax;
         client.getUrl = (path: string) => `http://jellyfin.test${path}`;
         client.getCurrentUserId = () => 'test-user-id';
+        fetchRequestSettings = vi.fn().mockResolvedValue({
+            available: true,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: false,
+            stale: false,
+        });
+        JC.seerrAPI = {
+            ...(JC.seerrAPI || {}),
+            fetchRequestSettings,
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
 
         const { installSeerrStatus } = await import('../seerr-status');
         installSeerrStatus();
         const { internal } = await import('./internal');
         await import('./seasons');
         checkForUnrequestedSeasons = internal.checkForUnrequestedSeasons as typeof checkForUnrequestedSeasons;
+        resolveUnrequestedSeasons = internal.resolveUnrequestedSeasons as typeof resolveUnrequestedSeasons;
         buildSeasonAvailabilityLinks = internal.buildSeasonAvailabilityLinks as typeof buildSeasonAvailabilityLinks;
         getSeasonStatusInfo = internal.getSeasonStatusInfo as typeof getSeasonStatusInfo;
         fetchJellyfinSeasonMap = internal.fetchJellyfinSeasonMap as typeof fetchJellyfinSeasonMap;
@@ -109,6 +126,142 @@ describe('more-info unrequested-season per-title request state', () => {
             },
         })).resolves.toBe(true);
         expect(ajax).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            name: 'fresh enabled settings',
+            settings: { available: true, partialRequestsEnabled: true, enableSpecialEpisodes: true, stale: false },
+            expected: true,
+        },
+        {
+            name: 'exact-generation stale enabled settings',
+            settings: { available: true, partialRequestsEnabled: true, enableSpecialEpisodes: true, stale: true },
+            expected: true,
+        },
+        {
+            name: 'Specials disabled',
+            settings: { available: true, partialRequestsEnabled: true, enableSpecialEpisodes: false, stale: false },
+            expected: false,
+        },
+        {
+            name: 'partial requests disabled',
+            settings: { available: true, partialRequestsEnabled: false, enableSpecialEpisodes: true, stale: false },
+            expected: false,
+        },
+    ])('resolves requestable Specials with $name', async ({ settings, expected }) => {
+        fetchRequestSettings.mockResolvedValue(settings);
+
+        await expect(resolveUnrequestedSeasons({
+            id: 42,
+            seasons: [
+                { seasonNumber: 0, episodeCount: 3 },
+                { seasonNumber: 1, episodeCount: 8 },
+            ],
+            mediaInfo: {
+                requests: [],
+                seasons: [
+                    { seasonNumber: 0, status: 1 },
+                    { seasonNumber: 1, status: 5 },
+                ],
+                jellyfinMediaId: 'series-id',
+            },
+        })).resolves.toEqual({ hasUnrequestedSeasons: expected, definitive: true });
+        expect(fetchRequestSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not suppress a requestable regular season when settings are unavailable', async () => {
+        fetchRequestSettings.mockResolvedValue({ available: false });
+
+        await expect(resolveUnrequestedSeasons({
+            id: 42,
+            seasons: [
+                { seasonNumber: 0, episodeCount: 3 },
+                { seasonNumber: 1, episodeCount: 8 },
+            ],
+            mediaInfo: {
+                requests: [],
+                seasons: [
+                    { seasonNumber: 0, status: 1 },
+                    { seasonNumber: 1, status: 7 },
+                ],
+            },
+        })).resolves.toEqual({ hasUnrequestedSeasons: true, definitive: true });
+        expect(fetchRequestSettings).not.toHaveBeenCalled();
+    });
+
+    it('leaves a Specials-only decision indeterminate when settings are unavailable', async () => {
+        fetchRequestSettings.mockResolvedValue({ available: false });
+
+        await expect(resolveUnrequestedSeasons({
+            id: 42,
+            seasons: [{ seasonNumber: 0, episodeCount: 3 }],
+            mediaInfo: {
+                requests: [],
+                seasons: [{ seasonNumber: 0, status: 1 }],
+            },
+        })).resolves.toEqual({ hasUnrequestedSeasons: false, definitive: false });
+    });
+
+    it.each([
+        {
+            name: 'empty',
+            root: { seasonNumber: 0, episodeCount: 0 },
+            mediaStatus: 1,
+            requests: [],
+        },
+        {
+            name: 'active',
+            root: { seasonNumber: 0, episodeCount: 3 },
+            mediaStatus: 1,
+            requests: [{
+                id: 1,
+                type: 'tv',
+                is4k: false,
+                status: 2,
+                seasons: [{ seasonNumber: 0, status: 2 }],
+            }],
+        },
+        {
+            name: 'available',
+            root: { seasonNumber: 0, episodeCount: 3 },
+            mediaStatus: 5,
+            requests: [],
+        },
+    ])('keeps $name Specials nonrequestable without consulting settings', async ({ root, mediaStatus, requests }) => {
+        await expect(resolveUnrequestedSeasons({
+            id: 42,
+            seasons: [root],
+            mediaInfo: {
+                requests,
+                seasons: [{ seasonNumber: 0, status: mediaStatus }],
+            },
+        })).resolves.toEqual({ hasUnrequestedSeasons: false, definitive: true });
+        expect(fetchRequestSettings).not.toHaveBeenCalled();
+    });
+
+    it('lets deleted Specials become the sole requestable season when enabled', async () => {
+        fetchRequestSettings.mockResolvedValue({
+            available: true,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: true,
+            stale: false,
+        });
+
+        await expect(resolveUnrequestedSeasons({
+            id: 42,
+            seasons: [{ seasonNumber: 0, episodeCount: 2 }],
+            mediaInfo: {
+                requests: [{
+                    id: 1,
+                    type: 'tv',
+                    is4k: false,
+                    status: 5,
+                    seasons: [{ seasonNumber: 0, status: 5 }],
+                }],
+                seasons: [{ seasonNumber: 0, status: 7 }],
+            },
+        })).resolves.toEqual({ hasUnrequestedSeasons: true, definitive: true });
     });
 
     it('keeps raw AVAILABLE fail-closed without a viewer-scoped Jellyfin absence query', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/seasons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/seasons.ts
@@ -290,20 +290,66 @@ cards.forEach((card: any) => {
 });
 }
 
+export interface UnrequestedSeasonsResolution {
+    /** Whether at least one normal-quality season can be requested now. */
+    hasUnrequestedSeasons: boolean;
+    /**
+     * False only when an async prerequisite could not be proven. Callers must
+     * fail closed for this render without memoizing the negative result.
+     */
+    definitive: boolean;
+}
+
+const DEFINITIVE_NO_SEASONS: UnrequestedSeasonsResolution = Object.freeze({
+    hasUnrequestedSeasons: false,
+    definitive: true,
+});
+const INDETERMINATE_SEASONS: UnrequestedSeasonsResolution = Object.freeze({
+    hasUnrequestedSeasons: false,
+    definitive: false,
+});
+
 /**
- * Check if a TV show has any unrequested seasons by querying the request endpoint
- * @param {object} data - The TV show data from Seerr
- * @returns {Promise<boolean>} - True if there are seasons that can be requested
+ * Resolve whether a TV show has an unrequested normal-quality season.
+ *
+ * Regular seasons are independent of Seerr's Specials capability. Season 0
+ * participates only when it is non-empty, otherwise requestable under the
+ * same request/media-state rules, and a complete request-settings snapshot
+ * proves both partial-season requests and special-episode requests are
+ * enabled. Exact-generation `stale:true` settings remain authoritative; an
+ * unavailable snapshot produces an indeterminate result so lifecycle owners
+ * can retry without publishing a stale affordance.
+ *
+ * @param {object} data - Complete TV details from Seerr.
+ * @returns {Promise<UnrequestedSeasonsResolution>}
  */
-// Kept async because callers and the exported internal test seam consume a
-// Promise; the unsafe viewer-scoped Jellyfin read was deliberately removed.
-// eslint-disable-next-line @typescript-eslint/require-await
-async function checkForUnrequestedSeasons(data: any) {
-// Get all seasons from TMDB data that have episodes (excluding specials and unaired seasons)
-const tmdbSeasons = (data.seasons || []).filter((s: any) => s.seasonNumber > 0 && s.episodeCount > 0);
-if (tmdbSeasons.length === 0) return false;
+async function resolveUnrequestedSeasons(data: any): Promise<UnrequestedSeasonsResolution> {
 
 try {
+    if (!data || typeof data !== 'object' || !Array.isArray(data.seasons)) {
+        throw new Error('TV detail did not contain a complete root-season relation.');
+    }
+
+    const seenRootSeasons = new Set<number>();
+    const tmdbSeasons: any[] = [];
+    for (const season of data.seasons) {
+        const seasonNumber = season?.seasonNumber;
+        const episodeCount = season?.episodeCount;
+        if (!Number.isInteger(seasonNumber)
+            || seasonNumber < 0
+            || !Number.isInteger(episodeCount)
+            || episodeCount < 0
+            || seenRootSeasons.has(seasonNumber)) {
+            throw new Error('TV detail contained an invalid root-season row.');
+        }
+        seenRootSeasons.add(seasonNumber);
+        if (episodeCount > 0) tmdbSeasons.push(season);
+    }
+
+    const regularSeasons = tmdbSeasons.filter((season) => season.seasonNumber > 0);
+    const specialsSeason = tmdbSeasons.find((season) => season.seasonNumber === 0) || null;
+    if (regularSeasons.length === 0 && !specialsSeason) return DEFINITIVE_NO_SEASONS;
+
     // Seerr's TV-detail response loads this media row with its complete
     // `requests` relation, and each MediaRequest eagerly loads its season rows.
     // Consume that bounded per-title relation instead of scanning the server's
@@ -388,24 +434,51 @@ try {
     // link IDs cannot prove global absence across all scanner libraries.
     const jellyfinMediaId = data.mediaInfo?.jellyfinMediaId || null;
 
-    for (const tmdbSeason of tmdbSeasons) {
+    const isRequestableSeason = (tmdbSeason: any): boolean => {
         const seasonNumber = Number(tmdbSeason.seasonNumber);
         if (activeNormalRequestSeasons.has(seasonNumber)) {
-            continue;
+            return false;
         }
 
         const rawStatus = mediaStatusMap.get(seasonNumber);
         const effectiveStatus = JC.seerrStatus!.effectiveMediaStatus(rawStatus, jellyfinMediaId);
-        if (JC.seerrStatus!.isRequestable(effectiveStatus)) {
-            return true;
-        }
+        return JC.seerrStatus!.isRequestable(effectiveStatus);
+    };
+
+    if (regularSeasons.some(isRequestableSeason)) {
+        return { hasUnrequestedSeasons: true, definitive: true };
     }
 
-    return false;
+    // If Specials is already active or available, its capability cannot alter
+    // the result and no settings request is needed.
+    if (!specialsSeason || !isRequestableSeason(specialsSeason)) {
+        return DEFINITIVE_NO_SEASONS;
+    }
+
+    const requestSettings = await JC.seerrAPI!.fetchRequestSettings();
+    if (!requestSettings.available) return INDETERMINATE_SEASONS;
+
+    // Seerr's whole-show path deliberately excludes season 0. Specials are
+    // actionable only through the partial-season flow, so both capabilities
+    // are required to avoid publishing a dead-end Request More affordance.
+    const specialsEnabled = requestSettings.partialRequestsEnabled
+        && requestSettings.enableSpecialEpisodes;
+    return {
+        hasUnrequestedSeasons: specialsEnabled,
+        definitive: true,
+    };
 } catch (error: any) {
     console.error(`[More Info Modal] Error checking unrequested seasons:`, error);
-    return false;
+    return INDETERMINATE_SEASONS;
 }
+}
+
+/**
+ * Legacy boolean seam retained for existing callers while lifecycle-aware
+ * owners consume resolveUnrequestedSeasons and its definitive flag.
+ */
+async function checkForUnrequestedSeasons(data: any): Promise<boolean> {
+    return (await resolveUnrequestedSeasons(data)).hasUnrequestedSeasons;
 }
 
 /**
@@ -466,4 +539,5 @@ internal.buildSeasonAvailabilityLinks = buildSeasonAvailabilityLinks;
 internal.fetchJellyfinSeasonMap = fetchJellyfinSeasonMap;
 internal.enrichSeasonCardsWithJellyfinLinks = enrichSeasonCardsWithJellyfinLinks;
 internal.checkForUnrequestedSeasons = checkForUnrequestedSeasons;
+internal.resolveUnrequestedSeasons = resolveUnrequestedSeasons;
 internal.buildSeasonsSection = buildSeasonsSection;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/buttons.ts
@@ -169,6 +169,28 @@ function configureTvShowButton(button: any, overallStatus: any, seasonAnalysis: 
         button.disabled = disabled;
         button.className = `seerr-request-button seerr-button-tv ${className}`; // Reset classes
     };
+    if (seasonAnalysis?.specialsOnly) {
+        // The search projection cannot prove that Specials has episodes or is
+        // enabled. Keep status display deterministic but do not publish a
+        // request action; full details/More Info owns the authoritative check.
+        switch (overallStatus) {
+            case MediaStatus.AVAILABLE:
+                setButton(JC.t!('seerr_btn_available'), icons.available, 'seerr-button-available', true, null);
+                break;
+            case MediaStatus.BLOCKED:
+                setButton(JC.t!('seerr_btn_blocklisted'), icons.cancel, 'seerr-button-blocklisted', true, null);
+                break;
+            case MediaStatus.PENDING:
+            case MediaStatus.PROCESSING:
+            case MediaStatus.PARTIALLY_AVAILABLE:
+                setButton(JC.t!('seerr_btn_pending'), icons.pending, 'seerr-button-pending', true, null);
+                break;
+            default:
+                setButton(JC.t!('seerr_btn_request'), icons.request, 'seerr-button-request', true, null);
+                break;
+        }
+        return;
+    }
     switch (overallStatus) {
         case MediaStatus.PENDING: setButton(JC.t!('seerr_btn_pending'), icons.pending, 'seerr-button-pending'); break;
         case MediaStatus.PROCESSING: setButton(JC.t!('seerr_btn_request'), icons.request, 'seerr-button-request'); break;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results-specials.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results-specials.test.ts
@@ -1,0 +1,97 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+
+describe('Seerr search-card Specials status projection', () => {
+    let internal: Record<string, any>;
+    let fetchRequestSettings: ReturnType<typeof vi.fn>;
+
+    beforeAll(async () => {
+        JC.t = (key: string) => key;
+        JC.escapeHtml = (value: unknown) => String(value);
+        JC.pluginConfig = {
+            SeerrEnable4KRequests: true,
+            SeerrEnable4KTvRequests: true,
+        };
+        const { installSeerrStatus } = await import('../seerr-status');
+        installSeerrStatus();
+        const uiModule = await import('./internal');
+        uiModule.installSeerrUiFacade();
+        internal = uiModule.internal;
+        internal.icons = new Proxy({}, { get: () => '' });
+        internal.addDownloadProgressHover = vi.fn();
+        internal.hide4KPopup = vi.fn();
+        internal.show4KPopup = vi.fn();
+        await import('./results');
+        await import('./buttons');
+    });
+
+    beforeEach(() => {
+        document.body.replaceChildren();
+        JC.identity.transition('specials-card-server', `specials-card-user-${Math.random()}`, 'test setup');
+        fetchRequestSettings = vi.fn();
+        JC.seerrAPI = {
+            canRequest4k: () => true,
+            fetchRequestSettings,
+        } as unknown as NonNullable<typeof JC.seerrAPI>;
+    });
+
+    function configure(seasons: Array<{ seasonNumber: number; status: number }>): HTMLButtonElement {
+        const button = document.createElement('button');
+        document.body.appendChild(button);
+        internal.configureRequestButton(button, {
+            id: 674,
+            mediaType: 'tv',
+            name: 'Specials fixture',
+            mediaInfo: { status: 5, status4k: 1, seasons },
+        }, true, true);
+        return button;
+    }
+
+    it('keeps an available regular season available when Specials is unknown', () => {
+        const analysis = internal.analyzeSeasonStatuses([
+            { seasonNumber: 0, status: 1 },
+            { seasonNumber: 1, status: 5 },
+        ]);
+
+        expect(analysis).toMatchObject({ overallStatus: 5, total: 1, availableCount: 1 });
+        expect(analysis.specialsOnly).toBeUndefined();
+
+        const button = configure([
+            { seasonNumber: 0, status: 1 },
+            { seasonNumber: 1, status: 5 },
+        ]);
+        expect(button.textContent).toContain('seerr_btn_available');
+        expect(button.disabled).toBe(true);
+        expect(document.querySelector('.seerr-split-arrow')).not.toBeNull();
+        expect(fetchRequestSettings).not.toHaveBeenCalled();
+    });
+
+    it('renders unknown Specials-only search data as a disabled detail-owned request', () => {
+        const analysis = internal.analyzeSeasonStatuses([{ seasonNumber: 0, status: 1 }]);
+        expect(analysis).toEqual({
+            overallStatus: 1,
+            statusSummary: null,
+            total: 0,
+            specialsOnly: true,
+        });
+
+        const button = configure([{ seasonNumber: 0, status: 1 }]);
+        expect(button.textContent).toContain('seerr_btn_request');
+        expect(button.disabled).toBe(true);
+        expect(button.classList).toContain('seerr-button-request');
+        expect(document.querySelector('.seerr-split-arrow')).toBeNull();
+        expect(fetchRequestSettings).not.toHaveBeenCalled();
+    });
+
+    it('preserves an available Specials-only status without a request or 4K affordance', () => {
+        const analysis = internal.analyzeSeasonStatuses([{ seasonNumber: 0, status: 5 }]);
+        expect(analysis).toMatchObject({ overallStatus: 5, specialsOnly: true });
+
+        const button = configure([{ seasonNumber: 0, status: 5 }]);
+        expect(button.textContent).toContain('seerr_btn_available');
+        expect(button.disabled).toBe(true);
+        expect(button.classList).toContain('seerr-button-available');
+        expect(document.querySelector('.seerr-split-arrow')).toBeNull();
+        expect(fetchRequestSettings).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/results.ts
@@ -132,7 +132,19 @@ function analyzeSeasonStatuses(seasons: any) {
     if (!seasons || seasons.length === 0) return { overallStatus: 1, statusSummary: null, total: 0 };
     const regularSeasons = seasons.filter((s: any) => s.seasonNumber > 0);
     const total = regularSeasons.length;
-    if (total === 0) return { overallStatus: 1, statusSummary: null, total: 0 };
+    if (total === 0) {
+        const specials = seasons.find((season: any) => season?.seasonNumber === 0);
+        // Search-result mediaInfo is a sparse status projection: it carries no
+        // root-season episode count or request-settings snapshot. Preserve the
+        // status for badges, but mark a Specials-only card non-actionable until
+        // a full-detail owner can prove both capability and non-empty content.
+        return {
+            overallStatus: specials?.status ?? MediaStatus.UNKNOWN,
+            statusSummary: null,
+            total: 0,
+            specialsOnly: !!specials,
+        };
+    }
 
     const statusCounts = {
         available: regularSeasons.filter((s: any) => s.status === MediaStatus.AVAILABLE).length,
@@ -154,17 +166,6 @@ function analyzeSeasonStatuses(seasons: any) {
         statusSummary = (availableCount > 0) ? JC.t!('seerr_seasons_available_count', { count: availableCount, total }) : JC.t!('seerr_seasons_requested_count', { count: requestedCount, total });
     } else {
         overallStatus = MediaStatus.UNKNOWN;
-    }
-
-    // If every regular season is accounted for but the specials season (0) was never
-    // requested, still surface a "Request More" affordance instead of marking the
-    // show fully Available, so specials-only seasons remain requestable.
-    if (overallStatus === MediaStatus.AVAILABLE) {
-        const specialsSeason = seasons.find((s: any) => s.seasonNumber === 0);
-        if (specialsSeason && specialsSeason.status === MediaStatus.UNKNOWN) {
-            overallStatus = MediaStatus.DELETED;
-            statusSummary = JC.t!('seerr_seasons_accounted_for', { count: accountedForCount, total });
-        }
     }
 
     return { overallStatus, statusSummary, total, availableCount };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal-refresh.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal-refresh.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 describe('season modal refresh lifecycle', () => {
     let fetchTvShowDetails: ReturnType<typeof vi.fn>;
     let fetchTvSeasonDetails: ReturnType<typeof vi.fn>;
+    let fetchRequestSettings: ReturnType<typeof vi.fn>;
+    let requestTvSeasons: ReturnType<typeof vi.fn>;
     let modalRecords: Array<{ options: any; modalElement: HTMLElement }>;
 
     function tvDetails(activeRequest = false, includeAirDate = true) {
@@ -37,6 +39,13 @@ describe('season modal refresh lifecycle', () => {
         modalRecords = [];
         fetchTvShowDetails = vi.fn();
         fetchTvSeasonDetails = vi.fn().mockResolvedValue(null);
+        fetchRequestSettings = vi.fn().mockResolvedValue({
+            available: true,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: false,
+            stale: false,
+        });
+        requestTvSeasons = vi.fn();
 
         const jc = window.JellyfinCanopy as unknown as Record<string, any>;
         jc.seerrUI = {};
@@ -55,18 +64,13 @@ describe('season modal refresh lifecycle', () => {
         internal.handleRequestError = vi.fn();
 
         jc.seerrAPI = {
-            fetchRequestSettings: vi.fn().mockResolvedValue({
-                available: true,
-                partialRequestsEnabled: true,
-                enableSpecialEpisodes: false,
-                stale: false,
-            }),
+            fetchRequestSettings,
             fetchTvShowDetails,
             fetchTvSeasonDetails,
             fetchTmdbTvDetails: vi.fn().mockResolvedValue(null),
             fetchAdvancedRequestData: vi.fn(),
             fetchUserQuota: vi.fn().mockResolvedValue(null),
-            requestTvSeasons: vi.fn(),
+            requestTvSeasons,
             requestMedia: vi.fn(),
         };
         jc.seerrModal = {
@@ -127,6 +131,40 @@ describe('season modal refresh lifecycle', () => {
         expect(checkbox.disabled).toBe(true);
         expect(modal.modalElement.querySelector('.seerr-season-status')?.textContent)
             .toBe('seerr_season_status_requested');
+    });
+
+    it('submits season zero when Specials and partial requests are enabled', async () => {
+        fetchRequestSettings.mockResolvedValue({
+            available: true,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: true,
+            stale: false,
+        });
+        fetchTvShowDetails.mockResolvedValue({
+            name: 'Specials fixture',
+            seasons: [{ seasonNumber: 0, episodeCount: 3, name: 'Specials' }],
+            mediaInfo: {
+                status: 5,
+                status4k: 1,
+                seasons: [{ seasonNumber: 0, status: 1, status4k: 1 }],
+                requests: [],
+                downloadStatus: [],
+                downloadStatus4k: [],
+            },
+        });
+        const modal = await openModal();
+        const checkbox = modal.modalElement.querySelector<HTMLInputElement>(
+            '.seerr-season-item[data-season-number="0"] .seerr-season-checkbox',
+        )!;
+        expect(checkbox.disabled).toBe(false);
+        checkbox.checked = true;
+
+        const requestButton = document.createElement('button');
+        const close = vi.fn();
+        await modal.options.onSave(modal.modalElement, requestButton, close);
+
+        expect(requestTvSeasons).toHaveBeenCalledWith(123, [0], {}, null, false);
+        expect(close).toHaveBeenCalledOnce();
     });
 
     it('serializes polls and ignores an in-flight result after the modal closes', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal-status.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/season-modal-status.test.ts
@@ -32,6 +32,8 @@ describe('season modal status domains', () => {
         jellyfinMediaId?: string;
         rawMediaInfo?: any;
         rootSeasons?: any;
+        partialRequestsEnabled?: boolean;
+        enableSpecialEpisodes?: boolean;
     } = {}) {
         const host = options.host ?? document.createElement('div');
         const requests = options.requestStatus == null ? [] : [{
@@ -66,8 +68,8 @@ describe('season modal status domains', () => {
         internal.updateSeasonList(
             host,
             tvDetails,
-            true,
-            false,
+            options.partialRequestsEnabled ?? true,
+            options.enableSpecialEpisodes ?? false,
             options.is4kMode ?? false,
         );
 
@@ -215,6 +217,41 @@ describe('season modal status domains', () => {
         expect(row.status.textContent).toBe('seerr_season_status_not_requested');
         expect((row.host as any)._requestStateValid).toBe(true);
         expect((row.host as any)._validatedRegularSeasonNumbers).toEqual([1]);
+    });
+
+    it('makes a non-empty unknown Specials row selectable only when both capabilities are enabled', () => {
+        const specialMediaInfo = {
+            status: 5,
+            status4k: 1,
+            seasons: [{ seasonNumber: 0, status: 1, status4k: 1 }],
+            requests: [],
+        };
+        const enabled = renderSeason({
+            rootSeasons: [{ seasonNumber: 0, episodeCount: 3, name: 'Specials' }],
+            rawMediaInfo: specialMediaInfo,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: true,
+        });
+        expect(enabled.checkbox.dataset.seasonNumber).toBe('0');
+        expect(enabled.checkbox.disabled).toBe(false);
+        expect(enabled.status.textContent).toBe('seerr_season_status_not_requested');
+
+        const partialDisabled = renderSeason({
+            rootSeasons: [{ seasonNumber: 0, episodeCount: 3, name: 'Specials' }],
+            rawMediaInfo: specialMediaInfo,
+            partialRequestsEnabled: false,
+            enableSpecialEpisodes: true,
+        });
+        expect(partialDisabled.checkbox.dataset.seasonNumber).toBe('0');
+        expect(partialDisabled.checkbox.disabled).toBe(true);
+
+        const specialsDisabled = renderSeason({
+            rootSeasons: [{ seasonNumber: 0, episodeCount: 3, name: 'Specials' }],
+            rawMediaInfo: specialMediaInfo,
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: false,
+        });
+        expect(specialsDisabled.host.querySelector('[data-season-number="0"]')).toBeNull();
     });
 
     it('clears a selected season when refreshed request state disables it', () => {

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -359,7 +359,7 @@ Requesting in 4K is a two-part gate: an admin master switch, and per-user permis
 !!! note "When the 4K option actually appears"
     Beyond the admin master switch, the 4K option is offered only when the Seerr server actually has 4K enabled for that media type (a default 4K Radarr / Sonarr — Seerr's `movie4kEnabled` / `series4kEnabled`) **and** the signed-in user holds the Seerr **REQUEST_4K** (or the media-specific **REQUEST_4K_MOVIE** / **REQUEST_4K_TV**) permission. Otherwise the affordance is hidden. The server enforces the same rule on the request itself, so a 4K request can never be made without permission.
 
-In the **More Info** modal, TV actions use **Request More** as the primary action, with **Request in 4K** in the dropdown when 4K is requestable.
+In the **More Info** modal, TV actions use **Request More** when at least one season can still be requested, with **Request in 4K** in the dropdown when 4K is requestable. This includes **Specials** (Season 0) when Seerr has both partial-season requests and special-episode requests enabled. If only Specials remain and either setting is disabled or temporarily cannot be verified, Canopy does not show a request action. Search-result cards also wait for full title details before enabling a Specials-only request because Seerr's compact search response does not say whether Season 0 has episodes or whether those two settings are enabled.
 
 #### Requesting collections
 
@@ -377,7 +377,7 @@ These toggles on the **Seerr** tab shape the request experience:
 | **Show Request Quota Info** | On | Request modals display a chip with the user's current request usage and, when a complete request history makes it safe to derive, when the next slot frees up. A temporary history failure omits only that reset estimate rather than hiding Seerr's authoritative quota numbers — a maxed-out user then sees "Reset time is currently unavailable" instead of a silent gap, so an unavailable estimate is never mistaken for "no reset exists". A blocked request shows a detailed quota-error dialog instead of a vanishing toast. |
 | **Show Collections in Seerr Results** | On | Shows TMDB collections in results with an option to request the whole collection. See [Requesting collections](#requesting-collections). |
 | **Open Results in "More Info" Modal** | Off | Controls what happens when a user clicks a Seerr result's title or poster. **Off** opens the item in Seerr; **On** opens an in-app **More Info** modal, keeping the user inside Jellyfin. |
-| **Show "Request More" Button on Series** | On | Adds a **Request More** button beside the Seasons heading on Series detail pages whenever the show has unrequested seasons in Seerr, so users can request more seasons without using the search bar. |
+| **Show "Request More" Button on Series** | On | Adds a **Request More** button beside the Seasons heading on Series detail pages whenever the show has requestable seasons in Seerr, so users can request more seasons without using the search bar. A non-empty Specials season counts when Seerr enables both partial-season and special-episode requests. |
 | **Show Streaming Providers on Posters** | — | Shows Elsewhere provider icons on Seerr result cards (needs a TMDB key). See [Streaming posters on Seerr cards](#streaming-posters-on-seerr-cards). |
 
 ### Recommendations, similar & discovery on detail pages

--- a/e2e/mock-integrations/server.js
+++ b/e2e/mock-integrations/server.js
@@ -155,6 +155,61 @@ function movieDetail(id) {
     };
 }
 
+function tvSpecialsDetail(id) {
+    const idNumber = Number(id);
+    return {
+        id: idNumber,
+        mediaType: 'tv',
+        name: 'JC Specials Request Fixture',
+        originalName: 'JC Specials Request Fixture',
+        overview: 'Hermetic TV fixture with every regular season available and only Specials unrequested.',
+        firstAirDate: '2024-01-01',
+        lastAirDate: '2025-01-01',
+        status: 'Returning Series',
+        episodeRunTime: [42],
+        posterPath: null,
+        backdropPath: null,
+        genres: [{ id: 18, name: 'Drama' }],
+        contentRatings: { results: [{ iso_3166_1: 'US', rating: 'TV-14' }] },
+        credits: { cast: [], crew: [] },
+        createdBy: [],
+        relatedVideos: [],
+        keywords: [],
+        seasons: [
+            {
+                seasonNumber: 0,
+                episodeCount: 3,
+                name: 'Specials',
+                overview: 'Requestable fixture Specials.',
+                airDate: '2024-01-01',
+                posterPath: '/jc-specials-fixture.jpg',
+            },
+            {
+                seasonNumber: 1,
+                episodeCount: 8,
+                name: 'Season 1',
+                overview: 'Already available regular season.',
+                airDate: '2024-02-01',
+                posterPath: '/jc-season-one-fixture.jpg',
+            },
+        ],
+        mediaInfo: {
+            id: idNumber + 100000,
+            status: 5,
+            status4k: 1,
+            jellyfinMediaId: null,
+            jellyfinMediaId4k: null,
+            downloadStatus: [],
+            downloadStatus4k: [],
+            seasons: [
+                { seasonNumber: 0, status: 1, status4k: 1 },
+                { seasonNumber: 1, status: 5, status4k: 1 },
+            ],
+            requests: [],
+        },
+    };
+}
+
 function searchResults(query) {
     const normalized = query.toLowerCase();
     if (normalized.includes('deadpool')) {
@@ -167,6 +222,9 @@ function searchResults(query) {
     }
     if (normalized.includes('night of the living dead')) {
         return [10331, 10332, 10333, 10334].map(movieDetail);
+    }
+    if (normalized.includes('specials request fixture')) {
+        return [tvSpecialsDetail(1399)];
     }
     return [550, 603, 862].map(movieDetail);
 }
@@ -262,7 +320,13 @@ async function handleSeerr(request, response) {
         return json(response, 200, { movie4kEnabled: true, series4kEnabled: true });
     }
     if (url.pathname === '/api/v1/settings/main') {
-        return json(response, 200, { partialRequestsEnabled: true });
+        return json(response, 200, {
+            partialRequestsEnabled: true,
+            enableSpecialEpisodes: true,
+        });
+    }
+    if (url.pathname === '/api/v1/overrideRule' && request.method === 'GET') {
+        return json(response, 200, []);
     }
     if (url.pathname === '/api/v1/user' && request.method === 'GET') {
         return json(response, 200, page(readFixtureState().users));
@@ -306,6 +370,20 @@ async function handleSeerr(request, response) {
         return match[2]
             ? json(response, 200, page([603, 862].map(movieDetail)))
             : json(response, 200, movieDetail(match[1]));
+    }
+    match = url.pathname.match(/^\/api\/v1\/tv\/(\d+)\/season\/(\d+)$/);
+    if (match && request.method === 'GET') {
+        return json(response, 200, {
+            id: Number(match[2]),
+            seasonNumber: Number(match[2]),
+            episodes: [{ episodeNumber: 1, airDate: '2024-01-01' }],
+        });
+    }
+    match = url.pathname.match(/^\/api\/v1\/tv\/(\d+)(?:\/(similar|recommendations|ratings))?$/);
+    if (match && request.method === 'GET') {
+        if (match[2] === 'ratings') return json(response, 200, {});
+        if (match[2]) return json(response, 200, page([]));
+        return json(response, 200, tvSpecialsDetail(match[1]));
     }
     match = url.pathname.match(/^\/api\/v1\/collection\/(\d+)$/);
     if (match && request.method === 'GET') {

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -117,6 +117,7 @@
     "e2e/seerr-collection-rich-cards.spec.ts › Seerr collection request rich cards (#463) › modern / mobile",
     "e2e/seerr-collection-rich-cards.spec.ts › Seerr collection request rich cards (#463) › modern / desktop",
     "e2e/seerr-collection-rich-cards.spec.ts › Seerr collection responsive device audit (#463 follow-up) › modern / 50-device popularity proxy / 23 portrait viewports",
+    "e2e/seerr-specials-request-more.spec.ts › Seerr Specials Request More (#674) › enabled Specials render and submit season zero while disabled or unavailable settings fail closed",
     "e2e/seerr-modal-history.spec.ts › Seerr modal history ownership › synthetic success consumes its own entry before the next real Back",
     "e2e/seerr-modal-history.spec.ts › Seerr modal history ownership › one Escape closes only the topmost nested modal and keeps the shortcut gate",
     "e2e/seerr-modal-history.spec.ts › Seerr modal history ownership › intervening SPA history preserves one-step Back and Forward around a retired modal",

--- a/e2e/seerr-specials-request-more.spec.ts
+++ b/e2e/seerr-specials-request-more.spec.ts
@@ -1,0 +1,151 @@
+// Regression for #674: a show whose regular seasons are complete must still
+// expose Request More when its non-empty Specials season is unrequested and
+// both Seerr capabilities are enabled. The test drives the live Jellyfin 12
+// client, real Canopy facades, server proxy, and hermetic Seerr fixture.
+import {
+    test,
+    expect,
+    loginAs,
+    showRoute,
+    waitForHash,
+    assertNoRuntimeErrors,
+} from './fixtures/auth';
+import { seerrReady } from './fixtures/seerr';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const TV_ID = 1399;
+const SETTINGS_PATH = '/JellyfinCanopy/seerr/settings/partial-requests';
+
+test.describe('Seerr Specials Request More (#674)', () => {
+    test('enabled Specials render and submit season zero while disabled or unavailable settings fail closed', async ({
+        page,
+        consoleErrors,
+    }) => {
+        await loginAs(page, 'admin', consoleErrors);
+        test.skip(!(await seerrReady(page)), 'Seerr not configured on this server');
+        const seriesId = await page.evaluate(async () => {
+            const api = (window as any).ApiClient;
+            const result = await api.getJSON(api.getUrl(
+                `/Items?IncludeItemTypes=Series&Recursive=true&Limit=1&SearchTerm=${encodeURIComponent('Guard Test Show')}`,
+            ));
+            return result?.Items?.[0]?.Id as string | undefined;
+        });
+        expect(seriesId, 'seeded details route owner').toBeTruthy();
+        await showRoute(page, `/details?id=${seriesId}`);
+        await waitForHash(page, String(seriesId));
+        await page.waitForFunction(
+            () => typeof (window as any).JellyfinCanopy?.seerrMoreInfo?.open === 'function'
+                && typeof (window as any).JellyfinCanopy?.seerrUI?.showSeasonSelectionModal === 'function',
+            undefined,
+            { timeout: 60_000 },
+        );
+
+        let settingsMode: 'enabled' | 'disabled' | 'unavailable' = 'enabled';
+        await page.route(`**${SETTINGS_PATH}*`, async (route) => {
+            if (settingsMode === 'enabled') {
+                await route.continue();
+                return;
+            }
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: settingsMode === 'disabled'
+                    ? JSON.stringify({
+                        partialRequestsEnabled: true,
+                        enableSpecialEpisodes: false,
+                        stale: false,
+                    })
+                    : JSON.stringify({}),
+            });
+        });
+
+        let submittedRequest: Record<string, unknown> | null = null;
+        await page.route('**/JellyfinCanopy/seerr/request', async (route) => {
+            if (route.request().method() !== 'POST') {
+                await route.continue();
+                return;
+            }
+            submittedRequest = route.request().postDataJSON() as Record<string, unknown>;
+            await route.fulfill({
+                status: 201,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    id: 674,
+                    status: 1,
+                    media: { status: 2, status4k: 1 },
+                }),
+            });
+        });
+
+        const openMoreInfo = async (requireWireDetail = false): Promise<void> => {
+            const detailResponse = requireWireDetail
+                ? page.waitForResponse((response) => {
+                    const url = new URL(response.url());
+                    return response.request().method() === 'GET'
+                        && url.pathname === `/JellyfinCanopy/seerr/tv/${TV_ID}`;
+                })
+                : null;
+            await page.evaluate(async (tmdbId) => {
+                await (window as any).JellyfinCanopy.seerrMoreInfo.open(tmdbId, 'tv');
+            }, TV_ID);
+            if (detailResponse) {
+                expect((await detailResponse).ok(), 'hermetic TV detail proxy response').toBe(true);
+            }
+            await expect(page.locator('.jc-more-info-modal')).toBeVisible();
+        };
+        const closeMoreInfo = async (): Promise<void> => {
+            await page.evaluate(() => (window as any).JellyfinCanopy.seerrMoreInfo.close(true));
+            await expect(page.locator('.jc-more-info-modal')).toHaveCount(0);
+        };
+        const requestMore = page.locator(
+            '.jc-more-info-modal [data-mount="jc-actions"] .seerr-request-button',
+        );
+
+        // The unmodified hermetic server response owns the positive contract.
+        await openMoreInfo(true);
+        await expect(requestMore).toBeVisible();
+        await expect(requestMore).toContainText(/Request More/i);
+
+        await requestMore.click();
+        const seasonModal = page.locator('.seerr-season-modal.show');
+        await expect(seasonModal).toBeVisible();
+        const specials = seasonModal.locator(
+            '.seerr-season-item[data-season-number="0"] .seerr-season-checkbox',
+        );
+        await expect(specials).toBeEnabled();
+        await specials.check();
+        await seasonModal.locator('.seerr-modal-button-primary').click();
+        await expect.poll(() => submittedRequest).not.toBeNull();
+        expect(submittedRequest).toMatchObject({
+            mediaId: TV_ID,
+            mediaType: 'tv',
+            seasons: [0],
+        });
+
+        await page.evaluate(() => {
+            (window as any).JellyfinCanopy.seerrModal?.closeAll?.();
+            (window as any).JellyfinCanopy.seerrMoreInfo.close(true);
+        });
+
+        settingsMode = 'disabled';
+        const disabledSettingsResponse = page.waitForResponse(
+            (response) => new URL(response.url()).pathname === SETTINGS_PATH,
+        );
+        await openMoreInfo();
+        await disabledSettingsResponse;
+        await expect(requestMore).toHaveCount(0);
+        await closeMoreInfo();
+
+        settingsMode = 'unavailable';
+        const unavailableSettingsResponse = page.waitForResponse(
+            (response) => new URL(response.url()).pathname === SETTINGS_PATH,
+        );
+        await openMoreInfo();
+        await unavailableSettingsResponse;
+        await expect(requestMore).toHaveCount(0);
+        await closeMoreInfo();
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});


### PR DESCRIPTION
## Description

Fixes #674.

`Request More` previously ignored Season 0 and could therefore hide the only remaining requestable content for a show whose regular seasons were complete. This change treats a non-empty, otherwise-requestable Specials season as requestable only when Seerr reports both partial requests and special episodes enabled.

## Implementation notes

- Adds a structured full-detail resolver that distinguishes definitive negatives from temporarily unavailable settings.
- Keeps regular-season decisions independent of the Specials settings endpoint.
- Fails closed when Specials capability is unavailable or malformed, with bounded navigation/modal-owned retries and generation fencing so stale async results cannot repaint a refreshed modal.
- Keeps sparse search-card data conservative and avoids per-card settings/detail requests; full details remain authoritative.
- Submits Specials through the existing partial-request path as `seasons: [0]`.
- Adds unit, integration-fixture, real Jellyfin 12 browser, inventory, and user documentation coverage.

No breaking changes.

## Validation

- `npm run check:toolchain`
- Focused Vitest lifecycle and Specials suites (including stale-render and retry cleanup regressions)
- `npm run test:client:coverage`: 247 files, 2,062 tests passed; 2,798/3,191 lines (87.684%)
- `npm run test:server:coverage`: 4,104 tests passed; 42,788/52,592 lines (81.358%) using isolated official .NET SDK 10.0.109 because the host ASP.NET/Core runtime patch levels differed
- `npm run typecheck:src`
- `npm run typecheck`
- `npm run syntax`
- `npm run test:scripts -- --runInBand`: 137 tests passed
- `npm run build:bundle`: 173 deterministic files; build ID `d9cfd6e6f76bbd18dc81f5b0b59d98ac185cbac41cae8d18c678dc5eebdaba77`
- `dotnet build Jellyfin.Plugin.JellyfinCanopy/Jellyfin.Plugin.JellyfinCanopy.csproj -c Release`: 0 warnings, 0 errors
- `npm run check:docs`: all deterministic documentation gates and strict MkDocs build passed
- Targeted Playwright regression passed against the digest-pinned Jellyfin 12 image and asserted the exact `seasons: [0]` request
- Full local E2E inventory: 160/167 passed initially; the three unrelated failures were diagnosed and passed in fresh isolated reruns (Maintainerr 9/9, parental-revocation 1/1, pause persistence 2/2), and pause persistence also passed on an exact clean-main baseline. Four maintainer-only serial tests were skipped by policy. Hosted isolated shards are the authoritative full run.

`./verify.sh lint` completed under the repository's advisory lint policy. The repository-wide report remains 5,616 findings (3 errors, 5,613 warnings); focused lint of the changed tests has 0 errors (11 warnings).

Visual evidence: the real Jellyfin 12 Playwright regression exercises the rendered Request More and season-selection UI end to end; no binary screenshot artifact is attached.

## AI assistance

This PR was developed with AI assistance (GPT). I have reviewed and tested all changes and understand the implementation.

Auto-merge is intentionally not enabled because contributor PR auto-merge is prohibited by repository policy.
