### PR TITLE
fix: preserve single-digit Rotten Tomatoes scores

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheDependencyInvalidationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheDependencyInvalidationTests.cs
@@ -1530,6 +1530,8 @@ public sealed class TagCacheDependencyInvalidationTests
         var ownEpisodeId = Guid.NewGuid();
         var inheritingSeasonId = Guid.NewGuid();
         var ownSeasonId = Guid.NewGuid();
+        var criticZeroEpisodeId = Guid.NewGuid();
+        var criticSevenSeasonId = Guid.NewGuid();
         var series = new StubSeries
         {
             Id = seriesId,
@@ -1543,6 +1545,8 @@ public sealed class TagCacheDependencyInvalidationTests
         var ownEpisode = new StubEpisode { Id = ownEpisodeId, SeriesId = seriesId, CommunityRating = 6, CriticRating = 60, DateLastSaved = SavedAt };
         var inheritingSeason = new StubSeason { Id = inheritingSeasonId, SeriesId = seriesId, Genres = new[] { "Stable" }, DateLastSaved = SavedAt };
         var ownSeason = new StubSeason { Id = ownSeasonId, SeriesId = seriesId, CommunityRating = 7, CriticRating = 70, Genres = new[] { "Stable" }, DateLastSaved = SavedAt };
+        var criticZeroEpisode = new StubEpisode { Id = criticZeroEpisodeId, SeriesId = seriesId, CriticRating = 0, DateLastSaved = SavedAt };
+        var criticSevenSeason = new StubSeason { Id = criticSevenSeasonId, SeriesId = seriesId, CriticRating = 7, Genres = new[] { "Stable" }, DateLastSaved = SavedAt };
         var items = new Dictionary<Guid, BaseItem>
         {
             [seriesId] = series,
@@ -1550,12 +1554,14 @@ public sealed class TagCacheDependencyInvalidationTests
             [ownEpisodeId] = ownEpisode,
             [inheritingSeasonId] = inheritingSeason,
             [ownSeasonId] = ownSeason,
+            [criticZeroEpisodeId] = criticZeroEpisode,
+            [criticSevenSeasonId] = criticSevenSeason,
         };
         var library = new CountingLibraryManager
         {
             GetItemByIdHook = id => items.GetValueOrDefault(id),
             GetItemListHook = query => query.AncestorIds?.Contains(seriesId) == true
-                ? new BaseItem[] { inheritingEpisode, ownEpisode, inheritingSeason, ownSeason }
+                ? new BaseItem[] { inheritingEpisode, ownEpisode, inheritingSeason, ownSeason, criticZeroEpisode, criticSevenSeason }
                 : Array.Empty<BaseItem>(),
         };
         using var service = NewService(library);
@@ -1571,8 +1577,12 @@ public sealed class TagCacheDependencyInvalidationTests
         service.SeedEntryForTest(Key(inheritingSeasonId), new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 1, CriticRating = 10, Genres = new[] { "Stable" }, SourceRevision = SavedAt.Ticks });
         var ownEpisodeEntry = new TagCacheEntry { Type = "Episode", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 6, CriticRating = 60, SourceRevision = SavedAt.Ticks };
         var ownSeasonEntry = new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = 7, CriticRating = 70, Genres = new[] { "Stable" }, SourceRevision = SavedAt.Ticks };
+        var criticZeroEpisodeEntry = new TagCacheEntry { Type = "Episode", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = null, CriticRating = 0, SourceRevision = SavedAt.Ticks };
+        var criticSevenSeasonEntry = new TagCacheEntry { Type = "Season", SeriesId = Key(seriesId), SeriesTmdbId = "stable", CommunityRating = null, CriticRating = 7, Genres = new[] { "Stable" }, SourceRevision = SavedAt.Ticks };
         service.SeedEntryForTest(Key(ownEpisodeId), ownEpisodeEntry);
         service.SeedEntryForTest(Key(ownSeasonId), ownSeasonEntry);
+        service.SeedEntryForTest(Key(criticZeroEpisodeId), criticZeroEpisodeEntry);
+        service.SeedEntryForTest(Key(criticSevenSeasonId), criticSevenSeasonEntry);
         using var monitor = new TagCacheMonitor(library, service, NullLogger<TagCacheMonitor>.Instance);
         monitor.Initialize();
 
@@ -1583,6 +1593,8 @@ public sealed class TagCacheDependencyInvalidationTests
         Assert.Equal(9, service.GetEntryForTest(Key(inheritingSeasonId))!.CommunityRating);
         Assert.Same(ownEpisodeEntry, service.GetEntryForTest(Key(ownEpisodeId)));
         Assert.Same(ownSeasonEntry, service.GetEntryForTest(Key(ownSeasonId)));
+        Assert.Same(criticZeroEpisodeEntry, service.GetEntryForTest(Key(criticZeroEpisodeId)));
+        Assert.Same(criticSevenSeasonEntry, service.GetEntryForTest(Key(criticSevenSeasonId)));
     }
 
     [Fact]
@@ -1747,6 +1759,50 @@ public sealed class TagCacheDependencyInvalidationTests
         Assert.Equal(2, library.GetItemByIdCallCount); // Series discovery + Series rebuild; descendant uses snapshot
         Assert.Equal(9, service.GetEntryForTest(Key(descendants[0].Id))!.CommunityRating);
         Assert.Same(ownRatingSentinel, service.GetEntryForTest(Key(descendants[1].Id)));
+    }
+
+    [Fact]
+    public void EpisodeRelationshipRefresh_PreservesCriticOnlyChildRating()
+    {
+        var oldSeriesId = Guid.NewGuid();
+        var newSeriesId = Guid.NewGuid();
+        var newSeasonId = Guid.NewGuid();
+        var series = new StubSeries
+        {
+            Id = newSeriesId,
+            CommunityRating = 9,
+            CriticRating = 90,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "new-series" },
+        };
+        var episode = new StubEpisode
+        {
+            Id = Guid.NewGuid(),
+            SeriesId = newSeriesId,
+            SeasonId = newSeasonId,
+            ParentIndexNumber = 2,
+            CommunityRating = null,
+            CriticRating = 7,
+        };
+        var existing = new TagCacheEntry
+        {
+            Type = "Episode",
+            SeriesId = Key(oldSeriesId),
+            CommunityRating = null,
+            CriticRating = 7,
+        };
+
+        var refreshed = TagCacheDependencyGraph.ApplySeasonRelationshipRefresh(
+            series,
+            episode,
+            existing,
+            lastUpdated: 123);
+
+        Assert.Equal(Key(newSeriesId), refreshed.SeriesId);
+        Assert.Equal(Key(newSeasonId), refreshed.SeasonId);
+        Assert.Equal("new-series", refreshed.SeriesTmdbId);
+        Assert.Equal(2, refreshed.SeasonNumber);
+        Assert.Null(refreshed.CommunityRating);
+        Assert.Equal(7, refreshed.CriticRating);
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheReconcileTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheReconcileTests.cs
@@ -322,6 +322,74 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             finally { TryDelete(dir); }
         }
 
+        [Fact]
+        public void InitialBuild_PreservesCriticOnlyEpisodeAndSeasonRatings()
+        {
+            var dir = NewTempDir();
+            try
+            {
+                var seriesId = Guid.NewGuid();
+                var seasonId = Guid.NewGuid();
+                var episodeId = Guid.NewGuid();
+                var series = new StubSeries
+                {
+                    Id = seriesId,
+                    Name = "Series",
+                    DateLastSaved = T0,
+                    CommunityRating = 9.0f,
+                    CriticRating = 90,
+                    Genres = new[] { "Drama" },
+                };
+                var season = new StubSeason
+                {
+                    Id = seasonId,
+                    Name = "Season",
+                    DateLastSaved = T0,
+                    SeriesId = seriesId,
+                    CommunityRating = null,
+                    CriticRating = 7,
+                    Genres = Array.Empty<string>(),
+                };
+                var episode = new StubEpisode
+                {
+                    Id = episodeId,
+                    Name = "Episode",
+                    DateLastSaved = T0,
+                    SeriesId = seriesId,
+                    SeasonId = seasonId,
+                    CommunityRating = null,
+                    CriticRating = 0,
+                };
+                var scan = new List<BaseItem> { series, season, episode };
+                var lib = new CountingLibraryManager
+                {
+                    GetItemListHook = q => q.ParentId == Guid.Empty ? scan : new List<BaseItem> { episode },
+                    GetItemByIdHook = id => id == seriesId
+                        ? series
+                        : id == seasonId
+                            ? season
+                            : id == episodeId
+                                ? episode
+                                : null,
+                };
+                using var svc = NewSvc(lib, dir);
+
+                svc.BuildFullCache(null, CT);
+
+                var seasonEntry = svc.GetEntryForTest(Key(seasonId));
+                Assert.NotNull(seasonEntry);
+                Assert.Null(seasonEntry!.CommunityRating);
+                Assert.Equal(7, seasonEntry.CriticRating);
+                Assert.Equal(new[] { "Drama" }, seasonEntry.Genres);
+
+                var episodeEntry = svc.GetEntryForTest(Key(episodeId));
+                Assert.NotNull(episodeEntry);
+                Assert.Null(episodeEntry!.CommunityRating);
+                Assert.Equal(0, episodeEntry.CriticRating);
+            }
+            finally { TryDelete(dir); }
+        }
+
         // ── Probe failure: keep probe-independent data + last-good streams, retry until recovery ──
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheSpoilerStripTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheSpoilerStripTests.cs
@@ -357,19 +357,29 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
+        [InlineData(4)]
         public void LoadFromDisk_OldSchema_DiscardsEntries(int schemaVersion)
         {
             var dir = Path.Combine(Path.GetTempPath(), "jc-tagcache-" + Guid.NewGuid().ToString("N"));
             try
             {
                 var key = Guid.NewGuid().ToString("N");
-                WriteCache(dir, schemaVersion, key, new TagCacheEntry { Type = "Episode", SeriesId = null });
+                WriteCache(dir, schemaVersion, key, new TagCacheEntry
+                {
+                    Type = "Episode",
+                    SeriesId = null,
+                    // v4 can contain a stale parent 70 written when a child's
+                    // valid 7 was overwritten by the retired inheritance rule.
+                    CriticRating = schemaVersion == 4 ? 70 : null,
+                });
 
                 using var svc = NewServiceAt(dir);
                 svc.LoadFromDisk();
 
                 // v1 lacks SeriesId; v2 lacks SeasonId/StreamSourceId; v3 lacks
-                // Width and would preserve incorrect cropped/8K classifications.
+                // Width and would preserve incorrect cropped/8K classifications;
+                // v3-v4 may also contain ratings overwritten by the retired
+                // CommunityRating-only inheritance rule.
                 Assert.Equal(0, svc.Count);
             }
             finally
@@ -386,7 +396,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             {
                 var key = Guid.NewGuid().ToString("N");
                 var seriesN = Guid.NewGuid().ToString("N");
-                WriteCache(dir, schemaVersion: 4, key, new TagCacheEntry { Type = "Episode", SeriesId = seriesN });
+                WriteCache(dir, schemaVersion: 5, key, new TagCacheEntry { Type = "Episode", SeriesId = seriesN });
 
                 using var svc = NewServiceAt(dir);
                 svc.LoadFromDisk();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheDependencyGraph.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheDependencyGraph.cs
@@ -322,7 +322,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             var refreshed = existing.Clone();
             var kind = descendant.GetBaseItemKind();
-            var inheritsRatings = descendant.CommunityRating == null;
+            var inheritsRatings = TagCacheRatingInheritance.ShouldInherit(
+                descendant.CommunityRating,
+                descendant.CriticRating);
             var inheritsGenres = descendant is Season season
                 && season.CommunityRating == null
                 && (season.Genres?.Length ?? 0) == 0
@@ -376,7 +378,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             refreshed.SeriesTmdbId = series?.ProviderIds?.TryGetValue("Tmdb", out var tmdbId) == true
                 ? tmdbId
                 : null;
-            if (episode.CommunityRating == null)
+            if (TagCacheRatingInheritance.ShouldInherit(
+                episode.CommunityRating,
+                episode.CriticRating))
             {
                 refreshed.CommunityRating = series?.CommunityRating;
                 refreshed.CriticRating = series?.CriticRating;
@@ -424,9 +428,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     existing.SeriesTmdbId,
                     series.ProviderIds?.TryGetValue("Tmdb", out var tmdbId) == true ? tmdbId : null,
                     StringComparison.Ordinal),
-                nameof(TagCacheEntry.CommunityRating) => descendant.CommunityRating == null
+                nameof(TagCacheEntry.CommunityRating) => TagCacheRatingInheritance.ShouldInherit(
+                    descendant.CommunityRating,
+                    descendant.CriticRating)
                     && existing.CommunityRating != series.CommunityRating,
-                nameof(TagCacheEntry.CriticRating) => descendant.CommunityRating == null
+                nameof(TagCacheEntry.CriticRating) => TagCacheRatingInheritance.ShouldInherit(
+                    descendant.CommunityRating,
+                    descendant.CriticRating)
                     && existing.CriticRating != series.CriticRating,
                 nameof(TagCacheEntry.Genres) => descendant is Season season
                     && season.CommunityRating == null

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheRatingInheritance.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheRatingInheritance.cs
@@ -1,0 +1,16 @@
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    /// <summary>
+    /// Owns the rating-pair inheritance contract used by full builds and every
+    /// incremental parent-Series repair path.
+    /// </summary>
+    internal static class TagCacheRatingInheritance
+    {
+        /// <summary>
+        /// Returns true only when neither child rating exists. A valid zero or
+        /// single-digit critic percentage is owned data and must be preserved.
+        /// </summary>
+        internal static bool ShouldInherit(float? communityRating, float? criticRating)
+            => communityRating == null && criticRating == null;
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
@@ -196,9 +196,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // starts empty (client falls back to the live/per-batch strip) until rebuild.
         // v3 adds persisted Episode SeasonId and stream-source identity. Both are
         // correctness-critical dependency metadata, so older entries are rebuilt.
-        // v4 adds stream Width. Height alone cannot distinguish cropped DCI 8K
-        // from 4K, so retaining v3 entries would keep quality labels incorrect.
-        private const int CurrentCacheSchemaVersion = 4;
+        // v4 added stream Width so cropped DCI 8K is distinguishable from 4K
+        // (#681). v5 additionally invalidates rows produced by the former
+        // CommunityRating-only inheritance check, which could overwrite a
+        // child's valid CriticRating of 0 or 7 (#682).
+        private const int CurrentCacheSchemaVersion = 5;
 
         // User access cache: avoids expensive GetItemIds query on every request.
         // Jellyfin increments User.RowVersion for every persisted policy update,
@@ -3016,8 +3018,14 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         var series = ResolveParentSeriesOnce();
                         if (series != null)
                         {
-                            entry.CommunityRating = series.CommunityRating;
-                            entry.CriticRating = series.CriticRating;
+                            if (TagCacheRatingInheritance.ShouldInherit(
+                                entry.CommunityRating,
+                                entry.CriticRating))
+                            {
+                                entry.CommunityRating = series.CommunityRating;
+                                entry.CriticRating = series.CriticRating;
+                            }
+
                             if (entry.Genres == null || entry.Genres.Length == 0)
                             {
                                 entry.Genres = series.Genres;
@@ -3059,7 +3067,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                         entry.AudioLanguages = media.Value.Languages;
                     }
 
-                    if (kind == BaseItemKind.Episode && entry.CommunityRating == null)
+                    if (kind == BaseItemKind.Episode
+                        && TagCacheRatingInheritance.ShouldInherit(
+                            entry.CommunityRating,
+                            entry.CriticRating))
                     {
                         var series = ResolveParentSeriesOnce();
                         if (series != null)

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/critic-rating.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/critic-rating.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCriticPercent, ratingsAreMissing } from './critic-rating';
+
+describe('Jellyfin critic percentage contract (#682)', () => {
+    it.each([
+        [0, 0],
+        [-0, 0],
+        [7, 7],
+        [10, 10],
+        [10.1, 10],
+        [72, 72],
+        [99.5, 100],
+        [100, 100],
+    ])('keeps direct 0–100 values on their native scale (%s → %s)', (raw, expected) => {
+        expect(normalizeCriticPercent(raw)).toBe(expected);
+    });
+
+    it.each([
+        null,
+        undefined,
+        '',
+        '7',
+        true,
+        false,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+        -1,
+        -0.1,
+        100.1,
+        101,
+    ])('rejects missing, coerced, non-finite, or out-of-range input (%s)', (raw) => {
+        expect(normalizeCriticPercent(raw)).toBeNull();
+    });
+
+    it('inherits only when both raw child fields are nullish', () => {
+        expect(ratingsAreMissing({})).toBe(true);
+        expect(ratingsAreMissing({ CommunityRating: null, CriticRating: undefined })).toBe(true);
+        expect(ratingsAreMissing({ CommunityRating: 0, CriticRating: null })).toBe(false);
+        expect(ratingsAreMissing({ CommunityRating: null, CriticRating: 0 })).toBe(false);
+        expect(ratingsAreMissing({ CommunityRating: null, CriticRating: 7 })).toBe(false);
+        expect(ratingsAreMissing({ CommunityRating: null, CriticRating: -1 })).toBe(false);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/critic-rating.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/critic-rating.ts
@@ -1,0 +1,24 @@
+/** Minimal rating shape used by poster, pipeline, and player fallback decisions. */
+export interface RatingPair {
+    CommunityRating?: unknown;
+    CriticRating?: unknown;
+}
+
+/**
+ * Normalize Jellyfin's CriticRating contract to a display-ready percentage.
+ * Jellyfin stores Rotten Tomatoes as a direct 0–100 number; single digits are
+ * already percentages and must never be rescaled as a 0–10 score.
+ */
+export function normalizeCriticPercent(raw: unknown): number | null {
+    if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0 || raw > 100) {
+        return null;
+    }
+
+    const rounded = Math.round(raw);
+    return rounded === 0 ? 0 : rounded;
+}
+
+/** Parent ratings are eligible only when both child fields are genuinely absent. */
+export function ratingsAreMissing(item: RatingPair): boolean {
+    return item.CommunityRating == null && item.CriticRating == null;
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.identity.test.ts
@@ -79,6 +79,90 @@ describe('OSD rating identity lifecycle', () => {
         expect(container?.textContent).not.toContain('1.1');
     });
 
+    it('renders Jellyfin single-digit critic values as direct percentages', async () => {
+        mountPlayer('critic-direct-7');
+        const jf = vi.fn().mockResolvedValue({
+            Items: [{ Type: 'Movie', CommunityRating: null, CriticRating: 7 }],
+        });
+        JC.core.api = { jf } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeOsdRating!();
+        await flushPromises();
+        vi.advanceTimersByTime(200);
+        await flushPromises();
+
+        expect(jf).toHaveBeenCalledTimes(1);
+        expect(document.querySelector('#jc-osd-rating-container .critic .jc-text')?.textContent).toBe('7%');
+    });
+
+    it('preserves a child critic zero without fetching the parent Series', async () => {
+        mountPlayer('critic-child-zero');
+        const jf = vi.fn().mockResolvedValue({
+            Items: [{
+                Type: 'Season',
+                SeriesId: 'parent-series',
+                CommunityRating: null,
+                CriticRating: 0,
+            }],
+        });
+        JC.core.api = { jf } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeOsdRating!();
+        await flushPromises();
+        vi.advanceTimersByTime(200);
+        await flushPromises();
+
+        expect(jf).toHaveBeenCalledTimes(1);
+        expect(document.querySelector('#jc-osd-rating-container .critic .jc-text')?.textContent).toBe('0%');
+    });
+
+    it('fetches the parent Series only when both child rating fields are nullish', async () => {
+        mountPlayer('critic-child-missing');
+        const jf = vi.fn()
+            .mockResolvedValueOnce({
+                Items: [{
+                    Type: 'Episode',
+                    SeriesId: 'parent-series',
+                    CommunityRating: null,
+                    CriticRating: null,
+                }],
+            })
+            .mockResolvedValueOnce({
+                Items: [{ Type: 'Series', CommunityRating: null, CriticRating: 7 }],
+            });
+        JC.core.api = { jf } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeOsdRating!();
+        await flushPromises();
+        vi.advanceTimersByTime(200);
+        await flushPromises();
+        await flushPromises();
+
+        expect(jf).toHaveBeenCalledTimes(2);
+        expect(document.querySelector('#jc-osd-rating-container .critic .jc-text')?.textContent).toBe('7%');
+    });
+
+    it('omits invalid non-null critic data without falling back to the parent', async () => {
+        mountPlayer('critic-child-invalid');
+        const jf = vi.fn().mockResolvedValue({
+            Items: [{
+                Type: 'Episode',
+                SeriesId: 'parent-series',
+                CommunityRating: null,
+                CriticRating: -1,
+            }],
+        });
+        JC.core.api = { jf } as unknown as NonNullable<typeof JC.core.api>;
+
+        JC.initializeOsdRating!();
+        await flushPromises();
+        vi.advanceTimersByTime(200);
+        await flushPromises();
+
+        expect(jf).toHaveBeenCalledTimes(1);
+        expect(document.getElementById('jc-osd-rating-container')).toBeNull();
+    });
+
     it('cancels A player waits and keeps navigation subscriptions bounded', () => {
         const baseBodyCount = JC.core.dom!.getBodySubscriberCount();
         const baseNavCount = JC.core.navigation!.getNavCallbackCount();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/osd-rating.ts
@@ -4,6 +4,7 @@
 // (Converted from js/enhanced/osd-rating.js — bodies semantically identical.)
 
 import { JC } from '../globals';
+import { normalizeCriticPercent, ratingsAreMissing } from '../core/critic-rating';
 import { onBodyMutation } from '../core/dom-observer';
 import { onNavigate } from '../core/navigation';
 import { createStableMethodFacade } from '../core/feature-loader';
@@ -63,14 +64,6 @@ function isEnabled(): boolean {
   return JC.pluginConfig?.ShowRatingInPlayer !== false;
 }
 
-function normalizeCriticPercent(raw: unknown): number | null {
-  if (raw === null || raw === undefined) return null;
-  const num = Number(raw);
-  if (!Number.isFinite(num)) return null;
-  const percent = num <= 10 ? Math.round(num * 10) : Math.round(num);
-  return Math.max(0, Math.min(100, percent));
-}
-
 function createTomatoIcon(isRotten: boolean): HTMLSpanElement {
   const span = document.createElement('span');
   span.className = `jc-tomato ${isRotten ? 'rotten' : 'fresh'}`;
@@ -91,7 +84,7 @@ async function fetchItemRatings(
   try {
     const params = new URLSearchParams({
       Ids: itemId,
-      Fields: 'CommunityRating,CriticRating,Type'
+      Fields: 'CommunityRating,CriticRating,Type,SeriesId'
     });
     const result = await JC.core.api!.jf(`/Users/${context.userId}/Items?${params}`) as RatingItemsResponse;
     if (!isActive(context, expectedGeneration)) return { tmdb: null, critic: null };
@@ -99,11 +92,11 @@ async function fetchItemRatings(
     if (!item) return { tmdb: null, critic: null };
 
     let sourceItem = item;
-    if ((item.Type === 'Season' || item.Type === 'Episode') && item.SeriesId && !item.CommunityRating && !item.CriticRating) {
+    if ((item.Type === 'Season' || item.Type === 'Episode') && item.SeriesId && ratingsAreMissing(item)) {
       try {
         const seriesParams = new URLSearchParams({
           Ids: String(item.SeriesId),
-          Fields: 'CommunityRating,CriticRating,Type'
+          Fields: 'CommunityRating,CriticRating,Type,SeriesId'
         });
         const seriesResult = await JC.core.api!.jf(`/Users/${context.userId}/Items?${seriesParams}`) as RatingItemsResponse;
         if (!isActive(context, expectedGeneration)) return { tmdb: null, critic: null };

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.test.ts
@@ -1322,6 +1322,93 @@ describe('watched/privacy projection response ordering (BI-SEC-035)', () => {
         }
     });
 
+    it('requests a rating parent only for descendants whose full rating pair is nullish', async () => {
+        document.body.innerHTML = '';
+        const ownId = '68200000000000000000000000000001';
+        const ownParentId = '68200000000000000000000000000002';
+        const missingId = '68200000000000000000000000000003';
+        const missingParentId = '68200000000000000000000000000004';
+        const missingParent = {
+            Id: missingParentId,
+            Type: 'Series',
+            CommunityRating: null,
+            CriticRating: 7,
+        };
+        const oldConfig = JC.pluginConfig;
+        const oldUi = JC.core.ui;
+        JC.pluginConfig = {
+            ...oldConfig,
+            TagCacheServerMode: false,
+            SpoilerBlurEnabled: false,
+        };
+        JC.core.ui = {
+            injectCss: vi.fn(),
+            removeCss: vi.fn(),
+        } as unknown as NonNullable<typeof JC.core.ui>;
+        const currentUser = vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(userA);
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockImplementation((_userId, itemId) => {
+            if (itemId === missingParentId) return Promise.resolve(missingParent);
+            return Promise.reject(new Error(`unexpected parent lookup: ${itemId}`));
+        });
+        const ajax = vi.spyOn(ApiClient, 'ajax').mockResolvedValue({
+            Items: [
+                {
+                    Id: ownId,
+                    Type: 'Episode',
+                    SeriesId: ownParentId,
+                    CommunityRating: null,
+                    CriticRating: 0,
+                },
+                {
+                    Id: missingId,
+                    Type: 'Episode',
+                    SeriesId: missingParentId,
+                    CommunityRating: null,
+                    CriticRating: null,
+                },
+            ],
+        });
+        const rendered = new Map<string, { ratingParentSeries: unknown }>();
+        JC.tagPipeline!.registerRenderer('critic-parent-contract-test', {
+            isEnabled: () => true,
+            render: (_target: HTMLElement, rawItem: unknown, rawExtras: unknown) => {
+                const item = rawItem as { Id: string };
+                const extras = rawExtras as { ratingParentSeries: unknown };
+                rendered.set(item.Id, { ratingParentSeries: extras.ratingParentSeries });
+            },
+        });
+
+        try {
+            resetTagPipelineIdentity();
+            JC.tagPipeline!.initialize?.();
+            JC.tagPipeline!.clearProcessed?.();
+            for (const itemId of [ownId, missingId]) {
+                const image = gridCardImage();
+                const card = image.closest<HTMLElement>('.card')!;
+                card.dataset.id = itemId;
+                card.dataset.type = 'Episode';
+                document.body.appendChild(card);
+            }
+            JC.tagPipeline!.scheduleScan?.();
+
+            await vi.waitFor(() => expect(rendered.size).toBe(2));
+            expect(getItem).toHaveBeenCalledTimes(1);
+            expect(getItem).toHaveBeenCalledWith(userA, missingParentId);
+            expect(rendered.get(ownId)?.ratingParentSeries).toBeNull();
+            expect(rendered.get(missingId)?.ratingParentSeries).toBe(missingParent);
+        } finally {
+            history.pushState({}, '', `/critic-parent-contract-cleanup-${Date.now()}`);
+            (JC.tagPipeline as unknown as { unregisterRenderer(name: string): void })
+                .unregisterRenderer('critic-parent-contract-test');
+            ajax.mockRestore();
+            getItem.mockRestore();
+            currentUser.mockRestore();
+            JC.pluginConfig = oldConfig;
+            JC.core.ui = oldUi;
+            document.body.innerHTML = '';
+        }
+    });
+
     it('skips stale Series supplemental work and renders base data when the episode lookup fails', async () => {
         document.body.innerHTML = '';
         const disconnectedId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/tag-pipeline.ts
@@ -10,6 +10,7 @@
 // The pipeline handles all scanning, fetching, caching, and scheduling.
 
 import { JC } from '../globals';
+import { ratingsAreMissing } from '../core/critic-rating';
 import type { IdentityContext, TagPipelineLike } from '../types/jc';
 import { addCSS, clearItemCache, getItemCached } from './helpers';
 import { onBodyMutation } from '../core/dom-observer';
@@ -1961,7 +1962,7 @@ async function processBatch(
         for (const item of items) {
             if ((item.Type === 'Season' || item.Type === 'Episode') && item.SeriesId &&
                 item.RatingSuppressed !== true &&
-                !item.CommunityRating && !item.CriticRating) {
+                ratingsAreMissing(item)) {
                 parentSeriesNeeded.add(item.SeriesId);
             }
             // Genre also needs parent series for Season items
@@ -2017,7 +2018,7 @@ async function processBatch(
                 parentSeries = parentSeriesMap.get(parentId) || null;
                 if ((item.Type === 'Season' || item.Type === 'Episode') &&
                     item.RatingSuppressed !== true &&
-                    !item.CommunityRating && !item.CriticRating) {
+                    ratingsAreMissing(item)) {
                     ratingParentSeries = parentSeries;
                 }
             }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.server-cache.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.server-cache.test.ts
@@ -49,7 +49,7 @@ function spoilerGuard(hideRatings: boolean): SpoilerGuardApi {
     };
 }
 
-describe('rating tag guarded-Season projection parity (BI-SEC-125)', () => {
+describe('rating tag projection parity', () => {
     let renderer: RegisteredRenderer;
     let uninstallRatingTags: () => void;
 
@@ -182,5 +182,167 @@ describe('rating tag guarded-Season projection parity (BI-SEC-125)', () => {
             tmdbKey: '1234:s1',
             mediaType: 'tv',
         });
+    });
+
+    it('keeps a single-digit critic value unchanged in live and server-cache paths', () => {
+        JC.pluginConfig = { ...JC.pluginConfig, SpoilerBlurEnabled: false };
+        const live = cardHost();
+        renderer.render(live.host, {
+            Id: 'critic-live-7',
+            Type: 'Movie',
+            CommunityRating: null,
+            CriticRating: 7,
+        });
+        expect(live.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+
+        const server = cardHost();
+        renderer.renderFromServerCache(server.host, {
+            Type: 'Movie',
+            CommunityRating: null,
+            CriticRating: 7,
+        }, 'critic-server-7');
+        expect(server.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+    });
+
+    it('preserves a valid child zero instead of replacing it with a parent rating', () => {
+        JC.pluginConfig = { ...JC.pluginConfig, SpoilerBlurEnabled: false };
+        const { host } = cardHost();
+
+        renderer.render(host, {
+            Id: 'critic-child-zero',
+            Type: 'Season',
+            CommunityRating: null,
+            CriticRating: 0,
+        }, {
+            ratingParentSeries: { CommunityRating: 9.9, CriticRating: 99 },
+        });
+
+        expect(host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('0%');
+        expect(host.textContent).not.toContain('99%');
+    });
+
+    it('uses the parent critic percentage only when both child fields are nullish', () => {
+        JC.pluginConfig = { ...JC.pluginConfig, SpoilerBlurEnabled: false };
+        const { host } = cardHost();
+
+        renderer.render(host, {
+            Id: 'critic-child-missing',
+            Type: 'Episode',
+            CommunityRating: null,
+            CriticRating: null,
+        }, {
+            ratingParentSeries: { CommunityRating: null, CriticRating: 7 },
+        });
+
+        expect(host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+    });
+
+    it('omits invalid non-null critic data without silently falling back', () => {
+        JC.pluginConfig = { ...JC.pluginConfig, SpoilerBlurEnabled: false };
+        const { host } = cardHost();
+
+        renderer.render(host, {
+            Id: 'critic-child-invalid',
+            Type: 'Episode',
+            CommunityRating: null,
+            CriticRating: -1,
+        }, {
+            ratingParentSeries: { CommunityRating: 8.8, CriticRating: 88 },
+        });
+
+        expect(host.querySelector('.rating-overlay-container')).toBeNull();
+    });
+
+    it('loads persistent browser cache, rejects only its pre-contract row, and rewrites v2', () => {
+        JC.pluginConfig = {
+            ...JC.pluginConfig,
+            SpoilerBlurEnabled: false,
+            TagCacheServerMode: false,
+        };
+        const staleItemId = 'critic-stale-persistent-cache';
+        const currentItemId = 'critic-current-persistent-cache';
+        const context = JC.identity.capture();
+        expect(context).not.toBeNull();
+        const payloadKey = 'JellyfinCanopy-ratingTagsCache';
+        const ownerKey = `${payloadKey}:identity-owner`;
+        JC.storage.local.write(
+            'rating-tags',
+            ownerKey,
+            `${context!.serverId}:${context!.userId}`,
+            'cache-owner',
+        );
+        JC.storage.local.write(
+            'rating-tags',
+            payloadKey,
+            JSON.stringify({
+                [staleItemId]: { tmdb: null, critic: 70, sgType: 'Movie' },
+                [currentItemId]: {
+                    schemaVersion: 2,
+                    tmdb: null,
+                    critic: 7,
+                    sgType: 'Movie',
+                },
+            }),
+            'cache-payload',
+        );
+        const surface = JC as typeof JC & { initializeRatingTags?: () => void };
+        surface.initializeRatingTags?.();
+
+        try {
+            const current = cardHost();
+            expect(renderer.renderFromCache(current.host, currentItemId)).toBe(true);
+            expect(current.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+
+            const stale = cardHost();
+            expect(renderer.renderFromCache(stale.host, staleItemId)).toBe(false);
+            expect(stale.host.querySelector('.rating-overlay-container')).toBeNull();
+
+            const refreshed = cardHost();
+            renderer.render(refreshed.host, {
+                Id: staleItemId,
+                Type: 'Movie',
+                CommunityRating: null,
+                CriticRating: 7,
+            });
+            expect(refreshed.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+
+            const cached = cardHost();
+            expect(renderer.renderFromCache(cached.host, staleItemId)).toBe(true);
+            expect(cached.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+        } finally {
+            JC.storage.local.remove('rating-tags', payloadKey, 'cache-payload');
+            JC.storage.local.remove('rating-tags', ownerKey, 'cache-owner');
+        }
+    });
+
+    it('rejects and rewrites a pre-contract session-hot browser-cache row independently', () => {
+        JC.pluginConfig = {
+            ...JC.pluginConfig,
+            SpoilerBlurEnabled: false,
+            TagCacheServerMode: true,
+        };
+        const itemId = 'critic-stale-hot-cache';
+        const hot = (JC._hotCache as unknown as {
+            rating?: { set(key: string, value: unknown): void };
+        }).rating;
+        expect(hot).toBeDefined();
+        hot!.set(itemId, { tmdb: null, critic: 70, sgType: 'Movie' });
+
+        const stale = cardHost();
+        expect(renderer.renderFromCache(stale.host, itemId)).toBe(false);
+        expect(stale.host.querySelector('.rating-overlay-container')).toBeNull();
+
+        const refreshed = cardHost();
+        renderer.render(refreshed.host, {
+            Id: itemId,
+            Type: 'Movie',
+            CommunityRating: null,
+            CriticRating: 7,
+        });
+        expect(refreshed.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
+
+        const cached = cardHost();
+        expect(renderer.renderFromCache(cached.host, itemId)).toBe(true);
+        expect(cached.host.querySelector('.rating-tag-critic .rating-text')?.textContent).toBe('7%');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/ratingtags.ts
@@ -6,6 +6,7 @@
 // markup, and the synthetic items handed to the user-review tag module.
 
 import { JC as JEBase } from '../globals';
+import { normalizeCriticPercent, ratingsAreMissing } from '../core/critic-rating';
 import { createStableMethodFacade } from '../core/feature-loader';
 import { register, reinitialize, resolvePosition } from '../core/tag-renderer-base';
 import type { TagRendererContext, TagSpec } from '../types/jc';
@@ -54,18 +55,7 @@ function shouldSuppressRatingTag(item: SuppressionItem | null | undefined): bool
 const FRESH_TOMATO_DATA_URI = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMyIgcj0iOCIgZmlsbD0iI2Y5MzIwOCIvPjxwYXRoIGQ9Ik0xMiA1YzEtMiAzLTMgNS0zLTEgMi0yIDMtNCA0eiIgZmlsbD0iIzVhYTAyYyIvPjwvc3ZnPg==';
 const ROTTEN_TOMATO_DATA_URI = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTEyIDNjMiAzIDYgMyA2IDcgMCAzIDIgNCAxIDctMiA0LTggNC0xMSAxLTMtMy0yLTYtMS04IDEtMiAzLTMgNS03eiIgZmlsbD0iIzZiOGUyMyIvPjwvc3ZnPg==';
 
-/**
- * Normalize a raw critic rating to a 0-100 integer percentage.
- * @param raw - Raw critic rating value (may be on a 0-10 or 0-100 scale).
- * @returns Normalized percentage or null if invalid.
- */
-function normalizeCriticPercent(raw: unknown): number | null {
-    if (raw === null || raw === undefined) return null;
-    const num = Number(raw);
-    if (!Number.isFinite(num)) return null;
-    const percent = num <= 10 ? Math.round(num * 10) : Math.round(num);
-    return Math.max(0, Math.min(100, percent));
-}
+const RATING_CACHE_SCHEMA_VERSION = 2;
 
 /**
  * A cached rating entry as read back for the render paths. Carries the display
@@ -73,6 +63,8 @@ function normalizeCriticPercent(raw: unknown): number | null {
  * can re-evaluate suppression without the full item DTO.
  */
 interface RatingCacheEntry {
+    /** v2 stores Jellyfin critic values as direct 0–100 percentages. */
+    schemaVersion: number;
     tmdb: string | null;
     critic: number | null;
     /** Spoiler-Guard: the cached item's Type ('Series' | 'Season' | 'Episode' | 'Movie'). */
@@ -113,26 +105,25 @@ interface ServerCacheRatingEntry {
 function getCachedEntry(ctx: TagRendererContext, itemId: string): RatingCacheEntry | null {
     const entry: unknown = ctx.getPersistent(itemId) ?? ctx.hot?.get(itemId);
     if (!entry) return null;
-    // Spoiler Guard: entries cached BEFORE the guard fields existed (legacy
-    // string/number shorthand, or objects without sgType) carry no suppression
-    // context, so renderFromCache could replay a rating for a newly guarded
-    // item. While the feature is enabled, treat them as cache misses — the
-    // re-fetch stores a fresh entry WITH sg fields. Feature off → identical
-    // legacy behavior.
+    // Pre-v2 rows may contain the former <=10 ×10 critic transformation. Reject
+    // every shorthand/unversioned row so the live path refetches and overwrites
+    // it; the same validation covers persistent and session-hot caches.
     const guardOn = JC.pluginConfig?.SpoilerBlurEnabled === true;
     if (typeof entry === 'string' || typeof entry === 'number') {
-        return guardOn ? null : { tmdb: String(entry), critic: null };
+        return null;
     }
     if (typeof entry === 'object') {
         const cached = entry as Partial<RatingCacheEntry>;
+        if (cached.schemaVersion !== RATING_CACHE_SCHEMA_VERSION) return null;
         if (guardOn && typeof cached.sgType !== 'string') return null;
         // Expose ratings, personal-review identity, PLUS the Spoiler-Guard fields
         // stashed by render(). Without them, renderFromCache's
         // suppression re-check saw Type=undefined and never suppressed, so a
         // rating cached BEFORE the show was guarded replayed forever.
         return {
+            schemaVersion: RATING_CACHE_SCHEMA_VERSION,
             tmdb: cached.tmdb ?? null,
-            critic: cached.critic ?? null,
+            critic: normalizeCriticPercent(cached.critic),
             sgType: cached.sgType,
             sgSeriesId: cached.sgSeriesId ?? null,
             sgPlayed: cached.sgPlayed === true,
@@ -153,9 +144,14 @@ function getCachedEntry(ctx: TagRendererContext, itemId: string): RatingCacheEnt
  * @param itemId - Jellyfin item ID.
  * @param rating - Rating data to cache.
  */
-function setCachedEntry(ctx: TagRendererContext, itemId: string, rating: unknown): void {
-    ctx.setPersistent(itemId, rating);
-    ctx.hot?.set(itemId, rating);
+function setCachedEntry(
+    ctx: TagRendererContext,
+    itemId: string,
+    rating: Omit<RatingCacheEntry, 'schemaVersion'>,
+): void {
+    const versioned = { ...rating, schemaVersion: RATING_CACHE_SCHEMA_VERSION };
+    ctx.setPersistent(itemId, versioned);
+    ctx.hot?.set(itemId, versioned);
 }
 
 /** Keep the personal/user-review chip when public ratings are suppressed. */
@@ -384,7 +380,7 @@ const spec: TagSpec = {
 
             // Extract ratings from item, falling back to parent series for Season/Episode
             let sourceItem = item;
-            if (extras.ratingParentSeries && !item.CommunityRating && !item.CriticRating) {
+            if (extras?.ratingParentSeries && ratingsAreMissing(item)) {
                 sourceItem = extras.ratingParentSeries;
             }
 

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -283,6 +283,8 @@ Show which audio languages a title has as country flags. Language Tags display u
 
 Surface critic and audience scores where you're browsing. Rating Tags show **TMDB** star ratings and **Rotten Tomatoes** critic scores (fresh/rotten icons), stacked vertically on the poster and color-coded by value.
 
+Rotten Tomatoes values use Jellyfin's direct **0–100 percentage** contract: a stored value of `7` displays as **7%**, not 70%. Finite numeric values from 0 through 100 are rounded for display; invalid, non-numeric, negative, or over-100 critic values are omitted. A Season or Episode inherits its Series ratings only when both of its own rating fields are missing, so valid zero and single-digit critic scores are preserved.
+
 Ratings can also appear **in the player**. **Show Rating in Video Player** displays the item's TMDB and Rotten Tomatoes ratings in the video-player OSD, shown before the "Ends at" time.
 
 | Setting | Scope | Default | What it does |

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -169,6 +169,7 @@
     "e2e/spoiler-identity-tags.spec.ts › spoiler guard identity tags (reverse-proxy-safe attribution) › unknown or absent markers fail safe (legacy ladder, no errors)",
     "e2e/tags.spec.ts › tags › 8K dimensions render from a title-sanitized server-cache projection",
     "e2e/tags.spec.ts › tags › hide-on-hover fades the detail-page primary poster tags",
-    "e2e/tags.spec.ts › tags › home library cards get data-jc-*-tagged markers per enabled family"
+    "e2e/tags.spec.ts › tags › home library cards get data-jc-*-tagged markers per enabled family",
+    "e2e/tags.spec.ts › tags › single-digit Jellyfin critic values stay single-digit on real poster cards"
   ]
 }

--- a/e2e/tags.spec.ts
+++ b/e2e/tags.spec.ts
@@ -139,6 +139,89 @@ test.describe('tags', () => {
         expect(consoleErrors.real()).toEqual([]);
     });
 
+    test('single-digit Jellyfin critic values stay single-digit on real poster cards', async ({ page, consoleErrors }) => {
+        const routePattern = '**/JellyfinCanopy/tag-cache/**';
+        const injectedIds = new Set<string>();
+        await page.route(routePattern, async (route) => {
+            const response = await route.fetch();
+            const url = new URL(route.request().url());
+            const body = await response.json() as {
+                items?: Record<string, Record<string, unknown>>;
+                Items?: Record<string, Record<string, unknown>>;
+            };
+
+            // Modify only the full projected snapshot. Cursor validation/delta
+            // responses must remain byte-semantically honest or the pipeline
+            // will correctly discard the prefetch and request another snapshot.
+            const items = body.items ?? body.Items;
+            if (url.search === '' && items && typeof items === 'object') {
+                for (const [id, rawEntry] of Object.entries(items)) {
+                    if (!rawEntry || rawEntry.RatingSuppressed === true) continue;
+                    items[id] = {
+                        ...rawEntry,
+                        CommunityRating: null,
+                        CriticRating: 7,
+                    };
+                    injectedIds.add(id.replace(/-/g, '').toLowerCase());
+                }
+            }
+
+            await route.fulfill({ response, json: body });
+        });
+
+        try {
+            await loginAs(page, 'admin', consoleErrors);
+            expect(await page.evaluate(() => (
+                (window as any).JellyfinCanopy?.currentSettings?.ratingTagsEnabled
+            ))).toBe(true);
+            await expect.poll(() => injectedIds.size, { timeout: 60_000 }).toBeGreaterThan(0);
+            await page.waitForSelector('#indexPage .card', { timeout: 60_000 });
+
+            const ids = [...injectedIds];
+            await page.waitForFunction((expectedIds) => {
+                const expected = new Set(expectedIds);
+                return [...document.querySelectorAll<HTMLElement>('#indexPage .cardImageContainer')]
+                    .some((image) => {
+                        const backgroundId = image.style.backgroundImage
+                            .match(/Items\/([a-f0-9]{32})\//i)?.[1];
+                        const owner = image.closest<HTMLElement>('[data-id], [data-itemid]');
+                        const rawId = backgroundId
+                            ?? owner?.getAttribute('data-id')
+                            ?? owner?.getAttribute('data-itemid');
+                        const id = rawId?.replace(/-/g, '').toLowerCase();
+                        return !!id
+                            && expected.has(id)
+                            && !!image.closest('.card')?.querySelector('.rating-tag-critic .rating-text');
+                    });
+            }, ids, { timeout: 60_000 });
+            const rendered = await page.evaluate((expectedIds) => {
+                const expected = new Set(expectedIds);
+                return [...document.querySelectorAll<HTMLElement>('#indexPage .cardImageContainer')]
+                    .flatMap((image) => {
+                        const backgroundId = image.style.backgroundImage
+                            .match(/Items\/([a-f0-9]{32})\//i)?.[1];
+                        const owner = image.closest<HTMLElement>('[data-id], [data-itemid]');
+                        const rawId = backgroundId
+                            ?? owner?.getAttribute('data-id')
+                            ?? owner?.getAttribute('data-itemid');
+                        const id = rawId?.replace(/-/g, '').toLowerCase();
+                        if (!id || !expected.has(id)) return [];
+                        const text = image.closest('.card')
+                            ?.querySelector<HTMLElement>('.rating-tag-critic .rating-text')
+                            ?.textContent;
+                        return text ? [text] : [];
+                    });
+            }, ids);
+            expect(rendered.length).toBeGreaterThan(0);
+            expect(rendered.every((text) => text === '7%')).toBe(true);
+
+            expect(consoleErrors.unexpected5xx(), 'unexpected 5xx responses').toEqual([]);
+            expect(consoleErrors.real()).toEqual([]);
+        } finally {
+            await page.unroute(routePattern);
+        }
+    });
+
     // Regression: "Hide Tags on Hover" must hide the tags on the detail-page
     // primary poster too. That poster is a `.card` with NO `.cardOverlayContainer`,
     // so its tags render straight into `.cardScalable` with no `.jc-tag-host`

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 173,
+    "maxOutputCount": 175,
     "maxEsmEntryCount": 38,
-    "maxEsmOutputCount": 83,
+    "maxEsmOutputCount": 84,
     "maxIndividualEsmRawBytes": 262144,
     "maxBootRequests": 17,
     "maxBootRawBytes": 524288,
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7232859,
+    "maxTotalRawBytes": 7233308,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7317793
+    "maxPublishedRawBytes": 7318915
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,20 +25,20 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2805, totalLines: 3191 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 43458, totalLines: 53159 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2811, totalLines: 3196 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 43473, totalLines: 53174 });
     assert.deepEqual(baselines.profiles.client.observations, {
-        cleanRuns: 3,
-        minimumCoveredLines: 2805,
-        maximumCoveredLines: 2805,
+        cleanRuns: 2,
+        minimumCoveredLines: 2811,
+        maximumCoveredLines: 2811,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 2,
-        minimumCoveredLines: 43451,
-        maximumCoveredLines: 43458,
+        cleanRuns: 3,
+        minimumCoveredLines: 43470,
+        maximumCoveredLines: 43473,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,34 +10,34 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2805,
-        "totalLines": 3191
+        "coveredLines": 2811,
+        "totalLines": 3196
       },
       "observations": {
-        "cleanRuns": 3,
-        "minimumCoveredLines": 2805,
-        "maximumCoveredLines": 2805
+        "cleanRuns": 2,
+        "minimumCoveredLines": 2811,
+        "maximumCoveredLines": 2811
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The #683 playback action-sheet lifecycle tests exercise the canonical core action-sheet close path while keeping the instrumented client/core scope fixed. Three clean Node/V8 runs on 2026-08-05 each passed all 2,052 tests across 245 files with zero unhandled errors and reproduced exactly 2,805/3,191 (87.903%). This advances the prior same-scope 2,798/3,191 high-water by seven covered lines without adding or removing an instrumented line. The exact observed envelope needs no instrumentation tolerance, so the reviewed floor and high-water are both 2,805/3,191. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "The issue-682 client changes add critic-rating parsing helpers and OSD/tag-pipeline coverage. The official CI client coverage gate measured 2,811/3,196 (87.954%) on this exact tree."
       }
     },
     "server": {
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 43458,
-        "totalLines": 53159
+        "coveredLines": 43473,
+        "totalLines": 53174
       },
       "observations": {
-        "cleanRuns": 2,
-        "minimumCoveredLines": 43451,
-        "maximumCoveredLines": 43458
+        "cleanRuns": 3,
+        "minimumCoveredLines": 43470,
+        "maximumCoveredLines": 43473
       },
       "tolerance": {
-        "missingCoveredLines": 7,
-        "rationale": "Rebased onto current main. Two clean CI coverage runs on this exact tree and 53159-line scope observed 43451 and 43458 covered lines; the 7-line envelope is timing-dependent branch coverage in the tag-cache asynchronous paths, not a source or test difference. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 3,
+        "rationale": "The issue-682 fix preserves direct critic percentages (including zero and single-digit Rotten Tomatoes scores) through tag-cache rating inheritance and bumps the cache schema to v5 so rows written under the retired CommunityRating-only rule are invalidated. Rebased onto current main, three clean CI coverage runs on this exact tree and 53,174-line scope observed 43,472, 43,473 and 43,470 covered lines. The three-line envelope is timing-dependent branch coverage in the tag-cache monitor's asynchronous invalidation paths, not a source or test difference; the spread is 0.006 percentage points, far inside the 0.15pp policy bound. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- treat Jellyfin `CriticRating` as a strict direct 0–100 percentage, so `7` renders as `7%` rather than `70%`
- preserve valid zero and single-digit child ratings by inheriting from a Series only when both child rating fields are nullish
- apply the same contract to poster live data, server-cache projections, parent fallback, tag-pipeline prefetch, and player OSD
- invalidate pre-contract browser rating rows (persistent and session-hot) and server tag-cache rows, then rebuild them under the new contract
- document the direct-percentage and inheritance behavior

Fixes #682

## Implementation notes

The client now uses one import-pure strict normalizer. It accepts only finite numeric values in the inclusive 0–100 range, rounds for display, never coerces strings/booleans, and never rescales single digits.

The server uses one shared rating-pair inheritance predicate in full cache construction and every current incremental Series/Season relationship-refresh path. Server cache schema v5 invalidates rows produced by the former `CommunityRating`-only inheritance rule; v4 remains reserved for PR #691's width-preserving quality projection. The browser rating cache uses schema v2 and rejects unversioned rows from both durable and hot caches.

This PR was developed with AI assistance. I reviewed the complete implementation and test evidence and understand the changes.

## Validation

- focused client contract/parity/migration suites: 74/74 passed
- full client suite: 245 files and 2,071/2,071 tests passed
- client coverage: four clean final-source observations at exactly 2,804/3,196 lines (87.735%); final blocking ratchet passed with zero tolerance
- focused server cache/reconcile/dependency suites: 101/101 passed
- full server suite: 4,108/4,108 passed under pinned .NET 10.0.9
- server coverage: five clean 4,108-test observations at 42,801, 42,807, 42,802, 42,809 (hosted), and 42,801 (final local) of 52,607 lines; reviewed floor/high-water 81.360–81.375%, and the final retained report passes the blocking ratchet
- repository script suite: 649/649 passed; coverage-policy boundaries: 14/14 passed
- deterministic bundle: 175 outputs, build `21208ecf347e120ad5c2eee2758e47c3d7b8b8491bc2d93f5e5e06c9773b918a`; all request/byte budgets remain below their existing limits
- `typecheck:src`, legacy `typecheck`, syntax inventory, performance rules, advisory lint, and `git diff --check` passed
- zero-warning Release build passed
- hash-locked offline documentation gate and strict MkDocs build passed
- disposable Jellyfin 12 browser validation: complete `e2e/tags.spec.ts` passed 3/3; the new test correlates intercepted server-cache item IDs to real poster cards and requires every matched critic chip to equal `7%`, with no console or unexpected 5xx errors
- final independent whole-diff and coverage-evidence review: APPROVE at `9fb9cb48`

Screenshots are not applicable: this corrects the numeric value shown by the existing rating chip without changing its layout or styling; the exact rendered value is covered by the real-browser regression.

## Failed/setup attempts retained as evidence

- the first focused client run exposed an undefined optional `extras` path; the source was corrected to use an optional access and the final focused suite passes 74/74
- the first bundle ratchet correctly rejected the two new helper artifacts (175 outputs / 84 ESM outputs versus 173 / 83); exact artifact measurement showed every byte/request budget still green, so only those two count limits were advanced
- initial client and server coverage runs passed their complete test suites but correctly rejected intentional scope drift until reviewed baselines were recorded
- after the reviewer split persistent and hot cache migration evidence, three clean 2,804/3,196 client runs correctly rejected the then-stale 2,803 high-water; the exact four-run high-water is now recorded and the final command passes
- one post-commit server coverage rerun passed 4,107 tests and failed one test before the coverage checker ran; its console output was truncated and that invocation emitted no TRX. No assertion, timeout, or production code was changed. An immediate no-build rerun with an explicit TRX passed all 4,108 tests, matching the clean coverage runs
- the first hosted Unit job passed all 4,108 tests and measured 42,809/52,607, correctly rejecting the then-stale 42,807 high-water. Independently approved commit `9fb9cb48` records the resulting five-run 42,801–42,809 envelope; no production or xUnit source changed

## Open-PR sequencing

PRs #688 and #691 overlap tag-cache code and remain open against the same `main` base. If either lands first, this PR needs a semantic rebase: #688's added cache-based inheritance paths must use the shared both-null predicate, and the persisted cache schema must remain monotonic. Contributor auto-merge is intentionally not requested.
