### PR TITLE
fix(playback): wait for track sheets before cycling

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.action-sheet.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.action-sheet.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import { installPlayback } from './playback';
+
+const mocks = vi.hoisted(() => ({ toast: vi.fn() }));
+vi.mock('../core/ui-kit', () => ({ toast: mocks.toast }));
+
+type TrackKind = 'subtitle' | 'audio';
+
+interface MountedSheet {
+    readonly container: HTMLElement;
+    readonly scroller: HTMLElement;
+    readonly clicks: ReturnType<typeof vi.fn>[];
+}
+
+function mountTrigger(kind: TrackKind, title = kind === 'subtitle' ? 'Subtitles' : 'Audio'): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.className = kind === 'subtitle' ? 'btnSubtitles' : 'btnAudio';
+    button.title = title;
+    document.body.appendChild(button);
+    return button;
+}
+
+function mountSheet(
+    kind: TrackKind,
+    title: string,
+    labels: string[],
+    currentIndex = 0,
+    ids: Array<string | undefined> = [],
+): MountedSheet {
+    const container = document.createElement('div');
+    container.className = 'dialogContainer';
+    const content = document.createElement('div');
+    content.className = 'actionSheetContent';
+    const heading = document.createElement('div');
+    heading.className = 'actionSheetTitle';
+    heading.textContent = title;
+    const scroller = document.createElement('div');
+    scroller.className = 'actionSheetScroller';
+    const clicks: ReturnType<typeof vi.fn>[] = [];
+
+    labels.forEach((label, index) => {
+        const row = document.createElement('button');
+        row.className = 'listItem';
+        if (ids[index]) row.dataset.id = ids[index];
+        const icon = document.createElement('span');
+        icon.className = 'actionsheetMenuItemIcon listItemIcon' + (index === currentIndex ? ' check' : '');
+        if (index === currentIndex) icon.style.visibility = 'visible';
+        const text = document.createElement('div');
+        text.className = kind === 'audio'
+            ? 'listItemBodyText actionSheetItemText'
+            : 'listItemBodyText';
+        text.textContent = label;
+        const click = vi.fn();
+        row.addEventListener('click', click);
+        clicks.push(click);
+        row.append(icon, text);
+        scroller.appendChild(row);
+    });
+
+    content.append(heading, scroller);
+    container.appendChild(content);
+    document.body.appendChild(container);
+    return { container, scroller, clicks };
+}
+
+async function flushMutations(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('playback track action-sheet readiness', () => {
+    let disposePlayback: (() => void) | undefined;
+    let translate: ReturnType<typeof vi.fn>;
+    let escapeHtml: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        document.body.innerHTML = '';
+        window.history.replaceState(null, '', '/web/index.html#/video?id=track-test');
+        const surface = JC as unknown as Record<string, unknown>;
+        surface.isVideoPage = () => window.location.hash.startsWith('#/video');
+        translate = vi.fn((key: string) => key);
+        escapeHtml = vi.fn((value: unknown) => `escaped:${String(value)}`);
+        surface.t = translate;
+        surface.escapeHtml = escapeHtml;
+        JC.identity.transition('track-server', 'track-user', 'track-sheet-test');
+        disposePlayback = installPlayback();
+        mocks.toast.mockReset();
+    });
+
+    afterEach(() => {
+        disposePlayback?.();
+        disposePlayback = undefined;
+        JC.identity.transition('', '', 'track-sheet-cleanup');
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+        window.history.replaceState(null, '', '/web/index.html#/home');
+        vi.restoreAllMocks();
+    });
+
+    it.each([
+        { kind: 'subtitle' as const, invoke: () => JC.cycleSubtitleTrack!(), title: 'Subtitles', toastKey: 'toast_subtitle' },
+        { kind: 'audio' as const, invoke: () => JC.cycleAudioTrack!(), title: 'Audio', toastKey: 'toast_audio' },
+    ])('cycles $kind exactly once when its rows mount after 200 ms', async ({ kind, invoke, title, toastKey }) => {
+        const trigger = mountTrigger(kind, title);
+        const triggerClick = vi.spyOn(trigger, 'click');
+
+        invoke();
+        vi.advanceTimersByTime(250);
+        expect(mocks.toast).not.toHaveBeenCalled();
+        const sheet = mountSheet(kind, title, ['Current', 'Next'], 0);
+        await flushMutations();
+
+        expect(triggerClick).toHaveBeenCalledTimes(1);
+        expect(sheet.clicks[0]).not.toHaveBeenCalled();
+        expect(sheet.clicks[1]).toHaveBeenCalledTimes(1);
+        expect(escapeHtml).toHaveBeenCalledWith('Next');
+        expect(translate).toHaveBeenCalledWith(
+            toastKey,
+            kind === 'subtitle' ? { subtitle: 'escaped:Next' } : { audio: 'escaped:Next' },
+        );
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(3_000);
+        expect(sheet.clicks[1]).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        { kind: 'subtitle' as const, invoke: () => JC.cycleSubtitleTrack!(), title: 'Subtitles' },
+        { kind: 'audio' as const, invoke: () => JC.cycleAudioTrack!(), title: 'Audio' },
+    ])('settles an atomic $kind mount exactly once', async ({ kind, invoke, title }) => {
+        const trigger = mountTrigger(kind, title);
+        let sheet: MountedSheet | undefined;
+        trigger.addEventListener('click', () => {
+            sheet = mountSheet(kind, title, ['Current', 'Next'], 0);
+        });
+
+        invoke();
+        expect(sheet).toBeDefined();
+        expect(sheet!.clicks[1]).toHaveBeenCalledTimes(1);
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+        await flushMutations();
+        vi.advanceTimersByTime(3_000);
+
+        expect(sheet!.clicks[1]).toHaveBeenCalledTimes(1);
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        { kind: 'subtitle' as const, invoke: () => JC.cycleSubtitleTrack!(), title: 'Subtitles', key: 'toast_no_subtitles_found' },
+        { kind: 'audio' as const, invoke: () => JC.cycleAudioTrack!(), title: 'Audio', key: 'toast_no_audio_tracks_found' },
+    ])('warns once only after the bounded window for an empty $kind sheet', ({ kind, invoke, title, key }) => {
+        const trigger = mountTrigger(kind, title);
+        const sheet = mountSheet(kind, title, []);
+        const dispatch = vi.spyOn(sheet.container, 'dispatchEvent');
+        const triggerClick = vi.spyOn(trigger, 'click');
+        let duplicateMounted = false;
+        trigger.addEventListener('click', () => {
+            duplicateMounted = true;
+            mountSheet(kind, title, ['Unexpected'], 0);
+        });
+
+        invoke();
+        expect(triggerClick).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(2_999);
+        expect(mocks.toast).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+        expect(mocks.toast).toHaveBeenCalledWith(key, undefined, 'warning');
+        expect(dispatch).toHaveBeenCalled();
+        expect(duplicateMounted).toBe(false);
+        vi.advanceTimersByTime(3_000);
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+    });
+
+    it('coalesces repeated same-kind presses while the sheet is opening', async () => {
+        const trigger = mountTrigger('audio');
+        const triggerClick = vi.spyOn(trigger, 'click');
+
+        JC.cycleAudioTrack!();
+        JC.cycleAudioTrack!();
+        const sheet = mountSheet('audio', 'Audio', ['English', 'Commentary'], 0);
+        await flushMutations();
+
+        expect(triggerClick).toHaveBeenCalledTimes(1);
+        expect(sheet.clicks[1]).toHaveBeenCalledTimes(1);
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets the latest cross-kind press win without a stale click or warning', async () => {
+        mountTrigger('audio');
+        mountTrigger('subtitle');
+
+        JC.cycleAudioTrack!();
+        JC.cycleSubtitleTrack!();
+        const staleAudio = mountSheet('audio', 'Audio', ['English', 'Commentary'], 0);
+        await flushMutations();
+        const subtitles = mountSheet('subtitle', 'Subtitles', ['Off', 'English'], 0);
+        await flushMutations();
+
+        expect(staleAudio.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(subtitles.clicks[1]).toHaveBeenCalledTimes(1);
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(3_000);
+        expect(mocks.toast).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the localized trigger title, the newest sheet, and stable secondary-subtitle id', async () => {
+        mountTrigger('subtitle', 'Untertitel');
+        const stale = mountSheet('subtitle', 'Untertitel', ['Stale current', 'Stale next'], 0);
+        const unrelated = mountSheet('audio', 'Tonspuren', ['Deutsch', 'English'], 0);
+
+        JC.cycleSubtitleTrack!();
+        const live = mountSheet(
+            'subtitle',
+            'Untertitel',
+            ['Sekundäre Untertitel', 'Deutsch', 'English'],
+            1,
+            ['secondarysubtitle', 'de', 'en'],
+        );
+        await flushMutations();
+
+        expect(stale.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(unrelated.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(live.clicks[0]).not.toHaveBeenCalled();
+        expect(live.clicks[2]).toHaveBeenCalledTimes(1);
+        expect(translate).toHaveBeenCalledWith('toast_subtitle', { subtitle: 'escaped:English' });
+    });
+
+    it('cancels silently when an owned target sheet is replaced', async () => {
+        const trigger = mountTrigger('audio');
+        const original = mountSheet('audio', 'Audio', []);
+        const triggerClick = vi.spyOn(trigger, 'click');
+
+        JC.cycleAudioTrack!();
+        expect(triggerClick).not.toHaveBeenCalled();
+        original.container.remove();
+        const replacement = mountSheet('audio', 'Audio', ['Replacement current', 'Replacement next'], 0);
+        const replacementDispatch = vi.spyOn(replacement.container, 'dispatchEvent');
+        await flushMutations();
+        vi.advanceTimersByTime(3_000);
+
+        expect(replacement.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(replacementDispatch).not.toHaveBeenCalled();
+        expect(mocks.toast).not.toHaveBeenCalled();
+    });
+
+    it('does not orphan readiness resources when a repeat races sheet replacement', async () => {
+        mountTrigger('audio');
+        const observe = vi.spyOn(MutationObserver.prototype, 'observe');
+        const disconnect = vi.spyOn(MutationObserver.prototype, 'disconnect');
+        const original = mountSheet('audio', 'Audio', []);
+
+        JC.cycleAudioTrack!();
+        expect(vi.getTimerCount()).toBe(1);
+        original.container.remove();
+        const replacement = mountSheet('audio', 'Audio', ['Replacement current', 'Replacement next'], 0);
+        JC.cycleAudioTrack!();
+
+        expect(observe).toHaveBeenCalledTimes(1);
+        expect(disconnect).toHaveBeenCalledTimes(1);
+        expect(vi.getTimerCount()).toBe(0);
+        await flushMutations();
+        vi.advanceTimersByTime(3_000);
+        expect(replacement.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(mocks.toast).not.toHaveBeenCalled();
+    });
+
+    it('cancels silently when navigation leaves the video route', async () => {
+        mountTrigger('audio');
+        JC.cycleAudioTrack!();
+
+        window.history.replaceState(null, '', '/web/index.html#/home');
+        const late = mountSheet('audio', 'Audio', ['English', 'Commentary'], 0);
+        await flushMutations();
+        vi.advanceTimersByTime(3_000);
+
+        expect(late.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(mocks.toast).not.toHaveBeenCalled();
+    });
+
+    it('cancels silently across an account transition', async () => {
+        mountTrigger('subtitle');
+        JC.cycleSubtitleTrack!();
+
+        JC.identity.transition('track-server-b', 'track-user-b', 'track-sheet-test');
+        const late = mountSheet('subtitle', 'Subtitles', ['Off', 'English'], 0);
+        await flushMutations();
+        vi.advanceTimersByTime(3_000);
+
+        expect(late.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(mocks.toast).not.toHaveBeenCalled();
+    });
+
+    it('cancels silently when the playback feature is disposed', async () => {
+        mountTrigger('audio');
+        JC.cycleAudioTrack!();
+        disposePlayback?.();
+        disposePlayback = undefined;
+
+        const late = mountSheet('audio', 'Audio', ['English', 'Commentary'], 0);
+        await flushMutations();
+        vi.advanceTimersByTime(3_000);
+
+        expect(late.clicks.every((click) => click.mock.calls.length === 0)).toBe(true);
+        expect(mocks.toast).not.toHaveBeenCalled();
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/playback.ts
@@ -6,10 +6,12 @@
 import { JC } from '../globals';
 import { toast } from '../core/ui-kit';
 import { createStableMethodFacade } from '../core/feature-loader';
+import { onBodyMutation } from '../core/dom-observer';
+import { closeOpenActionSheet, getActiveActionSheetScroller } from '../core/action-sheet';
 import { createAutoSkipEngine,
     createSessionItemResolver, parseTranscodeOffsetTicksFromSrc } from './auto-skip';
 import type { AutoSkipEngine, MediaSegment, VideoLike } from './auto-skip';
-import type { IdentityContext } from '../types/jc';
+import type { BodySubscriberHandle, IdentityContext } from '../types/jc';
 
 interface FpsStream {
     Type?: string;
@@ -509,98 +511,194 @@ const skipIntroOutro = (): void => {
 /**
  * Cycles through available subtitle tracks in the OSD menu.
  */
-const cycleSubtitleTrack = (): void => {
-    const context = JC.identity.capture();
-    if (!context) return;
-    const performCycle = () => {
-        if (!JC.identity.isCurrent(context)) return;
-        const allItems = document.querySelectorAll('.actionSheetContent .listItem');
-        if (allItems.length === 0) {
-            toast(JC.t!('toast_no_subtitles_found'), undefined, 'warning');
-            document.body.click();
-            return;
-        }
+type TrackSheetKind = 'subtitle' | 'audio';
 
-        const subtitleOptions = Array.from(allItems).filter(item => {
-            const textElement = item.querySelector('.listItemBodyText');
-            return textElement && textElement.textContent.trim() !== 'Secondary Subtitles';
-        });
+interface PendingTrackCycle {
+    readonly kind: TrackSheetKind;
+    readonly context: IdentityContext;
+    readonly expectedGeneration: number;
+    readonly expectedTitle: string;
+    readonly ignoredTitle: string | null;
+    ignoredScroller: HTMLElement | null;
+    ownedScroller: HTMLElement | null;
+    observer: BodySubscriberHandle | null;
+    deadlineTimer: number | null;
+}
 
-        if (subtitleOptions.length === 0) {
-            toast(JC.t!('toast_no_subtitles_found'), undefined, 'warning');
-            document.body.click();
-            return;
-        }
+// An empty mounted sheet is a real outcome, but a slow sheet must not be
+// mistaken for it. Three seconds matches the existing bounded aspect-sheet
+// backstop and remains explicitly retryable through another shortcut press.
+const TRACK_SHEET_READY_DEADLINE_MS = 3_000;
+let trackSheetSubscriberSequence = 0;
+let pendingTrackCycle: PendingTrackCycle | null = null;
 
-        const currentIndex = subtitleOptions.findIndex(option => {
-            const checkIcon = option.querySelector('.listItemIcon.check');
-            return checkIcon && getComputedStyle(checkIcon).visibility !== 'hidden';
-        });
+function trackTrigger(kind: TrackSheetKind): HTMLElement | null {
+    return document.querySelector<HTMLElement>(kind === 'subtitle' ? 'button.btnSubtitles' : 'button.btnAudio');
+}
 
-        const nextIndex = (currentIndex + 1) % subtitleOptions.length;
-        const nextOption = subtitleOptions[nextIndex];
+function normalizedSheetTitle(value: string | null | undefined): string {
+    return (value || '').replace(/\s+/g, ' ').trim();
+}
 
-        if (nextOption) {
-            (nextOption as HTMLElement).click();
-            const subtitleName = nextOption.querySelector('.listItemBodyText')!.textContent.trim();
-            toast(JC.t!('toast_subtitle', { subtitle: JC.escapeHtml(subtitleName) }));
-        }
-    };
+function trackTitle(kind: TrackSheetKind, trigger: HTMLElement | null): string {
+    return normalizedSheetTitle(trigger?.getAttribute('title') || trigger?.getAttribute('aria-label'))
+        || (kind === 'subtitle' ? 'Subtitles' : 'Audio');
+}
 
-    const subtitleMenuTitle = Array.from(document.querySelectorAll('.actionSheetContent .actionSheetTitle')).find(el => el.textContent === 'Subtitles');
-    if (subtitleMenuTitle) {
-        performCycle();
-    } else {
-        if (document.querySelector('.actionSheetContent')) {
-            document.body.click();
-        }
-        document.querySelector<HTMLElement>('button.btnSubtitles')?.click();
-        schedulePlaybackTimer(context, performCycle, 200);
+function activeSheetTitle(scroller: HTMLElement): string {
+    const content = scroller.closest<HTMLElement>('.actionSheetContent');
+    return normalizedSheetTitle(
+        content?.querySelector<HTMLElement>('.actionSheetTitle')?.textContent
+        || scroller.querySelector<HTMLElement>('.actionSheetTitle')?.textContent
+    );
+}
+
+function optionsForTrack(kind: TrackSheetKind, scroller: HTMLElement): HTMLElement[] {
+    const rows = Array.from(scroller.querySelectorAll<HTMLElement>('.listItem'));
+    if (kind === 'subtitle') {
+        return rows.filter((row) => row.dataset.id !== 'secondarysubtitle'
+            && row.querySelector('.listItemBodyText') !== null);
     }
-};
+    return rows.filter((row) => row.querySelector('.listItemBodyText.actionSheetItemText') !== null);
+}
 
-/**
- * Cycles through available audio tracks in the OSD menu.
- */
-const cycleAudioTrack = (): void => {
-    const context = JC.identity.capture();
-    if (!context) return;
-    const performCycle = () => {
-        if (!JC.identity.isCurrent(context)) return;
-        const audioOptions = Array.from(document.querySelectorAll('.actionSheetContent .listItem')).filter(item => item.querySelector('.listItemBodyText.actionSheetItemText'));
+function cancelPendingTrackCycle(expected?: PendingTrackCycle): void {
+    const pending = pendingTrackCycle;
+    if (!pending || (expected && pending !== expected)) return;
+    pendingTrackCycle = null;
+    cancelPlaybackTimer(pending.deadlineTimer);
+    pending.deadlineTimer = null;
+    pending.observer?.unsubscribe();
+    pending.observer = null;
+}
 
-        if (audioOptions.length === 0) {
-            toast(JC.t!('toast_no_audio_tracks_found'), undefined, 'warning');
-            document.body.click();
-            return;
-        }
+function trackCycleIsCurrent(pending: PendingTrackCycle): boolean {
+    return pendingTrackCycle === pending
+        && isPlaybackCurrent(pending.context, pending.expectedGeneration)
+        && JC.isVideoPage?.() === true;
+}
 
-        const currentIndex = audioOptions.findIndex(option => {
-            const checkIcon = option.querySelector('.actionsheetMenuItemIcon.listItemIcon.check');
-            return checkIcon && getComputedStyle(checkIcon).visibility !== 'hidden';
-        });
-
-        const nextIndex = (currentIndex + 1) % audioOptions.length;
-        const nextOption = audioOptions[nextIndex];
-
-        if (nextOption) {
-            (nextOption as HTMLElement).click();
-            const audioName = nextOption.querySelector('.listItemBodyText.actionSheetItemText')!.textContent.trim();
-            toast(JC.t!('toast_audio', { audio: JC.escapeHtml(audioName) }));
-        }
-    };
-
-    const audioMenuTitle = Array.from(document.querySelectorAll('.actionSheetContent .actionSheetTitle')).find(el => el.textContent === 'Audio');
-    if (audioMenuTitle) {
-        performCycle();
-    } else {
-        if (document.querySelector('.actionSheetContent')) {
-            document.body.click();
-        }
-        document.querySelector<HTMLElement>('button.btnAudio')?.click();
-        schedulePlaybackTimer(context, performCycle, 200);
+function resolveOwnedTrackScroller(pending: PendingTrackCycle): HTMLElement | null {
+    if (!trackCycleIsCurrent(pending)) {
+        cancelPendingTrackCycle(pending);
+        return null;
     }
-};
+    if (pending.ownedScroller && !pending.ownedScroller.isConnected) {
+        cancelPendingTrackCycle(pending);
+        return null;
+    }
+
+    const active = getActiveActionSheetScroller();
+    if (!active) return null;
+    const title = activeSheetTitle(active);
+    if (title !== pending.expectedTitle) {
+        // The pre-existing sheet and the superseded opposite-kind sheet can
+        // remain in Jellyfin's DOM while the requested menu mounts. Any other
+        // newer sheet is user/host replacement and silently cancels stale work.
+        if (active !== pending.ignoredScroller && title !== pending.ignoredTitle) {
+            cancelPendingTrackCycle(pending);
+        }
+        return null;
+    }
+
+    if (pending.ownedScroller && pending.ownedScroller !== active) {
+        cancelPendingTrackCycle(pending);
+        return null;
+    }
+    pending.ownedScroller = active;
+    return active;
+}
+
+function performPendingTrackCycle(pending: PendingTrackCycle): boolean {
+    const scroller = resolveOwnedTrackScroller(pending);
+    if (!scroller || pendingTrackCycle !== pending) return false;
+    const options = optionsForTrack(pending.kind, scroller);
+    if (options.length === 0) return false;
+
+    const checkSelector = pending.kind === 'subtitle'
+        ? '.listItemIcon.check'
+        : '.actionsheetMenuItemIcon.listItemIcon.check';
+    const currentIndex = options.findIndex((option) => {
+        const checkIcon = option.querySelector<HTMLElement>(checkSelector);
+        return checkIcon !== null && getComputedStyle(checkIcon).visibility !== 'hidden';
+    });
+    const nextOption = options[(currentIndex + 1) % options.length];
+    const textSelector = pending.kind === 'subtitle'
+        ? '.listItemBodyText'
+        : '.listItemBodyText.actionSheetItemText';
+    const trackName = nextOption?.querySelector<HTMLElement>(textSelector)?.textContent.trim();
+    if (!nextOption || !trackName) return false;
+
+    // Settle first: a click can synchronously mutate/close the sheet and must
+    // never leave its observer or timeout able to perform a second cycle.
+    cancelPendingTrackCycle(pending);
+    nextOption.click();
+    if (pending.kind === 'subtitle') {
+        toast(JC.t!('toast_subtitle', { subtitle: JC.escapeHtml(trackName) }));
+    } else {
+        toast(JC.t!('toast_audio', { audio: JC.escapeHtml(trackName) }));
+    }
+    return true;
+}
+
+function startTrackCycle(kind: TrackSheetKind): void {
+    const context = JC.identity.capture();
+    if (!context || JC.isVideoPage?.() !== true) return;
+
+    const previous = pendingTrackCycle;
+    const repeatedPending = previous?.kind === kind;
+    const trigger = trackTrigger(kind);
+    const pending: PendingTrackCycle = {
+        kind,
+        context,
+        expectedGeneration: playbackGeneration,
+        expectedTitle: repeatedPending ? previous.expectedTitle : trackTitle(kind, trigger),
+        ignoredTitle: previous && previous.kind !== kind ? previous.expectedTitle : null,
+        ignoredScroller: repeatedPending ? previous.ignoredScroller : null,
+        ownedScroller: repeatedPending ? previous.ownedScroller : null,
+        observer: null,
+        deadlineTimer: null,
+    };
+    cancelPendingTrackCycle();
+    pendingTrackCycle = pending;
+
+    const activeBeforeOpen = getActiveActionSheetScroller();
+    const targetAlreadyOpen = activeBeforeOpen !== null
+        && activeSheetTitle(activeBeforeOpen) === pending.expectedTitle;
+    if (!pending.ownedScroller && targetAlreadyOpen) {
+        pending.ownedScroller = activeBeforeOpen;
+    } else if (activeBeforeOpen && activeSheetTitle(activeBeforeOpen) !== pending.expectedTitle) {
+        pending.ignoredScroller = activeBeforeOpen;
+    }
+    if (performPendingTrackCycle(pending) || pendingTrackCycle !== pending) return;
+
+    pending.observer = onBodyMutation(
+        `jc-track-sheet-ready-${++trackSheetSubscriberSequence}`,
+        () => { performPendingTrackCycle(pending); }
+    );
+    pending.deadlineTimer = schedulePlaybackTimer(context, () => {
+        pending.deadlineTimer = null;
+        if (performPendingTrackCycle(pending) || !trackCycleIsCurrent(pending)) return;
+        const ownedScroller = resolveOwnedTrackScroller(pending);
+        if (pendingTrackCycle !== pending) return;
+        cancelPendingTrackCycle(pending);
+        if (ownedScroller) closeOpenActionSheet();
+        const key = kind === 'subtitle' ? 'toast_no_subtitles_found' : 'toast_no_audio_tracks_found';
+        toast(JC.t!(key), undefined, 'warning');
+    }, TRACK_SHEET_READY_DEADLINE_MS);
+
+    if (repeatedPending || targetAlreadyOpen) return;
+    if (activeBeforeOpen && activeSheetTitle(activeBeforeOpen) !== pending.expectedTitle) {
+        closeOpenActionSheet();
+    }
+    trigger?.click();
+    performPendingTrackCycle(pending); // atomic host mounts win without waiting for a mutation batch
+}
+
+const cycleSubtitleTrack = (): void => startTrackCycle('subtitle');
+
+/** Cycles through available audio tracks in the OSD menu. */
+const cycleAudioTrack = (): void => startTrackCycle('audio');
 
 // ~3s at 120ms: the aspect-ratio action sheet always opens well within this.
 const ASPECT_CYCLE_MAX_ATTEMPTS = 25;
@@ -944,6 +1042,7 @@ const handleLongPressClick = (e: Event): void => {
 };
 
 function resetPlaybackState(): void {
+    cancelPendingTrackCycle();
     playbackGeneration += 1;
     for (const timer of playbackTimers) clearTimeout(timer);
     playbackTimers.clear();

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -104,6 +104,10 @@ Drive Jellyfin without reaching for the mouse: a comprehensive set of hotkeys co
 | `Z` | Jump to Last Position |
 | `0`–`9` | Jump to that percentage of the video (`1` = 10%, `5` = 50%, …) |
 
+The audio and subtitle cycle shortcuts wait for Jellyfin's active track menu to
+finish mounting before changing one track. Repeated shortcuts coalesce while a
+menu is opening, and leaving playback cancels the pending action.
+
 **To customize a shortcut:**
 
 1. Press `?` to open Canopy User Settings.

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,12 +25,12 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2798, totalLines: 3191 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2805, totalLines: 3191 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 42809, totalLines: 52615 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 3,
-        minimumCoveredLines: 2798,
-        maximumCoveredLines: 2798,
+        minimumCoveredLines: 2805,
+        maximumCoveredLines: 2805,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 5,

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,17 +10,17 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2798,
+        "coveredLines": 2805,
         "totalLines": 3191
       },
       "observations": {
         "cleanRuns": 3,
-        "minimumCoveredLines": 2798,
-        "maximumCoveredLines": 2798
+        "minimumCoveredLines": 2805,
+        "maximumCoveredLines": 2805
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "The modern-layout-only change removes ten fully covered legacy-layout lines from the instrumented client/core scope. Three clean Node/V8 runs on 2026-08-04 each passed all 2,038 tests across 244 files with zero unhandled errors and reproduced exactly 2,798/3,191 (87.684%). The numeric percentage is not directly comparable with the prior 2,808/3,201 scope because the removed lines were all covered; no surviving line lost coverage. The exact observed envelope needs no instrumentation tolerance, so the reviewed floor and high-water for this smaller scope are 2,798/3,191. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "The #683 playback action-sheet lifecycle tests exercise the canonical core action-sheet close path while keeping the instrumented client/core scope fixed. Three clean Node/V8 runs on 2026-08-05 each passed all 2,052 tests across 245 files with zero unhandled errors and reproduced exactly 2,805/3,191 (87.903%). This advances the prior same-scope 2,798/3,191 high-water by seven covered lines without adding or removing an instrumented line. The exact observed envelope needs no instrumentation tolerance, so the reviewed floor and high-water are both 2,805/3,191. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
       }
     },
     "server": {


### PR DESCRIPTION
## Summary

- replace the fixed 200 ms audio/subtitle menu query with one shared, bounded action-sheet readiness cycle
- scope cycling to the newest localized target sheet, coalesce repeats, and cancel stale work across replacement, navigation, account changes, and disposal
- warn only after a final 3-second readiness check, keep track labels escaped, and document the user-visible behavior
- add focused coverage for delayed, atomic, empty, repeated, cross-kind, localized, replacement-race, navigation, account, and disposal paths

Fixes #683.

## Implementation notes

The playback feature uses the canonical `onBodyMutation` and action-sheet helpers. At most one observer and one lifecycle-owned deadline exist across both track kinds. Completion settles ownership before clicking a row, while every cancellation path unsubscribes the observer and removes the deadline.

This PR was developed with AI assistance. I reviewed and tested all changes and understand the implementation.

## Validation

- 53/53 focused playback, lifecycle, import-purity, leak, and escape tests
- client coverage: 2,052/2,052 tests across 245 files; three clean identical-tree runs each measured 2,805/3,191 lines (87.903%)
- server coverage: 4,104/4,104 tests; 42,786/52,592 lines, within the reviewed 12-line instrumentation envelope
- repository script suite: 649/649
- Release build: 0 warnings, 0 errors
- strict source and legacy typechecks, syntax inventory, performance-rules guard, deterministic bundle, coverage-boundary tests, and offline strict docs build
- advisory ESLint completed normally: 0 errors, 5,568 warnings (within the repository cap)
- independent whole-diff and publication reviews: approved

The behavior changes an existing keyboard action without changing layout or adding visible UI, so screenshots are not applicable. The complete hosted Jellyfin 12 E2E matrix remains the browser-level gate for this draft.

## Compatibility and risk

- no API, configuration, localization-key, or server behavior changes
- no breaking changes
- contributor auto-merge is intentionally not enabled
