### PR TITLE
feat: allow disabling individual shortcuts

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/ShortcutConfigurationNormalizerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/ShortcutConfigurationNormalizerTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration;
+
+public sealed class ShortcutConfigurationNormalizerTests
+{
+    private static readonly IReadOnlyList<Shortcut> Defaults = new[]
+    {
+        new Shortcut { Name = "First", Key = "F", Label = "First", Category = "Global" },
+        new Shortcut { Name = "Second", Key = "S", Label = "Second", Category = "Player" }
+    };
+
+    [Fact]
+    public void PersistedEmptyBinding_WinsConstructorDefault_AndSurvives()
+    {
+        var disabled = new Shortcut
+        {
+            Name = "First",
+            Key = string.Empty,
+            Label = "First",
+            Category = "Global",
+            ExtensionData = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+            {
+                ["Future"] = JsonDocument.Parse("{\"owner\":\"persisted\"}").RootElement.Clone()
+            }
+        };
+
+        var result = ShortcutConfigurationNormalizer.Normalize(
+            new Shortcut?[] { Defaults[0], disabled },
+            Defaults);
+
+        Assert.True(result.Changed);
+        Assert.Equal(1, result.DuplicatesDropped);
+        Assert.Same(disabled, result.Shortcuts[0]);
+        Assert.Equal(string.Empty, result.Shortcuts[0].Key);
+        Assert.Equal("persisted", result.Shortcuts[0].ExtensionData["Future"].GetProperty("owner").GetString());
+        Assert.Equal("Second", result.Shortcuts[1].Name);
+    }
+
+    [Fact]
+    public void MissingDefaults_Backfill_WithoutReplacingUnknownDisabledRows()
+    {
+        var custom = new Shortcut { Name = "FutureAction", Key = string.Empty, Label = "Future" };
+
+        var result = ShortcutConfigurationNormalizer.Normalize(
+            new Shortcut?[] { custom },
+            Defaults);
+
+        Assert.Same(custom, result.Shortcuts[0]);
+        Assert.Equal(string.Empty, result.Shortcuts[0].Key);
+        Assert.Equal(new[] { "First", "Second" }, result.MissingDefaults.Select(item => item.Name));
+        Assert.Equal(new[] { "FutureAction", "First", "Second" }, result.Shortcuts.Select(item => item.Name));
+    }
+
+    [Fact]
+    public void LastNamedRowWins_AndNamelessRowsAreTheOnlyMalformedEntries()
+    {
+        var earlier = new Shortcut { Name = "First", Key = "A" };
+        var winner = new Shortcut { Name = "First", Key = "B" };
+
+        var result = ShortcutConfigurationNormalizer.Normalize(
+            new Shortcut?[]
+            {
+                earlier,
+                null,
+                new Shortcut { Name = string.Empty, Key = "X" },
+                winner,
+                new Shortcut { Name = "Unknown", Key = string.Empty }
+            },
+            Defaults);
+
+        Assert.Equal(1, result.DuplicatesDropped);
+        Assert.Equal(2, result.MalformedDropped);
+        Assert.Same(winner, Assert.Single(result.Shortcuts, item => item.Name == "First"));
+        Assert.Equal(string.Empty, Assert.Single(result.Shortcuts, item => item.Name == "Unknown").Key);
+    }
+
+    [Fact]
+    public void NullKey_NormalizesToIntentionalEmpty_AndResultIsIdempotent()
+    {
+        var disabled = new Shortcut { Name = "First", Key = null! };
+        var first = ShortcutConfigurationNormalizer.Normalize(
+            new Shortcut?[] { disabled, Defaults[1] },
+            Defaults);
+
+        Assert.Equal(1, first.NullKeysNormalized);
+        Assert.Null(disabled.Key);
+        Assert.NotSame(disabled, first.Shortcuts[0]);
+        Assert.Equal(string.Empty, first.Shortcuts[0].Key);
+
+        var second = ShortcutConfigurationNormalizer.Normalize(first.Shortcuts, Defaults);
+        Assert.False(second.Changed);
+        Assert.Equal(first.Shortcuts, second.Shortcuts);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
@@ -218,7 +218,7 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
         var shortcutEntry = new Shortcut
         {
             Name = "Pause",
-            Key = "Space",
+            Key = string.Empty,
             Label = "Pause",
             Category = "Playback"
         };
@@ -239,6 +239,7 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
             TargetId,
             "shortcuts.json");
         Assert.Single(storedShortcuts.Shortcuts);
+        Assert.Equal(string.Empty, Assert.Single(storedShortcuts.Shortcuts).Key);
         Assert.True(
             storedShortcuts.ExtensionData["FutureShortcutSetting"]
                 .GetProperty("preserved")
@@ -252,6 +253,7 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
 
         var roundTrip = AssertResponse<UserShortcuts>(
             Controller().GetAdminTargetUserShortcuts(TargetId));
+        Assert.Equal(string.Empty, Assert.Single(roundTrip.Data!.Shortcuts).Key);
         Assert.Equal(
             3,
             Assert.Single(roundTrip.Data!.Shortcuts)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
@@ -452,11 +452,15 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var shortcuts = Controller(2).SaveUserSettingsShortcuts(UserId, new UserShortcuts
             {
                 Revision = 2,
-                Shortcuts = new List<Shortcut> { new Shortcut { Name = "Open", Key = "O" } }
+                Shortcuts = new List<Shortcut> { new Shortcut { Name = "Open", Key = string.Empty } }
             });
             var shortcutsAck = Assert.IsType<UserSettingsController.UserFileMutationResponse<UserShortcuts>>(
                 Assert.IsType<OkObjectResult>(shortcuts).Value);
             Assert.Equal(3, shortcutsAck.Revision);
+            Assert.Equal(string.Empty, Assert.Single(shortcutsAck.Data!.Shortcuts).Key);
+            Assert.Equal(
+                string.Empty,
+                Assert.Single(_manager.GetUserConfigurationStrict<UserShortcuts>(UserId, "shortcuts.json").Shortcuts).Key);
 
             var elsewhere = Controller(4).SaveUserSettingsElsewhere(UserId, new ElsewhereSettings
             {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.anonymous.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.anonymous.json
@@ -255,6 +255,12 @@
       "Key": "Z",
       "Label": "Jump to Last Position",
       "Name": "JumpToLastPosition"
+    },
+    {
+      "Category": "Player",
+      "Key": "0-9",
+      "Label": "Jump to Percentage",
+      "Name": "JumpToPercentage"
     }
   ],
   "ShowArrLinksAsText": false,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.authenticated.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.authenticated.json
@@ -255,6 +255,12 @@
       "Key": "Z",
       "Label": "Jump to Last Position",
       "Name": "JumpToLastPosition"
+    },
+    {
+      "Category": "Player",
+      "Key": "0-9",
+      "Label": "Jump to Percentage",
+      "Name": "JumpToPercentage"
     }
   ],
   "ShowArrLinksAsText": false,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.anonymous.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.anonymous.json
@@ -255,6 +255,12 @@
       "Key": "Z",
       "Label": "Jump to Last Position",
       "Name": "JumpToLastPosition"
+    },
+    {
+      "Category": "Player",
+      "Key": "0-9",
+      "Label": "Jump to Percentage",
+      "Name": "JumpToPercentage"
     }
   ],
   "ShowArrLinksAsText": true,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.authenticated.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.authenticated.json
@@ -255,6 +255,12 @@
       "Key": "Z",
       "Label": "Jump to Last Position",
       "Name": "JumpToLastPosition"
+    },
+    {
+      "Category": "Player",
+      "Key": "0-9",
+      "Label": "Jump to Percentage",
+      "Name": "JumpToPercentage"
     }
   ],
   "ShowArrLinksAsText": true,

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
@@ -150,7 +150,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                 new Shortcut { Name = "SkipIntroOutro", Key = "O", Label = "Skip Intro/Outro", Category = "Player" },
                 new Shortcut { Name = "FrameStepBack", Key = ",", Label = "Step Back One Frame", Category = "Player" },
                 new Shortcut { Name = "FrameStepForward", Key = ".", Label = "Step Forward One Frame", Category = "Player" },
-                new Shortcut { Name = "JumpToLastPosition", Key = "Z", Label = "Jump to Last Position", Category = "Player" }
+                new Shortcut { Name = "JumpToLastPosition", Key = "Z", Label = "Jump to Last Position", Category = "Player" },
+                new Shortcut { Name = "JumpToPercentage", Key = "0-9", Label = "Jump to Percentage", Category = "Player" }
             };
 
             // Seerr Search Settings

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/ShortcutConfigurationNormalizer.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/ShortcutConfigurationNormalizer.cs
@@ -1,0 +1,87 @@
+namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
+{
+    /// <summary>
+    /// Normalizes XmlSerializer's constructor-plus-persisted shortcut list.
+    /// Named empty keys are intentional disabled state; the last named row wins.
+    /// </summary>
+    internal static class ShortcutConfigurationNormalizer
+    {
+        internal sealed record Result(
+            List<Shortcut> Shortcuts,
+            int DuplicatesDropped,
+            int MalformedDropped,
+            int NullKeysNormalized,
+            IReadOnlyList<Shortcut> MissingDefaults)
+        {
+            internal bool Changed => DuplicatesDropped > 0
+                || MalformedDropped > 0
+                || NullKeysNormalized > 0
+                || MissingDefaults.Count > 0;
+        }
+
+        internal static Result Normalize(
+            IReadOnlyList<Shortcut?> shortcuts,
+            IReadOnlyList<Shortcut> defaults)
+        {
+            ArgumentNullException.ThrowIfNull(shortcuts);
+            ArgumentNullException.ThrowIfNull(defaults);
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var reversed = new List<Shortcut>(shortcuts.Count);
+            var duplicates = 0;
+            var malformed = 0;
+            var normalizedNullKeys = 0;
+
+            // XmlSerializer appends persisted rows to constructor defaults. Walk
+            // backwards so the persisted/last row is authoritative, including
+            // an empty key that deliberately disables the action.
+            for (var index = shortcuts.Count - 1; index >= 0; index--)
+            {
+                var shortcut = shortcuts[index];
+                if (shortcut == null || string.IsNullOrEmpty(shortcut.Name))
+                {
+                    malformed++;
+                    continue;
+                }
+
+                if (!seen.Add(shortcut.Name))
+                {
+                    duplicates++;
+                    continue;
+                }
+
+                if (shortcut.Key == null)
+                {
+                    shortcut = new Shortcut
+                    {
+                        Name = shortcut.Name,
+                        Key = string.Empty,
+                        Label = shortcut.Label,
+                        Category = shortcut.Category,
+                        ExtensionData = PersistedPayloadPolicy.CloneExtensionData(shortcut.ExtensionData)
+                    };
+                    normalizedNullKeys++;
+                }
+
+                reversed.Add(shortcut);
+            }
+
+            reversed.Reverse();
+            var normalized = new List<Shortcut>(reversed.Count + defaults.Count);
+            normalized.AddRange(reversed);
+            var missing = new List<Shortcut>();
+            foreach (var defaultShortcut in defaults)
+            {
+                if (string.IsNullOrEmpty(defaultShortcut.Name) || !seen.Add(defaultShortcut.Name))
+                {
+                    continue;
+                }
+
+                missing.Add(defaultShortcut);
+                normalized.Add(defaultShortcut);
+            }
+
+            return new Result(normalized, duplicates, malformed, normalizedNullKeys, missing);
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
@@ -92,6 +92,7 @@
             const tmdbStatusIndicator = document.getElementById('tmdbStatusIndicator');
 
             let shortcutOverrides = [];
+            let shortcutPersistedRows = [];
 
             const tabs = document.querySelectorAll('.jellyfin-tab-button');
             const tabContents = document.querySelectorAll('.jellyfin-tab-content');
@@ -870,17 +871,127 @@
             { Name: "SkipIntroOutro", Key: "O", Label: "Skip Intro/Outro", Category: "Player" },
             { Name: "FrameStepBack", Key: ",", Label: "Step Back One Frame", Category: "Player" },
             { Name: "FrameStepForward", Key: ".", Label: "Step Forward One Frame", Category: "Player" },
-            { Name: "JumpToLastPosition", Key: "Z", Label: "Jump to Last Position", Category: "Player" }
+            { Name: "JumpToLastPosition", Key: "Z", Label: "Jump to Last Position", Category: "Player" },
+            { Name: "JumpToPercentage", Key: "0-9", Label: "Jump to Percentage", Category: "Player" }
         ];
+
+        function jcNormalizeAdminShortcut(value) {
+            if (typeof value !== 'string') return '';
+            if (value === ' ') return 'Space';
+            var aliases = {
+                meta: 'Meta', cmd: 'Meta', command: 'Meta', os: 'Meta', super: 'Meta', win: 'Meta', windows: 'Meta',
+                ctrl: 'Ctrl', control: 'Ctrl', alt: 'Alt', option: 'Alt', shift: 'Shift'
+            };
+            var legacySpacePrefix = value.endsWith('+ ') ? value.slice(0, -1) : '';
+            var legacySpaceTokens = legacySpacePrefix.endsWith('+')
+                ? legacySpacePrefix.slice(0, -1).split('+').map(function (token) { return token.trim(); })
+                : [];
+            var hasLegacySpace = legacySpaceTokens.length > 0 && legacySpaceTokens.every(function (token) {
+                return token && aliases[token.toLowerCase()];
+            });
+            var source = hasLegacySpace ? legacySpacePrefix + 'Space' : value.trim();
+            if (!source) return '';
+            if (source === '0-9') return '0-9';
+            var order = ['Meta', 'Ctrl', 'Alt', 'Shift'];
+            var tokens;
+            if (source.endsWith('+')) {
+                tokens = source.slice(0, -1).split('+').map(function (token) { return token.trim(); }).filter(Boolean);
+                tokens.push('+');
+            } else {
+                tokens = source.split('+').map(function (token) { return token.trim(); }).filter(Boolean);
+            }
+            var modifiers = {};
+            var keys = [];
+            tokens.forEach(function (token) {
+                var modifier = aliases[token.toLowerCase()];
+                if (modifier) modifiers[modifier] = true;
+                else keys.push(token);
+            });
+            if (keys.length !== 1) return '';
+            var key = keys[0];
+            if (key === ' ') key = 'Space';
+            else if (/^[a-z]$/i.test(key)) key = key.toUpperCase();
+            else {
+                var named = {
+                    esc: 'Escape', escape: 'Escape', space: 'Space', spacebar: 'Space',
+                    arrowup: 'ArrowUp', arrowdown: 'ArrowDown', arrowleft: 'ArrowLeft', arrowright: 'ArrowRight',
+                    backspace: 'Backspace', delete: 'Delete', enter: 'Enter', tab: 'Tab', home: 'Home', end: 'End',
+                    pageup: 'PageUp', pagedown: 'PageDown'
+                };
+                if (key.length > 1) key = named[key.toLowerCase()] || key;
+            }
+            if (key.length === 1 && !/[A-Za-z0-9]/.test(key)) delete modifiers.Shift;
+            return order.filter(function (modifier) { return modifiers[modifier]; }).concat([key]).join('+');
+        }
+
+        function jcAdminShortcutBindingsConflict(left, right) {
+            var a = jcNormalizeAdminShortcut(left);
+            var b = jcNormalizeAdminShortcut(right);
+            if (!a || !b) return false;
+            if (a.toLowerCase() === b.toLowerCase()) return true;
+            return (a === '0-9' && /^[0-9]$/.test(b)) || (b === '0-9' && /^[0-9]$/.test(a));
+        }
+
+        function jcAdminEffectiveShortcuts(defaults, overrides) {
+            var lastOverride = new Map();
+            (overrides || []).forEach(function (shortcut) {
+                if (shortcut && shortcut.Name) lastOverride.set(shortcut.Name, shortcut);
+            });
+            var known = new Set();
+            var result = (defaults || []).map(function (shortcut) {
+                known.add(shortcut.Name);
+                return Object.assign({}, shortcut, lastOverride.get(shortcut.Name) || {});
+            });
+            lastOverride.forEach(function (shortcut, name) {
+                if (!known.has(name)) result.push(Object.assign({}, shortcut));
+            });
+            return result;
+        }
+
+        function jcSetAdminShortcutOverride(overrides, defaults, action, binding) {
+            var preserved = null;
+            var next = (overrides || []).filter(function (shortcut) {
+                if (!shortcut || shortcut.Name !== action) return true;
+                preserved = shortcut;
+                return false;
+            });
+            if (binding !== null) {
+                var product = (defaults || []).find(function (shortcut) { return shortcut.Name === action; }) || { Name: action };
+                next.push(Object.assign({}, product, preserved || {}, { Name: action, Key: binding }));
+            }
+            return next;
+        }
+
+        function jcAdminShortcutConflict(defaults, overrides, action, binding) {
+            return jcAdminEffectiveShortcuts(defaults, overrides).find(function (shortcut) {
+                return shortcut.Name !== action && jcAdminShortcutBindingsConflict(shortcut.Key, binding);
+            });
+        }
+
+        function jcMergeAdminShortcutRows(defaults, overrides, persistedRows) {
+            var persistedByName = new Map();
+            (persistedRows || []).forEach(function (shortcut) {
+                if (shortcut && shortcut.Name) persistedByName.set(shortcut.Name, shortcut);
+            });
+            return jcAdminEffectiveShortcuts(defaults, overrides).map(function (effective) {
+                return Object.assign({}, persistedByName.get(effective.Name) || {}, effective, {
+                    Name: effective.Name,
+                    Key: jcNormalizeAdminShortcut(effective.Key)
+                });
+            });
+        }
 
         function renderOverrides() {
             shortcutListContainer.innerHTML = '';
-            if (shortcutOverrides.length === 0) {
-                shortcutListContainer.innerHTML = '<p class="fieldDescription" style="text-align: center;">No overrides configured. All shortcuts are using default values.</p>';
-            }
-            shortcutOverrides.forEach((shortcut, index) => {
+            const effectiveShortcuts = jcAdminEffectiveShortcuts(defaultShortcuts, shortcutOverrides)
+                .filter(shortcut => defaultShortcuts.some(item => item.Name === shortcut.Name));
+            effectiveShortcuts.forEach((shortcut) => {
+                const hasOverride = shortcutOverrides.some(item => item.Name === shortcut.Name);
+                const isGroup = shortcut.Name === 'JumpToPercentage';
+                const normalizedKey = jcNormalizeAdminShortcut(shortcut.Key);
+                const isDisabled = normalizedKey === '';
                 const row = document.createElement('div');
-                row.className = 'inputContainer';
+                row.className = 'inputContainer jc-admin-shortcut-row';
                 row.style.display = 'flex';
                 row.style.alignItems = 'center';
                 row.style.gap = '1em';
@@ -890,40 +1001,87 @@
                 label.textContent = shortcut.Label;
                 label.style.flex = '1';
 
-                const input = document.createElement('input');
-                input.setAttribute('is', 'emby-input');
-                input.type = 'text';
-                input.value = shortcut.Key;
-                input.style.flex = '1';
-                input.style.textAlign = 'center';
-                input.addEventListener('input', (e) => {
-                    let value = e.target.value;
-                    // Automatically convert single lowercase letters to uppercase ***
-                    if (value.match(/^[a-z]$/)) {
-                        value = value.toUpperCase();
-                        e.target.value = value;
-                    }
-                    shortcutOverrides[index].Key = value;
-                });
-
-
                 const buttonContainer = document.createElement('div');
-                const removeBtn = document.createElement('button');
-                removeBtn.setAttribute('is', 'emby-button');
-                removeBtn.type = 'button';
-                removeBtn.textContent = 'Remove';
-                removeBtn.className = 'raised button-cancel';
-                removeBtn.style.marginLeft = '1em';
-                removeBtn.addEventListener('click', () => {
-                    shortcutOverrides.splice(index, 1);
+                buttonContainer.style.display = 'flex';
+                buttonContainer.style.gap = '0.5em';
+
+                if (isGroup) {
+                    const state = document.createElement('span');
+                    state.className = 'jc-admin-shortcut-state';
+                    state.textContent = isDisabled ? 'Disabled' : '0–9';
+                    state.style.flex = '1';
+                    state.style.textAlign = 'center';
+                    state.setAttribute('role', 'status');
+                    row.appendChild(label);
+                    row.appendChild(state);
+                } else {
+                    const input = document.createElement('input');
+                    input.setAttribute('is', 'emby-input');
+                    input.type = 'text';
+                    input.value = normalizedKey;
+                    input.placeholder = isDisabled ? 'Disabled' : '';
+                    input.setAttribute('aria-label', shortcut.Label + ' binding');
+                    input.style.flex = '1';
+                    input.style.textAlign = 'center';
+                    input.addEventListener('change', (event) => {
+                        const newKey = jcNormalizeAdminShortcut(event.target.value);
+                        if (!newKey) {
+                            // Clearing an input is not Disable; restore the last
+                            // acknowledged value and require the explicit button.
+                            renderOverrides();
+                            return;
+                        }
+                        const conflict = jcAdminShortcutConflict(defaultShortcuts, shortcutOverrides, shortcut.Name, newKey);
+                        if (conflict) {
+                            showValidationError(input.parentElement, "The key '" + newKey + "' is already used by '" + conflict.Label + "'.");
+                            renderOverrides();
+                            return;
+                        }
+                        shortcutOverrides = jcSetAdminShortcutOverride(shortcutOverrides, defaultShortcuts, shortcut.Name, newKey);
+                        jcMarkConfigDirty();
+                        renderOverrides();
+                        populateAddShortcutDropdown();
+                    });
+                    row.appendChild(label);
+                    row.appendChild(input);
+                }
+
+                const stateBtn = document.createElement('button');
+                stateBtn.setAttribute('is', 'emby-button');
+                stateBtn.type = 'button';
+                stateBtn.textContent = isDisabled && isGroup ? 'Enable' : 'Disable';
+                stateBtn.className = 'raised button-cancel';
+                stateBtn.disabled = isDisabled && !isGroup;
+                stateBtn.addEventListener('click', () => {
+                    const nextKey = isDisabled ? '0-9' : '';
+                    if (nextKey) {
+                        const conflict = jcAdminShortcutConflict(defaultShortcuts, shortcutOverrides, shortcut.Name, nextKey);
+                        if (conflict) {
+                            showValidationError(stateBtn, "The 0–9 group conflicts with '" + conflict.Label + "'.");
+                            return;
+                        }
+                    }
+                    shortcutOverrides = jcSetAdminShortcutOverride(shortcutOverrides, defaultShortcuts, shortcut.Name, nextKey);
                     jcMarkConfigDirty();
                     renderOverrides();
                     populateAddShortcutDropdown();
                 });
 
-                buttonContainer.appendChild(removeBtn);
-                row.appendChild(label);
-                row.appendChild(input);
+                const resetBtn = document.createElement('button');
+                resetBtn.setAttribute('is', 'emby-button');
+                resetBtn.type = 'button';
+                resetBtn.textContent = 'Reset';
+                resetBtn.className = 'raised';
+                resetBtn.disabled = !hasOverride;
+                resetBtn.addEventListener('click', () => {
+                    shortcutOverrides = jcSetAdminShortcutOverride(shortcutOverrides, defaultShortcuts, shortcut.Name, null);
+                    jcMarkConfigDirty();
+                    renderOverrides();
+                    populateAddShortcutDropdown();
+                });
+
+                buttonContainer.appendChild(stateBtn);
+                buttonContainer.appendChild(resetBtn);
                 row.appendChild(buttonContainer);
                 shortcutListContainer.appendChild(row);
             });
@@ -932,7 +1090,7 @@
         function populateAddShortcutDropdown() {
             addShortcutSelect.innerHTML = '';
             const overriddenNames = shortcutOverrides.map(s => s.Name);
-            const availableShortcuts = defaultShortcuts.filter(s => !overriddenNames.includes(s.Name));
+            const availableShortcuts = defaultShortcuts.filter(s => s.Name !== 'JumpToPercentage' && !overriddenNames.includes(s.Name));
 
             availableShortcuts.forEach(shortcut => {
                 const option = document.createElement('option');
@@ -970,27 +1128,22 @@
                 return;
             }
 
-            // Check 1: See if the key is already used in another custom override.
-            const overrideConflict = shortcutOverrides.find(s => s.Key.toLowerCase() === newKey.toLowerCase());
-
-            if (overrideConflict) {
-                const errorMessage = "The key '" + newKey + "' is already assigned to '" + overrideConflict.Label + "' as an override.";
-                showValidationError(addShortcutKeyInput.parentElement, errorMessage);
+            newKey = jcNormalizeAdminShortcut(newKey);
+            if (!newKey) {
+                showValidationError(addShortcutKeyInput.parentElement, 'Please enter one key with optional modifiers.');
                 return;
             }
-
-            // Check 2: See if the key is used by another default shortcut.
-            const defaultConflict = defaultShortcuts.find(s => s.Key.toLowerCase() === newKey.toLowerCase() && s.Name !== selectedName);
-
-            if (defaultConflict) {
-                const errorMessage = "The key '" + newKey + "' is already used by '" + defaultConflict.Label + "'.";
+            const conflict = jcAdminShortcutConflict(defaultShortcuts, shortcutOverrides, selectedName, newKey);
+            if (conflict) {
+                const errorMessage = "The key '" + newKey + "' is already used by '" + conflict.Label + "'.";
                 showValidationError(addShortcutKeyInput.parentElement, errorMessage);
                 return;
             }
 
             const defaultConfig = defaultShortcuts.find(s => s.Name === selectedName);
             if (defaultConfig) {
-                shortcutOverrides.push({ ...defaultConfig, Key: newKey });
+                shortcutOverrides = jcSetAdminShortcutOverride(shortcutOverrides, defaultShortcuts, selectedName, newKey);
+                jcMarkConfigDirty();
                 renderOverrides();
                 populateAddShortcutDropdown();
                 addShortcutKeyInput.value = '';
@@ -2548,9 +2701,10 @@
             checkInstalledPlugins();
             ApiClient.getPluginConfiguration(pluginId).then((config) => {
                 const savedShortcuts = (config.Shortcuts && config.Shortcuts.length > 0) ? config.Shortcuts : defaultShortcuts;
+                shortcutPersistedRows = savedShortcuts.slice();
                 shortcutOverrides = savedShortcuts.filter(saved => {
                     const def = defaultShortcuts.find(d => d.Name === saved.Name);
-                    return !def || saved.Key !== def.Key;
+                    return !def || jcNormalizeAdminShortcut(saved.Key) !== jcNormalizeAdminShortcut(def.Key);
                 });
 
                 renderOverrides();
@@ -2703,12 +2857,11 @@
             if (_maintenanceActionLoadError) {
                 throw new Error('Cannot save while the persisted maintenance action is invalid.');
             }
-            const finalShortcuts = [...defaultShortcuts];
-            shortcutOverrides.forEach(override => {
-                const index = finalShortcuts.findIndex(s => s.Name === override.Name);
-                if (index !== -1) finalShortcuts[index] = override;
-            });
-            config.Shortcuts = finalShortcuts;
+            config.Shortcuts = jcMergeAdminShortcutRows(
+                defaultShortcuts,
+                shortcutOverrides,
+                (config.Shortcuts && config.Shortcuts.length > 0) ? config.Shortcuts : shortcutPersistedRows
+            );
 
             // Simple fields: one generic, type-aware pass over every
             // [data-config-key] element (see readBoundFieldsIntoConfig above).

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -2547,7 +2547,7 @@
                             </div>
                             <hr style="border:0; border-top: 1px solid rgba(255,255,255,0.05); margin: 5px 0;">
 
-                            <h4>Add Override</h4>
+                            <h4>Set Custom Binding</h4>
                             <div style="display:flex; gap:10px; align-items:center;">
                                 <select is="emby-select" class="emby-select" id="add-shortcut-select" style="flex:1;"></select>
                                 <input is="emby-input" id="add-shortcut-key" type="text" placeholder="Key (e.g. Shift+A)" style="flex:1;"/>
@@ -2560,7 +2560,8 @@
                             </div>
                             <div id="shortcut-error-comment" style="display: none; color: #ff6b6b; margin-top:5px;"></div>
 
-                            <h4 style="margin-top:20px;">Current Overrides</h4>
+                            <h4 style="margin-top:20px;">All Shortcuts</h4>
+                            <p class="fieldDescription">Use <strong>Disable</strong> to store an intentional disabled binding. <strong>Reset</strong> restores the compiled product default. Clearing a text field does not disable an action.</p>
                             <div id="shortcut-list-container" style="display:flex; flex-direction:column; gap:10px;"></div>
                         </div>
                     </fieldset>

--- a/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
@@ -379,40 +379,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy
                 config.Shortcuts ??= new List<Shortcut>();
                 originalShortcuts = config.Shortcuts;
 
-                var seen = new HashSet<string>(StringComparer.Ordinal);
-                var dedupedReversed = new List<Shortcut>(originalShortcuts.Count);
-                var emptyKeyNames = new HashSet<string>(StringComparer.Ordinal);
-                for (int i = originalShortcuts.Count - 1; i >= 0; i--)
-                {
-                    var s = originalShortcuts[i];
-                    var name = s?.Name ?? string.Empty;
-                    if (string.IsNullOrEmpty(name)) continue;
-                    if (string.IsNullOrEmpty(s?.Key))
-                    {
-                        emptyKeyNames.Add(name);
-                        continue;
-                    }
-                    if (seen.Add(name)) dedupedReversed.Add(s!);
-                }
-                var deduped = new List<Shortcut>(dedupedReversed.Count);
-                for (int i = dedupedReversed.Count - 1; i >= 0; i--) deduped.Add(dedupedReversed[i]);
-                var malformed = emptyKeyNames.Where(n => !seen.Contains(n)).ToList();
-                int duplicatesDropped = originalShortcuts.Count - deduped.Count - malformed.Count;
-
                 var defaults = new PluginConfiguration().Shortcuts ?? new List<Shortcut>();
-                var missing = defaults.Where(d => !seen.Contains(d.Name ?? string.Empty)).ToList();
-                deduped.AddRange(missing);
+                var result = ShortcutConfigurationNormalizer.Normalize(originalShortcuts, defaults);
+                if (!result.Changed) return;
 
-                if (duplicatesDropped == 0 && missing.Count == 0 && malformed.Count == 0) return;
-
-                config.Shortcuts = deduped;
+                config.Shortcuts = result.Shortcuts;
                 SaveConfiguration();
                 _logger.LogInformation(
-                    $"Normalized shortcut list: dropped {duplicatesDropped} duplicate(s), " +
-                    $"{malformed.Count} malformed entry/entries" +
-                    (malformed.Count > 0 ? $" [{string.Join(", ", malformed)}]" : "") +
-                    $", added {missing.Count} missing default(s)" +
-                    (missing.Count > 0 ? $" [{string.Join(", ", missing.Select(s => s.Name))}]" : ""));
+                    $"Normalized shortcut list: dropped {result.DuplicatesDropped} duplicate(s), " +
+                    $"{result.MalformedDropped} malformed entry/entries, " +
+                    $"normalized {result.NullKeysNormalized} null key(s), " +
+                    $"added {result.MissingDefaults.Count} missing default(s)" +
+                    (result.MissingDefaults.Count > 0
+                        ? $" [{string.Join(", ", result.MissingDefaults.Select(s => s.Name))}]"
+                        : string.Empty));
             }
             catch (IOException ex)
             {

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "مفعل",
   "status_disabled": "معطل",
+  "shortcut_enable": "تمكين",
+  "shortcut_disable": "تعطيل",
   "feature_auto_pause": "{{icon:pause}} إيقاف مؤقت تلقائي",
   "feature_auto_resume": "{{icon:play}} استئناف تلقائي",
   "feature_auto_pip": "{{icon:pip}} صورة في صورة (PiP) تلقائي",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature}: {status}",
   "status_enabled": "Активирано",
   "status_disabled": "Деактивирано",
+  "shortcut_enable": "Активиране",
+  "shortcut_disable": "Деактивиране",
   "feature_auto_pause": "{{icon:pause}} Автоматична пауза",
   "feature_auto_resume": "{{icon:play}} Автоматично възобновяване",
   "feature_auto_pip": "{{icon:pip}} Автоматична PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Activat",
   "status_disabled": "Desactivat",
+  "shortcut_enable": "Activa",
+  "shortcut_disable": "Desactiva",
   "feature_auto_pause": "{{icon:pause}} Pausa automàtica",
   "feature_auto_resume": "{{icon:play}} Reanudació automàtica",
   "feature_auto_pip": "{{icon:pip}} PiP automàtic",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Povoleno",
   "status_disabled": "Zakázáno",
+  "shortcut_enable": "Povolit",
+  "shortcut_disable": "Zakázat",
   "feature_auto_pause": "{{icon:pause}} Automatické pozastavení",
   "feature_auto_resume": "{{icon:play}} Automatické pokračování",
   "feature_auto_pip": "{{icon:pip}} Auto Obraz v obraze",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Aktiveret",
   "status_disabled": "Deaktiveret",
+  "shortcut_enable": "Aktivér",
+  "shortcut_disable": "Deaktivér",
   "feature_auto_pause": "{{icon:pause}} Auto-pause",
   "feature_auto_resume": "{{icon:play}} Auto-genoptag",
   "feature_auto_pip": "{{icon:pip}} Auto-PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Aktiviert",
   "status_disabled": "Deaktiviert",
+  "shortcut_enable": "Aktivieren",
+  "shortcut_disable": "Deaktivieren",
   "feature_auto_pause": "{{icon:pause}} Auto-Pause",
   "feature_auto_resume": "{{icon:play}} Auto-Fortsetzen",
   "feature_auto_pip": "{{icon:pip}} Auto-PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Enabled",
   "status_disabled": "Disabled",
+  "shortcut_enable": "Enable",
+  "shortcut_disable": "Disable",
   "feature_auto_pause": "{{icon:pause}} Auto-Pause",
   "feature_auto_resume": "{{icon:play}} Auto-Resume",
   "feature_auto_pip": "{{icon:pip}} Auto PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Enabled",
   "status_disabled": "Disabled",
+  "shortcut_enable": "Enable",
+  "shortcut_disable": "Disable",
   "feature_auto_pause": "{{icon:pause}} Auto-Pause",
   "feature_auto_resume": "{{icon:play}} Auto-Resume",
   "feature_auto_pip": "{{icon:pip}} Auto PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Enabled",
   "status_disabled": "Disabled",
+  "shortcut_enable": "Enable",
+  "shortcut_disable": "Disable",
   "feature_auto_pause": "{{icon:pause}} Auto-Pause",
   "feature_auto_resume": "{{icon:play}} Auto-Resume",
   "feature_auto_pip": "{{icon:pip}} Auto PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Activado",
   "status_disabled": "Desactivado",
+  "shortcut_enable": "Activar",
+  "shortcut_disable": "Desactivar",
   "feature_auto_pause": "{{icon:pause}} Pausa automática",
   "feature_auto_resume": "{{icon:play}} Reanudación automática",
   "feature_auto_pip": "{{icon:pip}} PiP automático",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Activé",
   "status_disabled": "Désactivé",
+  "shortcut_enable": "Activer",
+  "shortcut_disable": "Désactiver",
   "feature_auto_pause": "{{icon:pause}} Pause auto",
   "feature_auto_resume": "{{icon:play}} Reprise auto",
   "feature_auto_pip": "{{icon:pip}} PiP auto",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
@@ -714,6 +714,8 @@
   "hidden_content_group_cast": "Cast / Actors",
   "status_enabled": "מופעל",
   "status_disabled": "מבוטל",
+  "shortcut_enable": "הפעלה",
+  "shortcut_disable": "השבתה",
   "selection_included": "כלול",
   "hidden_content_show_button_details_desc": "Show the hide button on movie and series detail pages",
   "active_streams_none": "No Active Streams",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Engedélyezve",
   "status_disabled": "Letiltva",
+  "shortcut_enable": "Engedélyezés",
+  "shortcut_disable": "Letiltás",
   "feature_auto_pause": "{{icon:pause}} Automatikus szüneteltetés",
   "feature_auto_resume": "{{icon:play}} Automatikus folytatás",
   "feature_auto_pip": "{{icon:pip}} Automatikus kép a képben",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Abilitato",
   "status_disabled": "Disabilitato",
+  "shortcut_enable": "Abilita",
+  "shortcut_disable": "Disabilita",
   "feature_auto_pause": "{{icon:pause}} Pausa automatica",
   "feature_auto_resume": "{{icon:play}} Ripresa automatica",
   "feature_auto_pip": "{{icon:pip}} Auto-PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Ingeschakeld",
   "status_disabled": "Uitgeschakeld",
+  "shortcut_enable": "Inschakelen",
+  "shortcut_disable": "Uitschakelen",
   "feature_auto_pause": "{{icon:pause}} Automatisch pauzeren",
   "feature_auto_resume": "{{icon:play}} Automatisch hervatten",
   "feature_auto_pip": "{{icon:pip}} Automatisch PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Aktivert",
   "status_disabled": "Deaktivert",
+  "shortcut_enable": "Aktiver",
+  "shortcut_disable": "Deaktiver",
   "feature_auto_pause": "{{icon:pause}} Automatisk pause",
   "feature_auto_resume": "{{icon:play}} Automatisk gjenoppta",
   "feature_auto_pip": "{{icon:pip}} Automatisk 'Bilde i bilde' (PiP)",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Włączono",
   "status_disabled": "Wyłączono",
+  "shortcut_enable": "Włącz",
+  "shortcut_disable": "Wyłącz",
   "feature_auto_pause": "{{icon:pause}} Auto-pauza",
   "feature_auto_resume": "{{icon:play}} Auto-wznowienie",
   "feature_auto_pip": "{{icon:pip}} Auto PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Hoisted",
   "status_disabled": "Furled",
+  "shortcut_enable": "Hoist",
+  "shortcut_disable": "Furl",
   "feature_auto_pause": "{{icon:pause}} Auto Drop Anchor",
   "feature_auto_resume": "{{icon:play}} Auto Weigh Anchor",
   "feature_auto_pip": "{{icon:pip}} Auto Spyglass",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Ativado",
   "status_disabled": "Desativado",
+  "shortcut_enable": "Ativar",
+  "shortcut_disable": "Desativar",
   "feature_auto_pause": "{{icon:pause}} Pausa Automática",
   "feature_auto_resume": "{{icon:play}} Retomada Automática",
   "feature_auto_pip": "{{icon:pip}} PiP Automático",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Ativado",
   "status_disabled": "Desativado",
+  "shortcut_enable": "Ativar",
+  "shortcut_disable": "Desativar",
   "feature_auto_pause": "{{icon:pause}} Pausa Automática",
   "feature_auto_resume": "{{icon:play}} Retomada Automática",
   "feature_auto_pip": "{{icon:pip}} PiP Automático",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Включено",
   "status_disabled": "Отключено",
+  "shortcut_enable": "Включить",
+  "shortcut_disable": "Отключить",
   "feature_auto_pause": "{{icon:pause}} Автопауза",
   "feature_auto_resume": "{{icon:play}} Автовозобновление",
   "feature_auto_pip": "{{icon:pip}} Автоматический PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Povolené",
   "status_disabled": "Zakázané",
+  "shortcut_enable": "Povoliť",
+  "shortcut_disable": "Zakázať",
   "feature_auto_pause": "{{icon:pause}} Automatické pozastavenie",
   "feature_auto_resume": "{{icon:play}} Automatické pokračovanie",
   "feature_auto_pip": "{{icon:pip}} Auto Obraz v obraze",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Aktiverad",
   "status_disabled": "Inaktiverad",
+  "shortcut_enable": "Aktivera",
+  "shortcut_disable": "Inaktivera",
   "feature_auto_pause": "{{icon:pause}} Auto-paus",
   "feature_auto_resume": "{{icon:play}} Auto-återuppta",
   "feature_auto_pip": "{{icon:pip}} Auto-PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "Etkin",
   "status_disabled": "Devre Dışı",
+  "shortcut_enable": "Etkinleştir",
+  "shortcut_disable": "Devre dışı bırak",
   "feature_auto_pause": "{{icon:pause}} Otomatik Duraklat",
   "feature_auto_resume": "{{icon:play}} Otomatik Devam Et",
   "feature_auto_pip": "{{icon:pip}} Otomatik PiP",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "已启用",
   "status_disabled": "已停用",
+  "shortcut_enable": "启用",
+  "shortcut_disable": "禁用",
   "feature_auto_pause": "{{icon:pause}} 自动暂停",
   "feature_auto_resume": "{{icon:play}} 自动继续播放",
   "feature_auto_pip": "{{icon:pip}} 自动画中画",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
@@ -24,6 +24,8 @@
   "toast_feature_status": "{feature} {status}",
   "status_enabled": "已啟用",
   "status_disabled": "已停用",
+  "shortcut_enable": "啟用",
+  "shortcut_disable": "停用",
   "feature_auto_pause": "{{icon:pause}} 自動暫停",
   "feature_auto_resume": "{{icon:play}} 自動繼續播放",
   "feature_auto_pip": "{{icon:pip}} 自動畫中畫",

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/config-page-shortcuts.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/config-page-shortcuts.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+
+const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
+const SRC_ROOT = TEST_FILE_PATH.replace(/\/core\/[^/]+$/, '/');
+const CONFIG_PAGE_JS = SRC_ROOT.replace(/src\/$/, 'Configuration/config-page.js');
+const CONFIG_PAGE_HTML = SRC_ROOT.replace(/src\/$/, 'Configuration/configPage.html');
+
+function read(path: string): string {
+    const source = ts.sys.readFile(path);
+    expect(source, `missing source: ${path}`).toBeTruthy();
+    return source!;
+}
+
+function productionFunction(source: string, name: string): string {
+    const match = source.match(new RegExp(
+        `^ {8}function ${name}\\([^\\n]*\\) \\{[\\s\\S]*?^ {8}\\}`,
+        'm',
+    ));
+    expect(match, `missing production helper: ${name}`).toBeTruthy();
+    return match![0];
+}
+
+interface Shortcut {
+    Name: string;
+    Key: string;
+    Label?: string;
+    [key: string]: unknown;
+}
+
+interface Helpers {
+    normalize(value: unknown): string;
+    conflict(left: unknown, right: unknown): boolean;
+    effective(defaults: Shortcut[], overrides: Shortcut[]): Shortcut[];
+    setOverride(overrides: Shortcut[], defaults: Shortcut[], action: string, binding: string | null): Shortcut[];
+    findConflict(defaults: Shortcut[], overrides: Shortcut[], action: string, binding: string): Shortcut | undefined;
+    merge(defaults: Shortcut[], overrides: Shortcut[], persisted: Shortcut[]): Shortcut[];
+}
+
+function loadHelpers(source: string): Helpers {
+    const names = [
+        'jcNormalizeAdminShortcut',
+        'jcAdminShortcutBindingsConflict',
+        'jcAdminEffectiveShortcuts',
+        'jcSetAdminShortcutOverride',
+        'jcAdminShortcutConflict',
+        'jcMergeAdminShortcutRows',
+    ];
+    // Execute only closed helpers extracted from checked-in production source.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const factory = new Function([
+        ...names.map(name => productionFunction(source, name)),
+        `return {
+            normalize: jcNormalizeAdminShortcut,
+            conflict: jcAdminShortcutBindingsConflict,
+            effective: jcAdminEffectiveShortcuts,
+            setOverride: jcSetAdminShortcutOverride,
+            findConflict: jcAdminShortcutConflict,
+            merge: jcMergeAdminShortcutRows
+        };`,
+    ].join('\n')) as () => Helpers;
+    return factory();
+}
+
+describe('admin shortcut configuration contract', () => {
+    const js = read(CONFIG_PAGE_JS);
+    const html = read(CONFIG_PAGE_HTML);
+    const helpers = loadHelpers(js);
+    const defaults: Shortcut[] = [
+        { Name: 'Play', Key: 'P', Label: 'Play' },
+        { Name: 'JumpToPercentage', Key: '0-9', Label: 'Jump' },
+    ];
+
+    it('renders the full action list with deliberate Disable and Reset semantics', () => {
+        expect(js).toContain('jcAdminEffectiveShortcuts(defaultShortcuts, shortcutOverrides)');
+        expect(js).toContain("shortcut.Name === 'JumpToPercentage'");
+        expect(js).toContain("stateBtn.textContent = isDisabled && isGroup ? 'Enable' : 'Disable'");
+        expect(js).toContain("resetBtn.textContent = 'Reset'");
+        expect(html).toContain('Clearing a text field does not disable an action');
+    });
+
+    it('normalizes modifiers and reserves only bare digits for the group', () => {
+        expect(helpers.normalize('shift+ctrl+k')).toBe('Ctrl+Shift+K');
+        expect(helpers.normalize('ctrl+ ')).toBe('Ctrl+Space');
+        expect(helpers.conflict('0-9', '5')).toBe(true);
+        expect(helpers.conflict('0-9', 'Ctrl+5')).toBe(false);
+        expect(helpers.conflict('', '5')).toBe(false);
+    });
+
+    it('calculates conflicts from the effective map rather than disabled defaults', () => {
+        expect(helpers.findConflict(defaults, [], 'Play', '5')?.Name).toBe('JumpToPercentage');
+        const disabledGroup = [{ Name: 'JumpToPercentage', Key: '', Label: 'Jump' }];
+        expect(helpers.findConflict(defaults, disabledGroup, 'Play', '5')).toBeUndefined();
+        expect(helpers.findConflict(defaults, [], 'Play', 'Ctrl+5')).toBeUndefined();
+    });
+
+    it('uses one last-wins override and Reset removes every duplicate', () => {
+        const duplicates = [
+            { Name: 'Play', Key: 'X', Earlier: true },
+            { Name: 'Play', Key: 'Y', Future: { owner: 'last' } },
+        ];
+        expect(helpers.setOverride(duplicates, defaults, 'Play', '')).toEqual([
+            { Name: 'Play', Key: '', Label: 'Play', Future: { owner: 'last' } },
+        ]);
+        expect(helpers.setOverride(duplicates, defaults, 'Play', null)).toEqual([]);
+    });
+
+    it('persists empty keys while preserving known and unknown row metadata', () => {
+        const persisted = [
+            { Name: 'Play', Key: 'P', Future: { exact: 9007199254740993n.toString() } },
+            { Name: 'FutureAction', Key: '', Opaque: { keep: true } },
+        ];
+        const overrides = [
+            { Name: 'Play', Key: '', Label: 'Play' },
+            { Name: 'FutureAction', Key: '', Opaque: { keep: true } },
+        ];
+
+        expect(helpers.merge(defaults, overrides, persisted)).toEqual([
+            {
+                Name: 'Play', Key: '', Label: 'Play',
+                Future: { exact: '9007199254740993' },
+            },
+            { Name: 'JumpToPercentage', Key: '0-9', Label: 'Jump' },
+            { Name: 'FutureAction', Key: '', Opaque: { keep: true } },
+        ]);
+    });
+
+    it('preserves JavaScript prototype names as ordinary shortcut rows', () => {
+        const poisonNames = ['__proto__', 'constructor', 'toString'];
+        const poisonDefaults = poisonNames.map(Name => ({ Name, Key: 'P', Label: Name }));
+        const overrides = poisonNames.map(Name => ({ Name, Key: '', Opaque: { Name } }));
+        const persisted = poisonNames.map(Name => ({ Name, Key: 'X', Future: { Name } }));
+
+        expect(helpers.effective(poisonDefaults, overrides)).toEqual(
+            poisonNames.map(Name => ({ Name, Key: '', Label: Name, Opaque: { Name } })),
+        );
+        expect(helpers.merge(poisonDefaults, overrides, persisted)).toEqual(
+            poisonNames.map(Name => ({
+                Name,
+                Key: '',
+                Label: Name,
+                Future: { Name },
+                Opaque: { Name },
+            })),
+        );
+        expect(helpers.effective([], overrides).map(row => row.Name)).toEqual(poisonNames);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.shortcuts.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.shortcuts.test.ts
@@ -86,4 +86,63 @@ describe('shortcut configuration migration', () => {
             ],
         });
     });
+
+    it('treats an empty named row as an intentional user disable', () => {
+        JC.pluginConfig = {
+            Shortcuts: [
+                { Name: 'Play', Key: 'P' },
+                { Name: 'JumpToPercentage', Key: '0-9' },
+            ],
+        };
+        JC.userConfig = {
+            shortcuts: {
+                Revision: 8,
+                Shortcuts: [
+                    { Name: 'Play', Key: '' },
+                    { Name: 'JumpToPercentage', Key: '' },
+                ],
+            },
+        };
+
+        JC.initializeShortcuts!();
+
+        expect(JC.state!.activeShortcuts).toEqual({
+            Play: '',
+            JumpToPercentage: '',
+        });
+        expect(JC.userConfig.shortcuts!.Shortcuts).toEqual([
+            { Name: 'Play', Key: '' },
+            { Name: 'JumpToPercentage', Key: '' },
+        ]);
+    });
+
+    it('allows a user sentinel to re-enable an admin-disabled percentage group', () => {
+        JC.pluginConfig = { Shortcuts: [{ Name: 'JumpToPercentage', Key: '' }] };
+        JC.userConfig = {
+            shortcuts: { Shortcuts: [{ Name: 'JumpToPercentage', Key: '0-9' }] },
+        };
+
+        JC.initializeShortcuts!();
+
+        expect(JC.state!.activeShortcuts.JumpToPercentage).toBe('0-9');
+    });
+
+    it('replaces A-only disabled and custom bindings when account B initializes', () => {
+        JC.pluginConfig = { Shortcuts: [{ Name: 'Play', Key: 'P' }] };
+        JC.userConfig = {
+            shortcuts: {
+                Shortcuts: [
+                    { Name: 'Play', Key: '' },
+                    { Name: 'OnlyA', Key: 'A' },
+                ],
+            },
+        };
+        JC.initializeShortcuts!();
+        expect(JC.state!.activeShortcuts).toEqual({ Play: '', OnlyA: 'A' });
+
+        JC.userConfig = { shortcuts: { Shortcuts: [] } };
+        JC.initializeShortcuts!();
+
+        expect(JC.state!.activeShortcuts).toEqual({ Play: 'P' });
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.shortcuts.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.shortcuts.test.ts
@@ -25,6 +25,7 @@ describe('enhanced shortcut dispatch', () => {
         };
         (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => false;
         JC.t = (key: string) => key;
+        JC.showEnhancedPanel = vi.fn().mockResolvedValue(undefined);
         window.location.hash = '#/start';
     });
 
@@ -79,4 +80,171 @@ describe('enhanced shortcut dispatch', () => {
         expect(event.defaultPrevented).toBe(true);
         expect(window.location.hash).toBe('#/home.html');
     });
+
+    it('owns Jellyfin 12 digit dispatch in capture phase and seeks exactly once', () => {
+        document.body.innerHTML = '<video id="player"></video>';
+        JC.state!.activeShortcuts = { JumpToPercentage: '0-9' };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        const jump = vi.fn();
+        JC.jumpToPercentage = jump;
+        const host = vi.fn();
+        document.addEventListener('keydown', host);
+        JC.initializeCanopyScript!();
+
+        document.getElementById('player')!.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '5', code: 'Digit5', bubbles: true, cancelable: true,
+        }));
+
+        expect(jump).toHaveBeenCalledTimes(1);
+        expect(jump).toHaveBeenCalledWith(50);
+        expect(host).not.toHaveBeenCalled();
+        document.removeEventListener('keydown', host);
+    });
+
+    it('keeps disabled percentage seeking from leaking to Jellyfin native handling', () => {
+        document.body.innerHTML = '<video id="player"></video>';
+        JC.state!.activeShortcuts = { JumpToPercentage: '' };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        const jump = vi.fn();
+        JC.jumpToPercentage = jump;
+        const host = vi.fn();
+        document.addEventListener('keydown', host);
+        JC.initializeCanopyScript!();
+
+        document.getElementById('player')!.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '9', code: 'Numpad9', bubbles: true, cancelable: true,
+        }));
+
+        expect(jump).not.toHaveBeenCalled();
+        expect(host).not.toHaveBeenCalled();
+        document.removeEventListener('keydown', host);
+    });
+
+    it('gives the always-active panel shortcut precedence over a global question-mark binding', () => {
+        JC.state!.activeShortcuts = { GoToHome: '?' };
+        const showPanel = vi.mocked(JC.showEnhancedPanel!);
+        JC.initializeCanopyScript!();
+
+        document.body.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '?', code: 'Slash', shiftKey: true, bubbles: true, cancelable: true,
+        }));
+
+        expect(showPanel).toHaveBeenCalledTimes(1);
+        expect(window.location.hash).toBe('#/start');
+    });
+
+    it('gives the always-active panel shortcut precedence over a player question-mark binding', () => {
+        document.body.innerHTML = '<video></video>';
+        JC.state!.activeShortcuts = { FrameStepForward: '?' };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        const showPanel = vi.mocked(JC.showEnhancedPanel!);
+        const frameStep = vi.fn();
+        JC.frameStep = frameStep;
+        JC.initializeCanopyScript!();
+
+        document.querySelector('video')!.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '?', code: 'Slash', shiftKey: true, bubbles: true, cancelable: true,
+        }));
+
+        expect(showPanel).toHaveBeenCalledTimes(1);
+        expect(frameStep).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['Ctrl', { ctrlKey: true }],
+        ['Alt', { altKey: true }],
+        ['Meta', { metaKey: true }],
+    ])('leaves an unbound %s+digit available to downstream listeners', (_label, modifier) => {
+        document.body.innerHTML = '<video></video>';
+        JC.state!.activeShortcuts = { JumpToPercentage: '0-9' };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        JC.initializeCanopyScript!();
+        const downstream = vi.fn((event: KeyboardEvent) => event);
+        document.addEventListener('keydown', downstream);
+
+        document.querySelector('video')!.dispatchEvent(new KeyboardEvent('keydown', {
+            key: '5', code: 'Digit5', ...modifier, bubbles: true, cancelable: true,
+        }));
+
+        expect(downstream).toHaveBeenCalledTimes(1);
+        expect(downstream.mock.calls[0][0].defaultPrevented).toBe(false);
+        document.removeEventListener('keydown', downstream);
+    });
+
+    it.each([
+        ['Ctrl+5', { key: '5', code: 'Digit5', ctrlKey: true }, 'Ctrl+5'],
+        ['Alt+5', { key: '5', code: 'Digit5', altKey: true }, 'Alt+5'],
+        ['Meta+5', { key: '5', code: 'Digit5', metaKey: true }, 'Meta+5'],
+        ['shifted punctuation', { key: '%', code: 'Digit5', shiftKey: true }, '%'],
+    ])('dispatches an ordinary %s binding without percentage seeking', (_label, init, binding) => {
+        document.body.innerHTML = '<video></video>';
+        JC.state!.activeShortcuts = {
+            FrameStepForward: binding,
+            JumpToPercentage: '0-9',
+        };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        const frameStep = vi.fn();
+        const jump = vi.fn();
+        JC.frameStep = frameStep;
+        JC.jumpToPercentage = jump;
+
+        JC.keyListener!(new KeyboardEvent('keydown', {
+            ...init,
+            cancelable: true,
+        }));
+
+        expect(frameStep).toHaveBeenCalledTimes(1);
+        expect(frameStep).toHaveBeenCalledWith('forward');
+        expect(jump).not.toHaveBeenCalled();
+    });
+
+    it('gives a legacy exact bare-digit binding precedence over the percentage group', () => {
+        document.body.innerHTML = '<video></video>';
+        JC.state!.activeShortcuts = {
+            FrameStepForward: '5',
+            JumpToPercentage: '0-9',
+        };
+        (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+        const frameStep = vi.fn();
+        const jump = vi.fn();
+        JC.frameStep = frameStep;
+        JC.jumpToPercentage = jump;
+
+        JC.keyListener!(new KeyboardEvent('keydown', {
+            key: '5', code: 'Digit5', cancelable: true,
+        }));
+
+        expect(frameStep).toHaveBeenCalledTimes(1);
+        expect(jump).not.toHaveBeenCalled();
+    });
+
+    it.each(['input', 'select', 'contenteditable', 'modal', 'global-disable'])(
+        'suppresses host digit seeking without Canopy dispatch at the %s boundary',
+        (boundary) => {
+            document.body.innerHTML = boundary === 'input'
+                ? '<input id="target"><video></video>'
+                : boundary === 'select'
+                    ? '<select id="target"><option>one</option></select><video></video>'
+                    : boundary === 'contenteditable'
+                        ? '<div id="target" contenteditable="true"></div><video></video>'
+                        : '<div id="target"></div><video></video>';
+            JC.state!.activeShortcuts = { JumpToPercentage: '0-9' };
+            (JC as unknown as { isVideoPage: () => boolean }).isVideoPage = () => true;
+            if (boundary === 'modal') document.body.classList.add('jc-modal-open');
+            if (boundary === 'global-disable') JC.pluginConfig.DisableAllShortcuts = true;
+            const jump = vi.fn();
+            const host = vi.fn();
+            JC.jumpToPercentage = jump;
+            document.addEventListener('keydown', host);
+            JC.initializeCanopyScript!();
+            document.getElementById('target')!.dispatchEvent(new KeyboardEvent('keydown', {
+                key: '4', code: 'Digit4', bubbles: true, cancelable: true,
+            }));
+
+            expect(jump).not.toHaveBeenCalled();
+            expect(host).not.toHaveBeenCalled();
+            document.removeEventListener('keydown', host);
+            document.body.classList.remove('jc-modal-open');
+        },
+    );
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/events.ts
@@ -11,7 +11,15 @@ import { toast } from '../core/ui-kit';
 import { stampLayoutClass } from '../core/layout';
 import { migrateLegacyClientStorage } from './legacy-storage-migration';
 import type { IdentityContext } from '../types/jc';
-import { canonicalizeShortcut, shortcutFromEvent, shortcutsEqual } from './shortcut-codec';
+import {
+    canonicalizeShortcut,
+    hasShortcutModifiers,
+    isPercentageShortcutBinding,
+    physicalDigitFromEvent,
+    PERCENTAGE_SHORTCUT_NAME,
+    shortcutFromEvent,
+    shortcutsEqual,
+} from './shortcut-codec';
 
 interface EventOwner {
     isCurrent(): boolean;
@@ -25,6 +33,18 @@ function callOptional(name: string, ...args: unknown[]): unknown {
 
 function isVideoPage(): boolean {
     return callOptional('isVideoPage') === true;
+}
+
+/** True when a keyboard event belongs to a form or contenteditable owner. */
+function isEditableShortcutTarget(event: KeyboardEvent): boolean {
+    const candidates = [event.target, document.activeElement];
+    return candidates.some(candidate => {
+        if (!(candidate instanceof Element)) return false;
+        const editable = candidate.closest('input, textarea, select, [contenteditable]');
+        if (!editable) return false;
+        return editable.matches('input, textarea, select')
+            || editable.getAttribute('contenteditable') !== 'false';
+    });
 }
 
 /**
@@ -44,7 +64,9 @@ function panelKeyListener(e: KeyboardEvent, owner: EventOwner): void {
 
     if (e.key === '?') {
         e.preventDefault();
-        e.stopPropagation();
+        // This always-active owner is registered before the ordinary bubble
+        // listener. Keep a user-bound `?` from also dispatching underneath it.
+        e.stopImmediatePropagation();
         callOptional('showEnhancedPanel');
     }
 }
@@ -53,7 +75,9 @@ function panelKeyListener(e: KeyboardEvent, owner: EventOwner): void {
  * The main key listener for all other shortcuts.
  * @param e The keyboard event.
  */
-function keyListener(e: KeyboardEvent, owner: EventOwner): void {
+function keyListener(e: KeyboardEvent, owner: EventOwner, videoPage = isVideoPage()): void {
+    const physicalDigit = physicalDigitFromEvent(e);
+
     const context = JC.identity.capture();
     if (!owner.isCurrent() || !context
         || JC.pluginConfig?.DisableAllShortcuts
@@ -61,7 +85,7 @@ function keyListener(e: KeyboardEvent, owner: EventOwner): void {
     // INT-1: suppress every global shortcut while any JC modal is open so a
     // configured key can't fire through the dialog and navigate the SPA away.
     if (isAnyModalOpen() || document.body.classList.contains('jc-modal-open')) return;
-    if (['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName || '')) return;
+    if (isEditableShortcutTarget(e)) return;
 
     const combo = shortcutFromEvent(e);
     if (!combo) return;
@@ -96,8 +120,12 @@ function keyListener(e: KeyboardEvent, owner: EventOwner): void {
         document.getElementById('randomItemButton')?.click();
     }
 
+    // Legacy collisions are deterministic: the first exact named action owns
+    // the event, and the grouped percentage policy never runs after it.
+    if (e.defaultPrevented) return;
+
     // --- Player-Only Shortcuts ---
-    if (!isVideoPage() || !video) return;
+    if (!videoPage || !video) return;
 
     switch (combo) {
         case canonicalizeShortcut(activeShortcuts.BookmarkCurrentTime):
@@ -224,9 +252,32 @@ function keyListener(e: KeyboardEvent, owner: EventOwner): void {
             break;
     }
 
-    if (e.key.match(/^[0-9]$/)) {
-        callOptional('jumpToPercentage', parseInt(e.key) * 10);
+    if (!e.defaultPrevented
+        && physicalDigit !== null
+        && !hasShortcutModifiers(e)
+        && isPercentageShortcutBinding(activeShortcuts[PERCENTAGE_SHORTCUT_NAME])) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        callOptional('jumpToPercentage', physicalDigit * 10);
     }
+}
+
+/**
+ * Jellyfin 12 owns bare physical digits in a document-bubble listener and
+ * ignores defaultPrevented (including shifted Digit/Numpad keys). Capture only
+ * that native surface; modified digits remain ordinary shortcuts/events.
+ */
+function nativeDigitCaptureListener(e: KeyboardEvent, owner: EventOwner): void {
+    if (physicalDigitFromEvent(e) === null
+        || e.ctrlKey
+        || e.altKey
+        || e.metaKey
+        || !isVideoPage()) {
+        return;
+    }
+
+    e.stopImmediatePropagation();
+    keyListener(e, owner, true);
 }
 
 /**
@@ -377,6 +428,7 @@ class EnhancedEventsActivation implements EventOwner {
         this.addContextMenuListener();
 
         this.listen(document, 'keydown', (event) => panelKeyListener(event as KeyboardEvent, this));
+        this.listen(document, 'keydown', (event) => nativeDigitCaptureListener(event as KeyboardEvent, this), true);
         this.listen(document, 'keydown', stableEvents.facade.keyListener as EventListener);
 
         const videoPageCheck = (handlerName: string) => (e: Event): void => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.identity.test.ts
@@ -206,4 +206,202 @@ describe('settings shortcut editor identity ownership', () => {
         expect(key.textContent).toBe('P');
         expect(JC.identity.isCurrent(actor)).toBe(true);
     });
+
+    it('disables one action explicitly, removes duplicate rows, and preserves last-row metadata', async () => {
+        JC.identity.transition('server-a', 'user-a', 'shortcut-disable');
+        const actor = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = `
+            <div class="jc-shortcut-row">
+                <span class="shortcut-key" tabindex="0" data-action="play" data-label="Play">P</span>
+                <span><span class="modified-indicator">•</span>Play</span>
+                <button class="shortcut-state-button" data-action="play" data-operation="disable">Disabled</button>
+                <button class="shortcut-reset-button" data-action="play">Reset</button>
+            </div>`;
+        const shortcuts = {
+            Shortcuts: [
+                { Name: 'play', Key: 'X', Earlier: true },
+                { Name: 'play', Key: 'Y', FutureMetadata: { owner: 'last' } },
+            ],
+        };
+        const activeShortcuts = { play: 'Y' };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.t = (key: string) => ({
+            status_disabled: 'Disabled', shortcut_enable: 'Enable', shortcut_disable: 'Disable',
+        })[key] || key;
+        const editor: PanelEditorContext = {
+            mode: 'self', actor, targetUserId: actor.userId, targetDisplayName: '', appliesToActor: true,
+            settings: {}, shortcuts, activeShortcuts,
+            isCurrent: () => JC.identity.isCurrent(actor), saveSettings: save, saveShortcuts: save,
+        };
+        wireShortcutEditor({
+            help, editor, pluginShortcuts: [{ Name: 'play', Key: 'P' }],
+            primaryAccentColor: '#0ff', kbdBackground: '#111', identityContext: actor, trackTimer,
+        } as unknown as PanelContext);
+
+        help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.click();
+
+        expect(shortcuts.Shortcuts).toEqual([
+            { Name: 'play', Key: '', FutureMetadata: { owner: 'last' } },
+        ]);
+        await vi.waitFor(() => expect(activeShortcuts.play).toBe(''));
+        expect(help.querySelector('.shortcut-key')!.textContent).toBe('Disabled');
+        expect(help.querySelector('.shortcut-key')!.classList.contains('shortcut-disabled')).toBe(true);
+        expect(help.querySelector('.shortcut-key')!.getAttribute('aria-label')).toBe('Play: Disabled');
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-state-button')).toMatchObject({
+            textContent: 'Enable', disabled: true,
+        });
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.dataset.operation).toBe('enable');
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.getAttribute('aria-label'))
+            .toBe('Enable: Play');
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-reset-button')!.disabled).toBe(false);
+    });
+
+    it('resets a disabled override to the current admin value', async () => {
+        JC.identity.transition('server-a', 'user-a', 'shortcut-reset');
+        const actor = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = `
+            <div class="jc-shortcut-row">
+                <span class="shortcut-key shortcut-disabled" tabindex="0" data-action="play" data-label="Play">Disabled</span>
+                <span><span class="modified-indicator">•</span>Play</span>
+                <button class="shortcut-state-button" data-action="play" data-operation="enable" disabled>Enabled</button>
+                <button class="shortcut-reset-button" data-action="play">Reset</button>
+            </div>`;
+        const shortcuts = { Shortcuts: [{ Name: 'play', Key: '' }] };
+        const activeShortcuts = { play: '' };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.t = (key: string) => ({
+            status_disabled: 'Disabled', shortcut_enable: 'Enable', shortcut_disable: 'Disable',
+        })[key] || key;
+        const editor: PanelEditorContext = {
+            mode: 'self', actor, targetUserId: actor.userId, targetDisplayName: '', appliesToActor: true,
+            settings: {}, shortcuts, activeShortcuts,
+            isCurrent: () => JC.identity.isCurrent(actor), saveSettings: save, saveShortcuts: save,
+        };
+        wireShortcutEditor({
+            help, editor, pluginShortcuts: [{ Name: 'play', Key: 'Ctrl+P' }],
+            primaryAccentColor: '#0ff', kbdBackground: '#111', identityContext: actor, trackTimer,
+        } as unknown as PanelContext);
+
+        help.querySelector<HTMLButtonElement>('.shortcut-reset-button')!.click();
+
+        expect(shortcuts.Shortcuts).toEqual([]);
+        await vi.waitFor(() => expect(activeShortcuts.play).toBe('Ctrl+P'));
+        expect(help.querySelector('.shortcut-key')!.getAttribute('aria-label')).toBe('Play: Ctrl+P');
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-state-button')).toMatchObject({
+            textContent: 'Disable', disabled: false,
+        });
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.dataset.operation).toBe('disable');
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.getAttribute('aria-label'))
+            .toBe('Disable: Play');
+        expect(help.querySelector('.modified-indicator')).toBeNull();
+        expect(help.querySelector<HTMLButtonElement>('.shortcut-reset-button')!.disabled).toBe(true);
+    });
+
+    it('keeps the percentage group static and rejects enabling it across a bare-digit binding', () => {
+        vi.useFakeTimers();
+        JC.identity.transition('server-a', 'user-a', 'shortcut-group-conflict');
+        const actor = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = `
+            <div class="jc-shortcut-row">
+                <span class="shortcut-key shortcut-group-key shortcut-disabled" data-action="JumpToPercentage">Disabled</span>
+                <span>Jump</span>
+                <button class="shortcut-state-button" data-action="JumpToPercentage" data-operation="enable">Enabled</button>
+                <button class="shortcut-reset-button" data-action="JumpToPercentage" disabled>Reset</button>
+            </div>`;
+        const shortcuts = { Shortcuts: [] as Array<{ Name: string; Key: string }> };
+        const activeShortcuts = { JumpToPercentage: '', Other: '5' };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        const editor: PanelEditorContext = {
+            mode: 'self', actor, targetUserId: actor.userId, targetDisplayName: '', appliesToActor: true,
+            settings: {}, shortcuts, activeShortcuts,
+            isCurrent: () => JC.identity.isCurrent(actor), saveSettings: save, saveShortcuts: save,
+        };
+        wireShortcutEditor({
+            help, editor,
+            pluginShortcuts: [{ Name: 'JumpToPercentage', Key: '0-9' }, { Name: 'Other', Key: '5' }],
+            primaryAccentColor: '#0ff', kbdBackground: '#111', identityContext: actor, trackTimer,
+        } as unknown as PanelContext);
+
+        const groupKey = help.querySelector<HTMLElement>('.shortcut-group-key')!;
+        groupKey.dispatchEvent(new KeyboardEvent('keydown', { key: 'X', bubbles: true }));
+        help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.click();
+
+        expect(groupKey.classList.contains('shake-error')).toBe(true);
+        expect(shortcuts.Shortcuts).toEqual([]);
+        expect(save).not.toHaveBeenCalled();
+    });
+
+    it('re-enables the percentage group over an admin-disabled value when only modified digits exist', async () => {
+        JC.identity.transition('server-a', 'user-a', 'shortcut-group-enable');
+        const actor = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = `
+            <div class="jc-shortcut-row">
+                <span class="shortcut-key shortcut-group-key shortcut-disabled" data-action="JumpToPercentage">Disabled</span>
+                <span>Jump</span>
+                <button class="shortcut-state-button" data-action="JumpToPercentage" data-operation="enable">Enabled</button>
+                <button class="shortcut-reset-button" data-action="JumpToPercentage" disabled>Reset</button>
+            </div>`;
+        const shortcuts = { Shortcuts: [] as Array<{ Name: string; Key: string }> };
+        const activeShortcuts = { JumpToPercentage: '', Other: 'Ctrl+5' };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        JC.t = (key: string) => ({ status_disabled: 'Disabled', status_enabled: 'Enabled' })[key] || key;
+        const editor: PanelEditorContext = {
+            mode: 'self', actor, targetUserId: actor.userId, targetDisplayName: '', appliesToActor: true,
+            settings: {}, shortcuts, activeShortcuts,
+            isCurrent: () => JC.identity.isCurrent(actor), saveSettings: save, saveShortcuts: save,
+        };
+        wireShortcutEditor({
+            help, editor,
+            pluginShortcuts: [{ Name: 'JumpToPercentage', Key: '' }, { Name: 'Other', Key: 'Ctrl+5' }],
+            primaryAccentColor: '#0ff', kbdBackground: '#111', identityContext: actor, trackTimer,
+        } as unknown as PanelContext);
+
+        help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.click();
+
+        // pluginShortcuts is the effective admin tier; enabling always writes
+        // the reserved user sentinel, even when that tier is disabled.
+        expect(shortcuts.Shortcuts).toEqual([{ Name: 'JumpToPercentage', Key: '0-9' }]);
+        await vi.waitFor(() => expect(activeShortcuts.JumpToPercentage).toBe('0-9'));
+    });
+
+    it('updates only an admin-target editor map when disabling a shortcut', async () => {
+        JC.identity.transition('server-a', 'admin-a', 'shortcut-target-disable');
+        const actor = JC.identity.capture()!;
+        const help = document.createElement('div');
+        help.innerHTML = `
+            <div class="jc-shortcut-row">
+                <span class="shortcut-key" data-action="play">P</span><span>Play</span>
+                <button class="shortcut-state-button" data-action="play" data-operation="disable">Disabled</button>
+                <button class="shortcut-reset-button" data-action="play" disabled>Reset</button>
+            </div>`;
+        const targetShortcuts = { Shortcuts: [] as Array<{ Name: string; Key: string }> };
+        const targetActive = { play: 'P' };
+        const actorActive = { play: 'A' };
+        JC.state = { activeShortcuts: actorActive } as unknown as NonNullable<typeof JC.state>;
+        JC.pluginConfig = { DisableAllShortcuts: false };
+        const save = vi.fn().mockResolvedValue(undefined);
+        const editor: PanelEditorContext = {
+            mode: 'admin-target', actor, targetUserId: 'target', targetDisplayName: 'Target', appliesToActor: false,
+            settings: {}, shortcuts: targetShortcuts, activeShortcuts: targetActive,
+            isCurrent: () => JC.identity.isCurrent(actor), saveSettings: save, saveShortcuts: save,
+        };
+        wireShortcutEditor({
+            help, editor, pluginShortcuts: [{ Name: 'play', Key: 'P' }],
+            primaryAccentColor: '#0ff', kbdBackground: '#111', identityContext: actor, trackTimer,
+        } as unknown as PanelContext);
+
+        help.querySelector<HTMLButtonElement>('.shortcut-state-button')!.click();
+
+        await vi.waitFor(() => expect(targetActive.play).toBe(''));
+        expect(actorActive.play).toBe('A');
+        expect(JC.state.activeShortcuts).toBe(actorActive);
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/shortcut-editor.ts
@@ -7,10 +7,13 @@
 
 import { JC } from '../../globals';
 import {
+    canonicalizeShortcut,
     formatShortcut,
     normalizeShortcutEntries,
+    PERCENTAGE_SHORTCUT_NAME,
+    PERCENTAGE_SHORTCUT_RANGE,
+    shortcutBindingsConflict,
     shortcutFromEvent,
-    shortcutsEqual,
 } from '../shortcut-codec';
 import type { PanelContext } from './panel';
 import { toast } from '../../core/ui-kit';
@@ -47,11 +50,108 @@ export function wireShortcutEditor(ctx: PanelContext): void {
         await ctx.reconcileAfterSaveFailure?.();
     };
 
+    const shortcutEntries = shortcuts.Shortcuts;
+    const defaultFor = (action: string): any => pluginShortcuts.find((shortcut: any) => shortcut?.Name === action);
+    const hasOverride = (action: string): boolean => shortcutEntries.some((shortcut: any) => shortcut?.Name === action);
+    const effectiveDefault = (action: string): string => canonicalizeShortcut(defaultFor(action)?.Key);
+    const replaceOverride = (action: string, binding: string | null): void => {
+        let preserved: any = null;
+        for (let index = shortcutEntries.length - 1; index >= 0; index -= 1) {
+            if (shortcutEntries[index]?.Name !== action) continue;
+            if (!preserved) preserved = shortcutEntries[index];
+            shortcutEntries.splice(index, 1);
+        }
+        if (binding !== null) {
+            shortcutEntries.push({
+                ...defaultFor(action),
+                ...preserved,
+                Name: action,
+                Key: binding,
+            });
+        }
+        normalizeShortcutEntries(shortcutEntries);
+    };
+    const conflictFor = (action: string, binding: string): string | undefined => Object.keys(activeShortcuts)
+        .find(name => name !== action && shortcutBindingsConflict(activeShortcuts[name], binding));
+    const showConflict = (keyElement: HTMLElement): void => {
+        keyElement.style.background = 'rgb(255 0 0 / 60%)';
+        keyElement.classList.add('shake-error');
+        const timer = window.setTimeout(() => {
+            if (!isCurrent()) return;
+            keyElement.classList.remove('shake-error');
+            keyElement.style.background = kbdBackground;
+        }, 500);
+        trackTimer(timer);
+    };
+    const refreshRow = (action: string): void => {
+        const keyElement = Array.from(help.querySelectorAll<HTMLElement>('.shortcut-key'))
+            .find(element => element.dataset.action === action);
+        if (!keyElement) return;
+        const grouped = action === PERCENTAGE_SHORTCUT_NAME;
+        const binding = canonicalizeShortcut(activeShortcuts[action]);
+        const disabled = binding === '';
+        const display = disabled ? JC.t!('status_disabled') : formatShortcut(binding);
+        const label = keyElement.dataset.label || defaultFor(action)?.Label || action;
+        keyElement.textContent = display;
+        keyElement.setAttribute('aria-label', `${label}: ${display}`);
+        keyElement.classList.toggle('shortcut-disabled', disabled);
+        keyElement.style.opacity = disabled ? '0.72' : '1';
+        keyElement.style.background = kbdBackground;
+        const labelWrapper = keyElement.nextElementSibling;
+        const modified = hasOverride(action);
+        let indicator = labelWrapper?.querySelector<HTMLElement>('.modified-indicator') || null;
+        if (modified && !indicator && labelWrapper) {
+            indicator = document.createElement('span');
+            indicator.className = 'modified-indicator';
+            indicator.title = 'Modified by user';
+            indicator.style.cssText = `color:${primaryAccentColor}; font-size:20px; line-height:1;`;
+            indicator.textContent = '•';
+            labelWrapper.prepend(indicator);
+        } else if (!modified) {
+            indicator?.remove();
+        }
+        const row = keyElement.closest('.jc-shortcut-row');
+        const stateButton = row?.querySelector<HTMLButtonElement>('.shortcut-state-button');
+        if (stateButton) {
+            const operationLabel = disabled ? JC.t!('shortcut_enable') : JC.t!('shortcut_disable');
+            stateButton.dataset.operation = disabled ? 'enable' : 'disable';
+            stateButton.textContent = operationLabel;
+            stateButton.setAttribute('aria-label', `${operationLabel}: ${label}`);
+            stateButton.disabled = !grouped && disabled;
+        }
+        const resetButton = row?.querySelector<HTMLButtonElement>('.shortcut-reset-button');
+        if (resetButton) resetButton.disabled = !modified;
+    };
+    const saveBinding = (
+        action: string,
+        binding: string | null,
+        effectiveAfterSave: string,
+        keyElement: HTMLElement,
+    ): void => {
+        replaceOverride(action, binding);
+        const rowButtons = keyElement.closest('.jc-shortcut-row')?.querySelectorAll<HTMLButtonElement>('button');
+        rowButtons?.forEach(button => { button.disabled = true; });
+        void editor.saveShortcuts().then(() => {
+            if (!canSettleSave()) return;
+            // A self save still publishes after its initiating panel closes;
+            // an admin-target map remains panel-local and actor-isolated.
+            activeShortcuts[action] = effectiveAfterSave;
+            if (!isCurrent()) return;
+            refreshRow(action);
+            keyElement.blur();
+        }).catch((error: unknown) => {
+            void handleSaveFailure(error, keyElement);
+        });
+    };
+
     // --- Shortcut Key Binding Logic ---
     if (!JC.pluginConfig.DisableAllShortcuts) {
-        const shortcutKeys = help.querySelectorAll<HTMLElement>('.shortcut-key');
+        const shortcutKeys = help.querySelectorAll<HTMLElement>('.shortcut-key:not(.shortcut-group-key)');
         shortcutKeys.forEach(keyElement => {
-            const getOriginalKey = () => formatShortcut(activeShortcuts[keyElement.dataset.action!]);
+            const getOriginalKey = () => {
+                const binding = canonicalizeShortcut(activeShortcuts[keyElement.dataset.action!]);
+                return binding ? formatShortcut(binding) : JC.t!('status_disabled');
+            };
 
             keyElement.addEventListener('click', () => { if (isCurrent()) keyElement.focus(); });
 
@@ -74,79 +174,57 @@ export function wireShortcutEditor(ctx: PanelContext): void {
                 e.stopPropagation();
                 if (!isCurrent()) return;
 
-                const labelWrapper = keyElement.nextElementSibling;
                 const action = keyElement.dataset.action!;
 
                 if (e.key === 'Backspace') {
-                    const defaultConfig = pluginShortcuts.find((s: any) => s.Name === action);
-                    const defaultKey = formatShortcut(defaultConfig ? defaultConfig.Key : '');
-
-                    const shortcutIndex = shortcuts.Shortcuts!.findIndex((s: any) => s.Name === action);
-                    if (shortcutIndex > -1) {
-                        shortcuts.Shortcuts!.splice(shortcutIndex, 1);
-                    }
-                    normalizeShortcutEntries(shortcuts.Shortcuts);
-
-                    void editor.saveShortcuts().then(() => {
-                        if (!canSettleSave()) return;
-                        // Publish an actor shortcut after acknowledgement even
-                        // if its initiating panel has since closed.
-                        activeShortcuts[action] = defaultKey;
-                        if (!isCurrent()) return;
-                        keyElement.textContent = defaultKey;
-                        labelWrapper?.querySelector('.modified-indicator')?.remove();
-                        keyElement.blur();
-                    }).catch((error: unknown) => {
-                        void handleSaveFailure(error, keyElement);
-                    });
+                    saveBinding(action, null, effectiveDefault(action), keyElement);
                     return;
                 }
 
                 const combo = shortcutFromEvent(e);
                 if (!combo) return; // Don't allow setting only a modifier key.
-                const existingAction = Object.keys(activeShortcuts)
-                    .find(name => name !== action && shortcutsEqual(activeShortcuts[name], combo));
+                const existingAction = conflictFor(action, combo);
                 if (existingAction) {
-                    keyElement.style.background = 'rgb(255 0 0 / 60%)';
-                    keyElement.classList.add('shake-error');
-                    const timer = window.setTimeout(() => {
-                        if (!isCurrent()) return;
-                        keyElement.classList.remove('shake-error');
-                        if (document.activeElement === keyElement) {
-                            keyElement.style.background = kbdBackground;
-                        }
-                    }, 500);
-                    trackTimer(timer);
-                        // Reject the new keybinding and stop the function
+                    showConflict(keyElement);
                     return;
                 }
 
-                // Update or add the shortcut override
-                const userShortcut = shortcuts.Shortcuts!.find((s: any) => s.Name === action);
-                if (userShortcut) {
-                    userShortcut.Key = combo;
-                } else {
-                    const defaultConfig = pluginShortcuts.find((s: any) => s.Name === action);
-                    shortcuts.Shortcuts!.push({ ...defaultConfig, Key: combo });
-                }
-                normalizeShortcutEntries(shortcuts.Shortcuts);
-                void editor.saveShortcuts().then(() => {
-                    if (!canSettleSave()) return;
-                    activeShortcuts[action] = combo;
-                    if (!isCurrent()) return;
-                    keyElement.textContent = combo;
-                    if (labelWrapper && !labelWrapper.querySelector('.modified-indicator')) {
-                        const indicator = document.createElement('span');
-                        indicator.className = 'modified-indicator';
-                        indicator.title = 'Modified by user';
-                        indicator.style.cssText = `color:${primaryAccentColor}; font-size: 20px; line-height: 1;`;
-                        indicator.textContent = '•';
-                        labelWrapper.prepend(indicator);
+                saveBinding(action, combo, combo, keyElement);
+            });
+        });
+
+        help.querySelectorAll<HTMLButtonElement>('.shortcut-state-button').forEach(button => {
+            button.addEventListener('click', () => {
+                if (!isCurrent()) return;
+                const action = button.dataset.action!;
+                const keyElement = Array.from(help.querySelectorAll<HTMLElement>('.shortcut-key'))
+                    .find(element => element.dataset.action === action);
+                if (!keyElement) return;
+                if (button.dataset.operation === 'enable') {
+                    // Only the static percentage group exposes Enable. Ordinary
+                    // disabled rows are re-enabled by assigning a key or Reset.
+                    if (action !== PERCENTAGE_SHORTCUT_NAME) return;
+                    if (conflictFor(action, PERCENTAGE_SHORTCUT_RANGE)) {
+                        showConflict(keyElement);
+                        return;
                     }
-                    keyElement.blur();
-                }).catch((error: unknown) => {
-                    void handleSaveFailure(error, keyElement);
-                });
+                    saveBinding(action, PERCENTAGE_SHORTCUT_RANGE, PERCENTAGE_SHORTCUT_RANGE, keyElement);
+                    return;
+                }
+                saveBinding(action, '', '', keyElement);
+            });
+        });
+
+        help.querySelectorAll<HTMLButtonElement>('.shortcut-reset-button').forEach(button => {
+            button.addEventListener('click', () => {
+                if (!isCurrent() || button.disabled) return;
+                const action = button.dataset.action!;
+                const keyElement = Array.from(help.querySelectorAll<HTMLElement>('.shortcut-key'))
+                    .find(element => element.dataset.action === action);
+                if (!keyElement) return;
+                // Reset always reveals the lower-precedence admin value, even
+                // when legacy persisted bindings collide.
+                saveBinding(action, null, effectiveDefault(action), keyElement);
             });
         });
     }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
@@ -7,7 +7,11 @@
 
 import { JC } from '../../globals';
 import { assetUrl } from '../../core/asset-urls';
-import { formatShortcut } from '../shortcut-codec';
+import {
+    canonicalizeShortcut,
+    formatShortcut,
+    PERCENTAGE_SHORTCUT_NAME,
+} from '../shortcut-codec';
 import { escapeHtml } from '../../core/ui-kit';
 import { cssColorOr } from '../../core/css-safe';
 import { GITHUB_REPO } from './release-notes';
@@ -39,6 +43,46 @@ function tWithFallback(
     return result;
 }
 
+interface ShortcutTemplateEntry {
+    Name?: string;
+    Key?: string;
+    Label?: string;
+    Category?: string;
+}
+
+function shortcutRowHtml(
+    action: ShortcutTemplateEntry,
+    activeShortcuts: Record<string, string>,
+    userShortcutNames: ReadonlySet<string>,
+    kbdBackground: string,
+    primaryAccentColor: string,
+): string {
+    const name = action.Name || '';
+    if (!name) return '';
+    const label = tWithFallback(`shortcut_${name}`, action.Label || name);
+    const binding = canonicalizeShortcut(activeShortcuts[name]);
+    const disabled = binding === '';
+    const grouped = name === PERCENTAGE_SHORTCUT_NAME;
+    const display = disabled ? JC.t!('status_disabled') : formatShortcut(binding);
+    const targetState = disabled ? JC.t!('shortcut_enable') : JC.t!('shortcut_disable');
+    const resetLabel = JC.t!('discovery_customize_reset');
+    const modified = userShortcutNames.has(name);
+    const previewClasses = `shortcut-key${grouped ? ' shortcut-group-key' : ''}${disabled ? ' shortcut-disabled' : ''}`;
+
+    return `
+        <div class="jc-shortcut-row" style="display:grid; grid-template-columns:minmax(82px,auto) minmax(0,1fr) auto; align-items:center; gap:8px;">
+            <span class="${escapeHtml(previewClasses)}" tabindex="${grouped ? '-1' : '0'}" data-action="${escapeHtml(name)}" data-label="${escapeHtml(label)}" aria-label="${escapeHtml(`${label}: ${display}`)}" style="background:${kbdBackground}; padding:3px 8px; border:1px solid transparent; border-radius:3px; cursor:${grouped ? 'default' : 'pointer'}; transition:all 0.2s; opacity:${disabled ? '0.72' : '1'};">${escapeHtml(display)}</span>
+            <div class="jc-shortcut-label" style="display:flex; min-width:0; align-items:center; gap:8px;">
+                ${modified ? `<span title="Modified by user" class="modified-indicator" style="color:${primaryAccentColor}; font-size:20px; line-height:1;">•</span>` : ''}
+                <span>${escapeHtml(label)}${name === 'OpenEpisodePreview' ? ' <span style="font-size: 11px; opacity: 0.7;" title="Requires InPlayerEpisodePreview plugin from https://github.com/Namo2/InPlayerEpisodePreview/">ⓘ</span>' : ''}</span>
+            </div>
+            <div class="jc-shortcut-actions" style="display:flex; align-items:center; gap:5px;">
+                <button type="button" class="shortcut-state-button" data-action="${escapeHtml(name)}" data-operation="${disabled ? 'enable' : 'disable'}" aria-label="${escapeHtml(`${targetState}: ${label}`)}" ${!grouped && disabled ? 'disabled' : ''} style="font:inherit; font-size:11px; padding:4px 7px; border-radius:4px; border:1px solid rgba(255,255,255,0.18); background:rgba(255,255,255,0.07); color:#fff; cursor:pointer;">${escapeHtml(targetState)}</button>
+                <button type="button" class="shortcut-reset-button" data-action="${escapeHtml(name)}" aria-label="${escapeHtml(`${resetLabel}: ${label}`)}" ${modified ? '' : 'disabled'} style="font:inherit; font-size:11px; padding:4px 7px; border-radius:4px; border:1px solid rgba(255,255,255,0.18); background:rgba(255,255,255,0.07); color:#fff; cursor:pointer;">${escapeHtml(resetLabel)}</button>
+            </div>
+        </div>`;
+}
+
 /**
  * Builds the panel's inner HTML.
  * @param {object} ctx Shared panel context (theme constants) assembled in settings-panel/panel.ts.
@@ -68,9 +112,11 @@ export function buildPanelHtml(ctx: PanelContext): string {
             if (type === 'style') {
                 previewStyle = `background-color: ${cssColorOr(preset.bgColor, 'transparent')}; color: ${cssColorOr(preset.textColor, '#ffffff')}; border: 1px solid rgba(255,255,255,0.3); text-shadow: #000000 0px 0px 3px;`;
             } else if (type === 'font-size') {
-                previewStyle = `font-size: ${preset.size}em; color: #fff; text-shadow: 0 0 4px rgba(0,0,0,0.8);`;
+                previewStyle = `font-size: ${Number(preset.size) || 1}em; color: #fff; text-shadow: 0 0 4px rgba(0,0,0,0.8);`;
             } else if (type === 'font-family') {
-                previewStyle = `font-family: ${preset.family}; color: #fff; text-shadow: 0 0 4px rgba(0,0,0,0.8); font-size: 1.5em;`;
+                const family = String(preset.family ?? '').trim();
+                const safeFamily = /^[A-Za-z0-9 ,_-]{1,128}$/.test(family) ? family : 'inherit';
+                previewStyle = `font-family: ${escapeHtml(safeFamily)}; color: #fff; text-shadow: 0 0 4px rgba(0,0,0,0.8); font-size: 1.5em;`;
             }
             return `
                     <div class="preset-box ${type}-preset" data-preset-index="${index}" title="${escapeHtml(preset.name)}" style="display: flex; justify-content: center; align-items: center; padding: 8px; border: 2px solid transparent; border-radius: 8px; cursor: pointer; transition: all 0.2s; background: ${presetBoxBackground}; min-height: 30px;" onmouseover="this.style.background='rgba(255,255,255,0.3)'" onmouseout="this.style.background='${presetBoxBackground}'">
@@ -143,37 +189,22 @@ export function buildPanelHtml(ctx: PanelContext): string {
                         <div style="flex: 1; min-width: 400px;">
                             <h3 style="margin: 0 0 12px 0; font-size: 18px; color: ${primaryAccentColor}; font-family: inherit;">${JC.t!('panel_shortcuts_global')}</h3>
                             <div style="display: grid; gap: 8px; font-size: 14px;">
-                                ${((JC.pluginConfig.Shortcuts as any[]) || []).filter((s: any, index: number, self: any[]) => s.Category === 'Global' && index === self.findIndex((t: any) => t.Name === s.Name)).map((action: any) => `
-                                    <div style="display: flex; justify-content: space-between; align-items: center;">
-                                        <span class="shortcut-key" tabindex="0" data-action="${escapeHtml(action.Name)}" style="background:${kbdBackground}; padding:2px 8px; border-radius:3px; cursor:pointer; transition: all 0.2s;">${escapeHtml(formatShortcut(activeShortcuts[action.Name]))}</span>
-                                        <div style="display: flex; align-items: center; gap: 8px;">
-                                            ${userShortcutNames.has(action.Name) ? `<span title="Modified by user" class="modified-indicator" style="color:${primaryAccentColor}; font-size: 20px; line-height: 1;">•</span>` : ''}
-                                            <span>${escapeHtml(tWithFallback('shortcut_' + action.Name, action.Label))}</span>
-                                        </div>
-                                    </div>
-                                `).join('')}
+                                ${((JC.pluginConfig.Shortcuts as ShortcutTemplateEntry[]) || [])
+                                    .filter((s, index, self) => s.Category === 'Global' && index === self.findIndex(t => t.Name === s.Name))
+                                    .map(action => shortcutRowHtml(action, activeShortcuts, userShortcutNames, kbdBackground, primaryAccentColor))
+                                    .join('')}
                             </div>
                         </div>
                         <div style="flex: 1; min-width: 400px;">
                             <h3 style="margin: 0 0 12px 0; font-size: 18px; color: ${primaryAccentColor}; font-family: inherit;">${JC.t!('panel_shortcuts_player')}</h3>
                             <div style="display: grid; gap: 8px; font-size: 14px;">
-                                ${['CycleAspectRatio', 'ShowPlaybackInfo', 'SubtitleMenu', 'CycleSubtitleTracks', 'CycleAudioTracks', 'IncreasePlaybackSpeed', 'DecreasePlaybackSpeed', 'ResetPlaybackSpeed', 'BookmarkCurrentTime', 'OpenEpisodePreview', 'SkipIntroOutro', 'FrameStepBack', 'FrameStepForward', 'JumpToLastPosition'].map((action: string) => {
-                                    const a = ((JC.pluginConfig.Shortcuts as any[]) || []).find((s: any) => s.Name === action);
-                                    const fallbackLabel = a?.Label || action;
-                                    return `
-                                    <div style="display: flex; justify-content: space-between; align-items: center;">
-                                        <span class="shortcut-key" tabindex="0" data-action="${escapeHtml(action)}" style="background:${kbdBackground}; padding:2px 8px; border-radius:3px; cursor:pointer; transition: all 0.2s;">${escapeHtml(formatShortcut(activeShortcuts[action]))}</span>
-                                        <div style="display: flex; align-items: center; gap: 8px;">
-                                            ${userShortcutNames.has(action) ? `<span class="modified-indicator" title="Modified by user" style="color:${primaryAccentColor}; font-size: 20px; line-height: 1;">•</span>` : ''}
-                                            <span>${escapeHtml(tWithFallback('shortcut_' + action, fallbackLabel))}${action === 'OpenEpisodePreview' ? ' <span style="font-size: 11px; opacity: 0.7;" title="Requires InPlayerEpisodePreview plugin from https://github.com/Namo2/InPlayerEpisodePreview/">ⓘ</span>' : ''}</span>
-                                        </div>
-                                    </div>
-                                `;
-                                }).join('')}
-                                <div style="display: flex; justify-content: space-between;">
-                                    <span style="background:${kbdBackground}; padding:2px 8px; border-radius:3px;">0-9</span>
-                                    <span>${JC.t!('shortcut_JumpToPercentage')}</span>
-                                </div>
+                                ${['CycleAspectRatio', 'ShowPlaybackInfo', 'SubtitleMenu', 'CycleSubtitleTracks', 'CycleAudioTracks', 'IncreasePlaybackSpeed', 'DecreasePlaybackSpeed', 'ResetPlaybackSpeed', 'BookmarkCurrentTime', 'OpenEpisodePreview', 'SkipIntroOutro', 'FrameStepBack', 'FrameStepForward', 'JumpToLastPosition', PERCENTAGE_SHORTCUT_NAME]
+                                    .map(action => {
+                                        const entry = ((JC.pluginConfig.Shortcuts as ShortcutTemplateEntry[]) || [])
+                                            .find(shortcut => shortcut.Name === action)
+                                            || { Name: action, Label: action, Category: 'Player' };
+                                        return shortcutRowHtml(entry, activeShortcuts, userShortcutNames, kbdBackground, primaryAccentColor);
+                                    }).join('')}
                             </div>
                         </div>
                     </div>

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
     canonicalizeShortcut,
     formatShortcut,
+    hasShortcutModifiers,
+    isPercentageShortcutBinding,
     normalizeShortcutEntries,
+    physicalDigitFromEvent,
+    shortcutBindingsConflict,
     shortcutFromEvent,
     shortcutsEqual,
 } from './shortcut-codec';
@@ -114,5 +118,24 @@ describe('canonical shortcut codec', () => {
         expect(shortcutsEqual('Ctrl+Shift+K', 'shift+ctrl+k')).toBe(true);
         expect(shortcutsEqual('Ctrl+K', 'Ctrl+Shift+K')).toBe(false);
         expect(shortcutsEqual('', '')).toBe(false);
+    });
+
+    it('owns bare digits as one static percentage group without reserving modified digits', () => {
+        expect(isPercentageShortcutBinding('0-9')).toBe(true);
+        expect(formatShortcut('0-9')).toBe('0–9');
+        expect(shortcutBindingsConflict('0-9', '5')).toBe(true);
+        expect(shortcutBindingsConflict('5', '0-9')).toBe(true);
+        expect(shortcutBindingsConflict('0-9', 'Ctrl+5')).toBe(false);
+        expect(shortcutBindingsConflict('', '0-9')).toBe(false);
+        expect(shortcutBindingsConflict('Alt+5', 'Ctrl+5')).toBe(false);
+    });
+
+    it('derives top-row and numpad digits from code while keeping modifiers explicit', () => {
+        expect(physicalDigitFromEvent({ key: '%', code: 'Digit5' })).toBe(5);
+        expect(physicalDigitFromEvent({ key: '5', code: 'Numpad5' })).toBe(5);
+        expect(physicalDigitFromEvent({ key: '7' })).toBe(7);
+        expect(physicalDigitFromEvent({ key: '&', code: 'KeyA' })).toBeNull();
+        expect(hasShortcutModifiers({ metaKey: false, ctrlKey: false, altKey: false, shiftKey: false })).toBe(false);
+        expect(hasShortcutModifiers({ metaKey: false, ctrlKey: true, altKey: false, shiftKey: false })).toBe(true);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/shortcut-codec.ts
@@ -5,6 +5,10 @@
 const MODIFIER_ORDER = ['Meta', 'Ctrl', 'Alt', 'Shift'] as const;
 type Modifier = typeof MODIFIER_ORDER[number];
 
+/** Reserved grouped action used for the player's physical 0-9 seek policy. */
+export const PERCENTAGE_SHORTCUT_NAME = 'JumpToPercentage';
+export const PERCENTAGE_SHORTCUT_RANGE = '0-9';
+
 const MODIFIER_ALIASES: Readonly<Record<string, Modifier>> = {
     meta: 'Meta',
     cmd: 'Meta',
@@ -81,6 +85,7 @@ export interface ShortcutEntryLike {
 
 export interface ShortcutKeyboardEvent {
     key: string;
+    code?: string;
     metaKey: boolean;
     ctrlKey: boolean;
     altKey: boolean;
@@ -169,9 +174,46 @@ export function shortcutsEqual(left: unknown, right: unknown): boolean {
     return canonicalLeft !== '' && canonicalLeft === canonicalizeShortcut(right);
 }
 
+/** Whether a binding enables the reserved, non-rebindable percentage group. */
+export function isPercentageShortcutBinding(value: unknown): boolean {
+    return canonicalizeShortcut(value) === PERCENTAGE_SHORTCUT_RANGE;
+}
+
+/**
+ * Compare two effective bindings, including the grouped 0-9 reservation.
+ * Empty bindings never conflict, and modified digits remain ordinary keys.
+ */
+export function shortcutBindingsConflict(left: unknown, right: unknown): boolean {
+    const canonicalLeft = canonicalizeShortcut(left);
+    const canonicalRight = canonicalizeShortcut(right);
+    if (!canonicalLeft || !canonicalRight) return false;
+    if (canonicalLeft === canonicalRight) return true;
+    const leftIsRange = canonicalLeft === PERCENTAGE_SHORTCUT_RANGE;
+    const rightIsRange = canonicalRight === PERCENTAGE_SHORTCUT_RANGE;
+    return (leftIsRange && /^[0-9]$/.test(canonicalRight))
+        || (rightIsRange && /^[0-9]$/.test(canonicalLeft));
+}
+
+/** Resolve the physical top-row/numpad digit even when Shift changes event.key. */
+export function physicalDigitFromEvent(
+    event: Pick<ShortcutKeyboardEvent, 'key' | 'code'>,
+): number | null {
+    const codeMatch = /^(?:Digit|Numpad)([0-9])$/.exec(event.code || '');
+    const digit = codeMatch?.[1] || (/^[0-9]$/.test(event.key) ? event.key : '');
+    return digit ? Number(digit) : null;
+}
+
+/** Percentage seeking is intentionally limited to a zero-modifier digit. */
+export function hasShortcutModifiers(
+    event: Pick<ShortcutKeyboardEvent, 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+): boolean {
+    return event.metaKey || event.ctrlKey || event.altKey || event.shiftKey;
+}
+
 /** Display uses the same representation that persistence and dispatch consume. */
 export function formatShortcut(value: unknown): string {
-    return canonicalizeShortcut(value);
+    const canonical = canonicalizeShortcut(value);
+    return canonical === PERCENTAGE_SHORTCUT_RANGE ? '0–9' : canonical;
 }
 
 /** Normalize a loaded payload in place so its next save migrates legacy values. */

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/escape-guard.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/escape-guard.test.ts
@@ -180,18 +180,6 @@ const ALLOWLIST: AllowlistEntry[] = [
         line: 203,
         why: 'pre-built HTML from formatFutureReleaseDate\'s { isHtml, text } payload — the template that constructs it is itself scanned in render-helpers.ts',
     },
-    {
-        file: 'enhanced/settings-panel/template.ts',
-        expr: 'preset.size',
-        line: 71,
-        why: 'plugin-defined font-size preset tables (legacy js/ tree) — fixed numeric em values',
-    },
-    {
-        file: 'enhanced/settings-panel/template.ts',
-        expr: 'preset.family',
-        line: 73,
-        why: 'plugin-defined font-family preset tables (legacy js/ tree) — fixed font-family literals',
-    },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -70,7 +70,7 @@ These features make the player itself better — faster to drive from the keyboa
 
 ### Advanced keyboard shortcuts
 
-Drive Jellyfin without reaching for the mouse: a comprehensive set of hotkeys covers navigation and playback, and every shortcut is remappable per user.
+Drive Jellyfin without reaching for the mouse: a comprehensive set of hotkeys covers navigation and playback. Ordinary shortcuts can be remapped or individually disabled per user; the `0`–`9` percentage-seek group can be enabled or disabled as one policy.
 
 ![Canopy User Settings — Shortcuts tab](images/enhanced-panel-shortcuts.png)
 
@@ -112,8 +112,9 @@ menu is opening, and leaving playback cancels the pending action.
 
 1. Press `?` to open Canopy User Settings.
 2. Go to the **Shortcuts** tab.
-3. Click any key to set a custom binding.
-4. Changes save automatically, per user.
+3. Click any ordinary key to set a custom binding, or use **Disable** beside an action to turn only that action off.
+4. Use **Reset to defaults** to remove your override and reveal the administrator's current value. The percentage-seek row is a fixed `0`–`9` group with Enable/Disable and Reset controls rather than a rebindable single key.
+5. Changes save automatically, per user and follow that Jellyfin account across browsers.
 
 Modifier combinations work in any pressed order and are displayed consistently
 as `Meta+Ctrl+Alt+Shift+Key` (only the modifiers you use are shown). On macOS,
@@ -121,6 +122,10 @@ the Command key is stored as `Meta`; existing `Cmd`, `Command`, and differently
 ordered legacy bindings are normalized automatically without changing what the
 physical shortcut does. The editor rejects another binding with the same
 semantic key combination, even when its stored spelling or order differs.
+Bare number keys are reserved while the percentage-seek group is enabled;
+modified number combinations such as `Ctrl+5` remain available as ordinary
+bindings. Disabling the group also prevents Jellyfin's native player listener
+from seeking behind Canopy's setting.
 
 !!! note "Admin: disabling shortcuts server-wide"
 
@@ -128,6 +133,12 @@ semantic key combination, even when its stored spelling or order differs.
     the **Disable Keyboard Shortcuts** toggle in **Dashboard** → **Plugins** →
     **Jellyfin Canopy** → **Keyboard** tab. When enabled, the shortcuts stop
     working and the **Shortcuts** tab is removed from Canopy User Settings.
+
+    The same Keyboard tab lists every compiled shortcut. **Disable** stores an
+    explicit server-wide disabled value for that action, while **Reset** restores
+    the compiled product default. A user's own override still has the final say:
+    user Reset reveals the administrator value, including an administrator-disabled
+    action, and a deliberate user binding can re-enable an action for that user.
 
 ### Customizable subtitles
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -20,7 +20,7 @@ It does **not** work on Android TV or other native TV apps, because those client
 
 #### Can I customize the keyboard shortcuts?
 
-Yes. Open Canopy User Settings — click its item in the sidebar or press `?` — then go to the **Shortcuts** tab. Click any key to set a custom shortcut. Changes save automatically. See [The Enhanced Experience](enhanced.md) for the full shortcut list.
+Yes. Open Canopy User Settings — click its item in the sidebar or press `?` — then go to the **Shortcuts** tab. Click an ordinary key to rebind it, use **Disable** to turn off one action, or use **Reset to defaults** to reveal the administrator's current value. The fixed `0`–`9` percentage-seek group has Enable/Disable and Reset controls. Changes save automatically to that Jellyfin account. See [The Enhanced Experience](enhanced.md) for the full shortcut list.
 
 #### How do I change the plugin's language?
 

--- a/e2e/account-switch.spec.ts
+++ b/e2e/account-switch.spec.ts
@@ -165,7 +165,11 @@ function bUserFilePayload(
     const accountSwitchOwnerSentinel = bPayloadSentinel(segment, file);
     switch (file) {
         case 'shortcuts.json':
-            return { Revision: 0, Shortcuts: [], accountSwitchOwnerSentinel };
+            return {
+                Revision: 0,
+                Shortcuts: [{ Name: 'OpenSearch', Key: '' }],
+                accountSwitchOwnerSentinel,
+            };
         case 'bookmark.json':
             return { Revision: 0, Bookmarks: {}, accountSwitchOwnerSentinel };
         case 'settings.json':
@@ -689,6 +693,7 @@ async function assertOwnerState(
                 || JC.userConfig?.settings?.accountSwitchRaceSentinel === 'from-held-a-fetch',
             staleCache: JC.core.api.manager.getCached('jc-e2e-account-switch-a-only'),
             oldPanelConnected: !!(window as any).__jcASettingsPanel?.isConnected,
+            openSearchBinding: JC.state?.activeShortcuts?.OpenSearch,
         };
     }, expectedUserId);
 
@@ -716,6 +721,10 @@ async function assertOwnerState(
     expect(state.staleFetchPublished, 'late A fetch data cannot publish into B').toBe(false);
     expect(state.staleCache, 'identity reset clears the A-only core cache entry').toBeUndefined();
     expect(state.oldPanelConnected, 'the prior-user settings panel is detached').toBe(false);
+    expect(
+        state.openSearchBinding,
+        `${expectedSegment}: B's intentional empty shortcut replaces every A binding`
+    ).toBe('');
 }
 
 function expectFiveFilesOnce(

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -161,6 +161,7 @@
     "e2e/settings-persist.spec.ts › per-user settings persistence › clearing both maintenance actions persists and reloads warning-only mode",
     "e2e/settings-persist.spec.ts › per-user settings persistence › the admin config page exposes a control bound to the pause-screen delay default (XCUT-6)",
     "e2e/settings-persist.spec.ts › per-user settings persistence › the pause-screen delay panel input persists across reload",
+    "e2e/shortcut-disable.spec.ts › individual shortcut disablement › a disabled percentage group survives reload and blocks Jellyfin 12 native digit seeking",
     "e2e/spoiler-guard.spec.ts › Spoiler Guard › disabling shows the confirm dialog and restores the episode title",
     "e2e/spoiler-guard.spec.ts › Spoiler Guard › non-admin enables Spoiler Guard: toggle flips, toast shows, metadata + images strip",
     "e2e/spoiler-guard.spec.ts › Spoiler Guard › per-user isolation: the admin API view keeps the real title while the user is guarded",

--- a/e2e/shortcut-disable.spec.ts
+++ b/e2e/shortcut-disable.spec.ts
@@ -1,0 +1,231 @@
+// Individual shortcut disablement is a persisted three-tier policy, not a
+// presentation-only toggle. This spec drives the real user editor and server,
+// reloads the account, and then proves a disabled bare digit cannot fall
+// through to Jellyfin 12's own document-bubble percentage seek handler.
+import {
+    test,
+    expect,
+    loginAs,
+    showRoute,
+    waitForHash,
+    assertNoRuntimeErrors,
+} from './fixtures/auth';
+import type { Page } from 'playwright/test';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const PERCENTAGE_ACTION = 'JumpToPercentage';
+const SHORTCUT_SAVE = /\/JellyfinCanopy\/user-settings\/.+\/shortcuts\.json(?:\?|$)/i;
+
+async function waitReady(page: Page): Promise<void> {
+    await page.waitForFunction(
+        () => (window as any).JellyfinCanopy?.initialized === true
+            && !!(window as any).JellyfinCanopy?.userConfig?.shortcuts,
+        undefined,
+        { timeout: 60_000 }
+    );
+}
+
+function shortcutsSaved(page: Page): Promise<import('playwright/test').Response> {
+    return page.waitForResponse(
+        response => SHORTCUT_SAVE.test(response.url())
+            && response.request().method() === 'POST',
+        { timeout: 30_000 }
+    );
+}
+
+async function openShortcutPanel(page: Page): Promise<ReturnType<Page['locator']>> {
+    await page.evaluate(() => { (window as any).JellyfinCanopy.showEnhancedPanel(); });
+    const panel = page.locator('#jellyfin-canopy-panel');
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+    const tab = panel.locator('.tab-button[data-tab="shortcuts"]');
+    await expect(tab).toBeVisible();
+    await tab.click();
+    await expect(panel.locator('.jc-pane[data-pane="shortcuts"]')).toBeVisible();
+    return panel;
+}
+
+async function setVideoPosition(page: Page, ratio: number): Promise<{ duration: number; baseline: number }> {
+    return page.evaluate(async (targetRatio) => {
+        const video = document.querySelector('video');
+        if (!video || !Number.isFinite(video.duration) || video.duration <= 0) {
+            throw new Error('the real Jellyfin video element is not seekable');
+        }
+        video.pause();
+        const target = video.duration * targetRatio;
+        if (Math.abs(video.currentTime - target) > 0.05) {
+            await new Promise<void>((resolve, reject) => {
+                const timeout = window.setTimeout(
+                    () => reject(new Error('timed out positioning the Jellyfin video')),
+                    10_000
+                );
+                video.addEventListener('seeked', () => {
+                    window.clearTimeout(timeout);
+                    resolve();
+                }, { once: true });
+                video.currentTime = target;
+            });
+        }
+        return { duration: video.duration, baseline: video.currentTime };
+    }, ratio);
+}
+
+test.describe('individual shortcut disablement', () => {
+    test('a disabled percentage group survives reload and blocks Jellyfin 12 native digit seeking', async ({
+        page,
+        consoleErrors,
+    }) => {
+        test.slow();
+        await loginAs(page, 'user', consoleErrors);
+        const originalRows = await page.evaluate(() => JSON.parse(JSON.stringify(
+            (window as any).JellyfinCanopy.userConfig.shortcuts.Shortcuts || []
+        )));
+
+        try {
+            let panel = await openShortcutPanel(page);
+            let stateButton = panel.locator(
+                `.shortcut-state-button[data-action="${PERCENTAGE_ACTION}"]`
+            );
+            await expect(stateButton).toBeVisible();
+
+            // A dirty shared test server may already hold a disabled row. Make
+            // the enabled precondition explicit through the real control, then
+            // exercise Disable from that known state.
+            if (await stateButton.getAttribute('data-operation') === 'enable') {
+                const [response] = await Promise.all([
+                    shortcutsSaved(page),
+                    stateButton.click(),
+                ]);
+                expect(response.ok(), 'precondition enable is acknowledged').toBe(true);
+                await page.waitForFunction(
+                    (action) => (window as any).JellyfinCanopy.state.activeShortcuts[action] === '0-9',
+                    PERCENTAGE_ACTION
+                );
+            }
+
+            const [disabledResponse] = await Promise.all([
+                shortcutsSaved(page),
+                stateButton.click(),
+            ]);
+            expect(disabledResponse.ok(), 'Disable is acknowledged by the real user endpoint').toBe(true);
+            await page.waitForFunction(
+                (action) => (window as any).JellyfinCanopy.state.activeShortcuts[action] === '',
+                PERCENTAGE_ACTION
+            );
+
+            await page.reload({ waitUntil: 'domcontentloaded' });
+            await waitReady(page);
+            const persisted = await page.evaluate((action) => {
+                const JC = (window as any).JellyfinCanopy;
+                const rows = (JC.userConfig.shortcuts.Shortcuts || [])
+                    .filter((row: any) => row?.Name === action);
+                return {
+                    active: JC.state.activeShortcuts[action],
+                    keys: rows.map((row: any) => row.Key),
+                };
+            }, PERCENTAGE_ACTION);
+            expect(persisted, 'reload retains one intentional empty override').toEqual({
+                active: '',
+                keys: [''],
+            });
+
+            panel = await openShortcutPanel(page);
+            const preview = panel.locator(
+                `.shortcut-key[data-action="${PERCENTAGE_ACTION}"]`
+            );
+            stateButton = panel.locator(
+                `.shortcut-state-button[data-action="${PERCENTAGE_ACTION}"]`
+            );
+            const disabledLabel = await page.evaluate(() =>
+                (window as any).JellyfinCanopy.t('status_disabled')
+            );
+            await expect(preview).toHaveClass(/shortcut-disabled/);
+            await expect(preview).toHaveText(disabledLabel);
+            await expect(preview).toHaveAttribute('tabindex', '-1');
+            await expect(stateButton).toHaveAttribute('data-operation', 'enable');
+            await page.keyboard.press('Escape');
+            await expect(panel).toHaveCount(0);
+
+            const itemId = await page.evaluate(async () => {
+                const apiClient = (window as any).ApiClient;
+                const url = apiClient.getUrl(
+                    `/Items?Recursive=true&SearchTerm=${encodeURIComponent('Alpha Adventure')}`
+                    + `&IncludeItemTypes=Movie&Limit=1&userId=${apiClient.getCurrentUserId()}`
+                );
+                const result = await apiClient.ajax({ type: 'GET', url, dataType: 'json' });
+                return String(result.Items?.[0]?.Id || '');
+            });
+            expect(itemId, 'the seeded movie used for the native-key proof exists').not.toBe('');
+
+            await showRoute(page, `/details?id=${itemId}`);
+            const playButton = page.locator('.page:not(.hide) .mainDetailButtons .btnPlay').first();
+            await expect(playButton).toBeVisible({ timeout: 30_000 });
+            await playButton.click();
+            await waitForHash(page, '/video');
+            await page.waitForFunction(
+                () => {
+                    const video = document.querySelector('video');
+                    return !!video && Number.isFinite(video.duration) && video.duration > 3;
+                },
+                undefined,
+                { timeout: 30_000 }
+            );
+
+            const positioned = await setVideoPosition(page, 0.2);
+            expect(positioned.duration).toBeGreaterThan(3);
+            await page.evaluate(() => {
+                const video = document.querySelector('video')!;
+                const trace = {
+                    baseline: video.currentTime,
+                    positions: [] as number[],
+                    done: false,
+                };
+                (window as any).__jcDisabledDigitTrace = trace;
+                const onSeeking = (): void => { trace.positions.push(video.currentTime); };
+                video.addEventListener('seeking', onSeeking);
+                window.setTimeout(() => {
+                    video.removeEventListener('seeking', onSeeking);
+                    trace.done = true;
+                }, 750);
+                (document.activeElement as HTMLElement | null)?.blur?.();
+            });
+
+            await page.keyboard.press('8');
+            await page.waitForFunction(
+                () => (window as any).__jcDisabledDigitTrace?.done === true,
+                undefined,
+                { timeout: 5_000 }
+            );
+            const digitTrace = await page.evaluate(() => {
+                const video = document.querySelector('video')!;
+                return {
+                    ...(window as any).__jcDisabledDigitTrace,
+                    final: video.currentTime,
+                    paused: video.paused,
+                };
+            });
+            expect(digitTrace.positions, 'neither Canopy nor Jellyfin 12 seeks for disabled digits').toEqual([]);
+            expect(digitTrace.paused, 'the deterministic native-key probe remains paused').toBe(true);
+            expect(
+                Math.abs(digitTrace.final - digitTrace.baseline),
+                'the native Jellyfin document-bubble digit handler was intercepted'
+            ).toBeLessThan(0.1);
+        } finally {
+            await page.evaluate(async (rows) => {
+                const video = document.querySelector('video');
+                if (video) {
+                    video.pause();
+                    video.removeAttribute('src');
+                    video.load();
+                }
+                const JC = (window as any).JellyfinCanopy;
+                const shortcuts = JC.userConfig?.shortcuts;
+                if (!shortcuts) throw new Error('shortcut cleanup lost its owned payload');
+                shortcuts.Shortcuts = JSON.parse(JSON.stringify(rows));
+                await JC.saveUserSettings('shortcuts.json', shortcuts);
+            }, originalRows);
+        }
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7249038,
+    "maxTotalRawBytes": 7265530,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7335394
+    "maxPublishedRawBytes": 7351886
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2918, totalLines: 3304 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 43935, totalLines: 53701 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 43981, totalLines: 53733 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2918,
         maximumCoveredLines: 2918,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 2,
-        minimumCoveredLines: 43927,
-        maximumCoveredLines: 43935,
+        cleanRuns: 5,
+        minimumCoveredLines: 43966,
+        maximumCoveredLines: 43981,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 13);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 15);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 43935,
-        "totalLines": 53701
+        "coveredLines": 43981,
+        "totalLines": 53733
       },
       "observations": {
-        "cleanRuns": 2,
-        "minimumCoveredLines": 43927,
-        "maximumCoveredLines": 43935
+        "cleanRuns": 5,
+        "minimumCoveredLines": 43966,
+        "maximumCoveredLines": 43981
       },
       "tolerance": {
-        "missingCoveredLines": 13,
-        "rationale": "The issue-682 fix preserves direct critic percentages through every live and full-cache rating-inheritance path and bumps the cache schema to v5. After merging main at b0626553 (post #689/#692/#696), the instrumented scope is 53,701 lines: the #696 Calendar requester scope of 53,696 plus this branch's five critic-rating lines. Two post-merge full-suite runs on this exact source, tests and scope measured 43,927 and 43,929 covered plugin lines; the only local test failures were wall-clock budget asserts that execute their full plugin path before asserting elapsed time, so they do not reduce plugin-assembly coverage. The high-water is pinned to 43,935 to absorb the +4-to-+6 hosted-CI offset repeatedly observed on the two previous envelopes (local 43,905-43,914 vs CI 43,918; local 43,475-43,484 vs CI 43,485), with the floor held at 43,922 below both local observations. The spread is 0.024 percentage points, far inside the 0.15pp policy bound. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 15,
+        "rationale": "Issue #685 adds explicit disabled-shortcut normalization and server regressions, finally rebased onto merged issues #663 and #682 at main 05b8eddb. Five clean full-suite runs on this exact 53,733-line source and 4,185-test scope passed every test: two owner-side local runs measured 43,972 and 43,966, two coordinator local runs measured 43,974 and 43,976, and the hosted PR run measured the observed high-water 43,981. The reviewed observed high-water is therefore 43,981/53,733 (81.851%) and the exact observed floor is 43,966/53,733 (81.823%); the fifteen-line timing-dependent instrumentation spread is 0.028 percentage points, far inside the 0.15pp policy bound. This clean new-scope envelope also supersedes main's issue-682 metadata record, whose 43,935 high-water was predicted rather than observed; the hosted issue-682 run actually measured 43,928/53,701. One intervening coordinator full-coverage attempt failed two unnamed tests and is not counted as clean evidence; the repository wrapper emitted no TRX for that failed attempt. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add explicit Disable and Reset controls for individual keyboard shortcuts in self, admin, and admin-target editors.
- Preserve intentional empty bindings through server normalization and the factory → admin → user precedence chain.
- Treat percentage seeking as one reserved 0–9 group, block Jellyfin native bypass for disabled digits, and preserve modified-digit bindings.
- Refresh accessible labels, localization, documentation, reviewed bundle caps, and observed-only coverage evidence.

Refs #685.

## Validation

- Final independent feature, rebase-union, bundle, and coverage review: approved with no findings at exact head `949e25d80276ff222a2109c4f44949787d4310df` on current `main` `05b8eddb2267a283189d86113eeb2bb48484b6db`.
- Focused client: 66/66 passed; focused server: 37/37 passed.
- Full client: 253 files and 2,280/2,280 tests passed; client/core coverage exactly 2,918/3,304 lines.
- Full server: five clean identical-scope runs passed 4,185/4,185 tests and measured 43,966, 43,972, 43,974, 43,976, and hosted 43,981 / 53,733 lines; the exact reviewed floor/high-water envelope is 43,966–43,981 (15 lines, 0.028 percentage points).
- Coverage policy: 14/14 passed; retained 43,976/53,733 artifact passes inside the observed envelope.
- Jellyfin 12 E2E: the previously published head passed every substantive hosted gate, including all six isolated E2E shards and aggregate; the current head changes only the two coverage evidence files from that hosted production/test tree.
- Deterministic Release bundle: 177 outputs, build `90cc794694e6b8a12ef16b5b8ee336f1a559be046e00ded74696f05f270cadd1`, exactly 7,265,530 raw bytes and 7,351,886 published bytes; fail-closed caps and 9/9 bundle policy tests pass.
- Strict source typecheck, all 26 translations at 960 keys each, hash-locked offline documentation, bundle, and diff checks passed.

## Failed/setup attempts retained as evidence

- One intervening local full-server coverage attempt passed 4,183/4,185 and is excluded from the clean envelope. The repository wrapper emitted no TRX, so the two failed test names are unavailable; no assertion, timeout, or production code was changed, and the immediately surrounding complete runs passed all 4,185 tests.
- The first hosted run on owner-published head `bb8f27d1` passed all 4,185 tests and measured the new 43,981 high-water, then correctly failed only because its evidence file predicted 43,978. The amended head records the observed hosted value instead of predicting it.
- The first local documentation invocation used system Python without MkDocs and stopped after the content, permissions, and asset checks passed. Re-running the exact command with the existing hash-locked documentation environment passed the strict MkDocs build and support-contract gate.

## Compatibility

No breaking API change. Existing saved shortcuts remain compatible; empty named bindings now remain an intentional disabled state. The feature supports the repository's Jellyfin 12 modern React/MUI client contract. Browser behavior is covered by the required real Jellyfin 12 E2E inventory.

## Screenshots

No new screenshot is attached in this final rebase: the UI implementation is byte-identical to the previously reviewed and hosted all-green #694 feature patch, and the final amendment changes coverage evidence only.

## AI assistance

This PR was developed with AI assistance. I reviewed the complete final diff and validation evidence and understand the implementation.

## Merge policy

The repository owner explicitly directed native squash auto-merge for these owner-authored Project 10 PRs. The existing request remains fully subject to the current-base requirement, required checks, review state, and branch ruleset; no manual, administrator, or bypass merge is requested.
