### PR TITLE
test(seerr): stabilize remaining issued-back races

### DIFF
--- a/e2e/seerr-modal-history.spec.ts
+++ b/e2e/seerr-modal-history.spec.ts
@@ -435,6 +435,8 @@ test.describe('Seerr modal history ownership', () => {
                 window.removeEventListener('popstate', modalListener, true);
                 const proof = {
                     laterStates: [] as Array<string | null>,
+                    phaseAtBack: null as string | null,
+                    pushRuns: 0,
                     recoveryForwardQueued: false,
                     rewriteRuns: 0,
                     rewriteSettled: false,
@@ -514,14 +516,35 @@ test.describe('Seerr modal history ownership', () => {
                     );
                 });
 
+                // Place B after Canopy issues its real Back but before the
+                // browser can deliver that asynchronous traversal. A second
+                // zero-delay timer does not define that transaction boundary.
+                const ownBackDescriptor = Object.getOwnPropertyDescriptor(history, 'back');
+                const originalBack = history.back.bind(history);
+                const restoreBack = () => {
+                    if (ownBackDescriptor) {
+                        Object.defineProperty(history, 'back', ownBackDescriptor);
+                    } else {
+                        delete (history as { back?: () => void }).back;
+                    }
+                };
+                Object.defineProperty(history, 'back', {
+                    configurable: true,
+                    writable: true,
+                    value: () => {
+                        restoreBack();
+                        proof.phaseAtBack = owner.pendingOwnedTraversal?.phase ?? null;
+                        originalBack();
+                        proof.pushRuns += 1;
+                        history.pushState(
+                            { jcHistoryProof: 'async-canonical-route-b' },
+                            '',
+                            stableHref
+                        );
+                    },
+                });
+
                 handle.close();
-                setTimeout(() => {
-                    history.pushState(
-                        { jcHistoryProof: 'async-canonical-route-b' },
-                        '',
-                        stableHref
-                    );
-                }, 0);
 
                 // Keep this Playwright step attached to the browser task until
                 // the selected scheduler actually delivers, instead of starting
@@ -543,6 +566,8 @@ test.describe('Seerr modal history ownership', () => {
             }, undefined, { polling: 50, timeout: 30_000 });
             expect(await page.evaluate(() => (window as any).__jcAsyncCanonicalProof)).toEqual({
                 laterStates: ['async-canonical-route-b'],
+                phaseAtBack: 'issued',
+                pushRuns: 1,
                 recoveryForwardQueued: true,
                 rewriteRuns: 1,
                 rewriteSettled: true,
@@ -1038,7 +1063,12 @@ test.describe('Seerr modal history ownership', () => {
             const owner = (window as any).__jellyfinCanopySeerrModalHistoryOwnerV2;
             const modalListener = owner.listener as EventListener;
             window.removeEventListener('popstate', modalListener, true);
-            const proof = { laterStates: [] as unknown[], reactiveRuns: 0 };
+            const proof = {
+                laterStates: [] as unknown[],
+                phaseAtBack: null as string | null,
+                pushRuns: 0,
+                reactiveRuns: 0,
+            };
             (window as any).__jcReactivePushProof = proof;
             window.addEventListener('popstate', () => {
                 proof.reactiveRuns += 1;
@@ -1059,21 +1089,41 @@ test.describe('Seerr modal history ownership', () => {
             window.addEventListener('popstate', modalListener, { capture: true });
             window.addEventListener('popstate', (event) => proof.laterStates.push(event.state));
 
+            // Preserve a real asynchronous Back while making the intended
+            // issued-Back/host-PUSH ordering explicit and observable.
+            const ownBackDescriptor = Object.getOwnPropertyDescriptor(history, 'back');
+            const originalBack = history.back.bind(history);
+            const restoreBack = () => {
+                if (ownBackDescriptor) {
+                    Object.defineProperty(history, 'back', ownBackDescriptor);
+                } else {
+                    delete (history as { back?: () => void }).back;
+                }
+            };
+            Object.defineProperty(history, 'back', {
+                configurable: true,
+                writable: true,
+                value: () => {
+                    restoreBack();
+                    proof.phaseAtBack = owner.pendingOwnedTraversal?.phase ?? null;
+                    originalBack();
+                    proof.pushRuns += 1;
+                    History.prototype.pushState.call(
+                        history,
+                        { jcHistoryProof: 'reactive-route-b' },
+                        '',
+                        stableHref
+                    );
+                    owner.historyObserver?.({
+                        source: 'pushState',
+                        action: 'PUSH',
+                        state: history.state,
+                        href: location.href,
+                    });
+                },
+            });
+
             handle.close();
-            setTimeout(() => {
-                History.prototype.pushState.call(
-                    history,
-                    { jcHistoryProof: 'reactive-route-b' },
-                    '',
-                    stableHref
-                );
-                owner.historyObserver?.({
-                    source: 'pushState',
-                    action: 'PUSH',
-                    state: history.state,
-                    href: location.href,
-                });
-            }, 0);
         });
 
         await page.waitForFunction(() => {
@@ -1085,6 +1135,8 @@ test.describe('Seerr modal history ownership', () => {
         }, undefined, { polling: 50, timeout: 30_000 });
         expect(await page.evaluate(() => (window as any).__jcReactivePushProof)).toEqual({
             laterStates: [],
+            phaseAtBack: 'issued',
+            pushRuns: 1,
             reactiveRuns: 1,
         });
 


### PR DESCRIPTION
Refs #577.

## What changed

- replace the two remaining zero-delay host-PUSH timers in `seerr-modal-history.spec.ts` with the one-shot `history.back` interposition already proven by #615;
- restore the exact original `history.back` descriptor before issuing a real asynchronous browser traversal;
- place the adversarial B push synchronously after Back is issued, preserving each case's patched-versus-raw history-observer contract;
- assert that Canopy was in the `issued` phase and that the interposed host push ran exactly once.

This is test-harness-only. Production modal behavior, event ordering, assertions, 30-second limits, and runtime-error checks are unchanged.

## Root cause

The production close transaction schedules Back in a zero-delay timer, while these two older probes scheduled their host push in a second zero-delay timer. Browser history traversal is asynchronous and may run between those timer callbacks. Depending on that scheduler choice, stale A could arrive before B, after which the requestAnimationFrame case rewrote B to captured A or the reactive case let the later B overwrite D. The wait predicate then could never become true.

PR #699 exposed both outcomes on the same unchanged head: its initial shard-4 run timed out in the requestAnimationFrame case, and the single failed-job retry passed that case but timed out in the reactive case. Issue #577 already records the reactive timeout and an unchanged-head passing retry on an unrelated server-only PR. The affected tests and production modal file are outside #699's diff.

## Validation

- exact issue branch: `253c7dd5040d8bc36a27126c131acc3181906d91` on base `0f97a7872526153540662217560b70268a22470c`;
- disposable Jellyfin 12.0.0 stack using the required digest-pinned unstable image and a verified two-CPU quota:
  - exact two formerly failing cases repeated: **40/40 passed** with no retries;
  - complete `e2e/seerr-modal-history.spec.ts`: **26/26 passed** with no retries;
  - native Playwright shard 4/6 on the branch: **26/26 passed** with no retries;
- owning modal-history unit suite: **90/90 passed**;
- repository script suite: **655/655 passed**;
- `npm run typecheck:src`: passed;
- `npm run typecheck`: passed;
- `npm run syntax`: passed;
- Release plugin build: passed with **0 warnings / 0 errors**; deterministic bundle build `7f9c200d2621d3a059ef482edca62ecfc7d39e2d177983524f95f916a2f0a2ee`;
- Playwright discovery: **26 tests** compile and list in the changed file;
- `git diff --check`: passed.

Setup/exclusions:

- `npm ci` installed the exact lockfile successfully; npm reported two pre-existing high-severity audit findings. No dependency changes or audit fix were attempted because this PR changes one E2E spec only.
- The first `dotnet build --no-restore` in the fresh worktree stopped before compilation because `obj/project.assets.json` did not exist. The pinned .NET 10.0.109 SDK then restored the project, and the identical no-restore Release build passed as reported above.
- Direct ESLint invocation for the E2E file returned zero errors and one notice that the file has no matching ESLint configuration; it is not claimed as lint coverage.
- Full client/server coverage was not rerun because no production or unit-test source changed. The complete protected hosted matrix remains authoritative before merge.

## Compatibility and risk

- No user-facing, server, client bundle, API, persistence, configuration, or documentation behavior changes.
- The wrapper preserves a real Back traversal and restores itself before that traversal is issued. Each test's later real Back/Forward assertions exercise restoration and reversibility.
- If the expected close-time Back is never issued, the test still times out; no failure is converted into a pass by widening time or weakening the final state.

## AI assistance

This change was developed with AI assistance. The implementation, test evidence, and full one-file diff were reviewed and understood; an independent reviewer approved the final diff with no findings.
