### PR TITLE
Show file source on item details independently of poster tags

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileFormatGoldenTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileFormatGoldenTests.cs
@@ -78,6 +78,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
                 SubtitleVerticalPosition = 42,
                 WatchProgressMode = "time",
                 WatchProgressTimeFormat = "minutes",
+                ShowFileSource = true,
                 ShowResolutionTag = false,
                 // int? orders: mixed null / non-null so the golden pins that
                 // nulls are WRITTEN (NullValueHandling.Include) not omitted.
@@ -108,6 +109,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
             Assert.Null(back.SourceTagOrder);
             Assert.Equal(2, back.ResolutionTagOrder);
             Assert.Equal(0, back.DynamicRangeTagOrder);
+            Assert.True(back.ShowFileSource);
             Assert.Equal(
                 new[] { "Episode", "BoxSet" },
                 back.RatingTagScopeOverrides.DisabledItemTypes);

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileReadCompatTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/UserFileReadCompatTests.cs
@@ -124,6 +124,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration
             Assert.Equal(1, settings.RatingTagScopeOverrides.Version);
             Assert.Empty(settings.RatingTagScopeOverrides.DisabledItemTypes);
             Assert.Empty(settings.RatingTagScopeOverrides.DisabledSurfaces);
+            Assert.False(settings.ShowFileSource);
         }
 
         /// <summary>Unknown members (from newer/older plugin versions) remain

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
@@ -738,6 +738,10 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
         Assert.IsType<NotFoundObjectResult>(
             Controller().GetAdminTargetUserSettings(unknown.ToString("D")));
         Assert.IsType<NotFoundObjectResult>(
+            Controller(ifMatch: 0).SaveAdminTargetUserSettings(
+                unknown.ToString("N"),
+                new UserSettings { Revision = 0, ShowFileSource = true }));
+        Assert.IsType<NotFoundObjectResult>(
             Controller(ifMatch: 0).SaveAdminTargetUserShortcuts(
                 unknown.ToString("N"),
                 new UserShortcuts { Revision = 0 }));
@@ -745,6 +749,10 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
             Controller().GetAdminTargetUserFileEvidence(
                 unknown.ToString("N"),
                 "settings.json"));
+        Assert.IsType<NotFoundObjectResult>(
+            Controller().GetAdminTargetUserFileEvidence(
+                TargetId,
+                "unsupported.json"));
 
         Assert.False(Directory.Exists(UserDirectory(unknown)));
         Assert.False(Directory.Exists(UserDirectory(Guid.Empty)));

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
@@ -336,6 +336,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             Assert.Equal("time", stored.WatchProgressMode);
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MissingSettings_SeedFileSourceVisibilityFromPluginDefault(bool showFileSource)
+        {
+            _provider.Current = new PluginConfiguration { ShowFileSource = showFileSource };
+
+            var get = Assert.IsType<OkObjectResult>(
+                Controller().GetUserSettingsSettings(UserId));
+            var response = Assert.IsType<UserSettings>(get.Value);
+            var stored = _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json");
+
+            Assert.Equal(showFileSource, response.ShowFileSource);
+            Assert.Equal(showFileSource, stored.ShowFileSource);
+        }
+
         [Fact]
         public void MissingSettings_WithUnavailablePluginConfiguration_FailGetAndTransactionWithoutAFile()
         {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/UserFiles/settings.write.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/UserFiles/settings.write.json
@@ -25,6 +25,7 @@
   "WatchProgressMode": "time",
   "WatchProgressTimeFormat": "minutes",
   "ShowFileSizes": false,
+  "ShowFileSource": true,
   "ShowAudioLanguages": false,
   "QualityTagsEnabled": false,
   "ShowResolutionTag": false,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/configpage-save-keys.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/configpage-save-keys.json
@@ -214,6 +214,7 @@
   "ShowDynamicRangeTag",
   "ShowElsewhereOnSeerr",
   "ShowFileSizes",
+  "ShowFileSource",
   "ShowLetterboxdLinkAsText",
   "ShowRatingInPlayer",
   "ShowReleaseDates",

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.anonymous.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.anonymous.json
@@ -277,6 +277,7 @@
   "ShowDynamicRangeTag": true,
   "ShowElsewhereOnSeerr": false,
   "ShowFileSizes": false,
+  "ShowFileSource": false,
   "ShowLetterboxdLinkAsText": false,
   "ShowRatingInPlayer": true,
   "ShowReleaseDates": false,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.authenticated.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.default.authenticated.json
@@ -277,6 +277,7 @@
   "ShowDynamicRangeTag": true,
   "ShowElsewhereOnSeerr": false,
   "ShowFileSizes": false,
+  "ShowFileSource": false,
   "ShowLetterboxdLinkAsText": false,
   "ShowRatingInPlayer": true,
   "ShowReleaseDates": false,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.anonymous.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.anonymous.json
@@ -283,6 +283,7 @@
   "ShowDynamicRangeTag": false,
   "ShowElsewhereOnSeerr": true,
   "ShowFileSizes": true,
+  "ShowFileSource": true,
   "ShowLetterboxdLinkAsText": true,
   "ShowRatingInPlayer": false,
   "ShowReleaseDates": true,
@@ -295,8 +296,8 @@
   "ShowUserReviews": true,
   "ShowVideoCodecTag": false,
   "ShowWatchProgress": true,
-  "SourceTagOrder": 1240,
-  "SpecialFormatTagOrder": 1241,
+  "SourceTagOrder": 1241,
+  "SpecialFormatTagOrder": 1242,
   "SplashScreenImageUrl": "cfg-SplashScreenImageUrl",
   "SpoilerAdvancedMode": true,
   "SpoilerBlurEnabled": true,
@@ -312,11 +313,11 @@
   "SpoilerStripTags": false,
   "SyncSeerrWatchlist": true,
   "TagCacheServerMode": false,
-  "TagsCacheTtlDays": 1274,
+  "TagsCacheTtlDays": 1275,
   "TagsHideOnHover": true,
   "ThemeSelectorEnabled": true,
   "TmdbEnabled": true,
-  "ToastDuration": 1277,
+  "ToastDuration": 1278,
   "UseIcons": false,
-  "VideoCodecTagOrder": 1280
+  "VideoCodecTagOrder": 1281
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.authenticated.json
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Snapshots/public-config.distinctive.authenticated.json
@@ -283,6 +283,7 @@
   "ShowDynamicRangeTag": false,
   "ShowElsewhereOnSeerr": true,
   "ShowFileSizes": true,
+  "ShowFileSource": true,
   "ShowLetterboxdLinkAsText": true,
   "ShowRatingInPlayer": false,
   "ShowReleaseDates": true,
@@ -295,8 +296,8 @@
   "ShowUserReviews": true,
   "ShowVideoCodecTag": false,
   "ShowWatchProgress": true,
-  "SourceTagOrder": 1240,
-  "SpecialFormatTagOrder": 1241,
+  "SourceTagOrder": 1241,
+  "SpecialFormatTagOrder": 1242,
   "SplashScreenImageUrl": "cfg-SplashScreenImageUrl",
   "SpoilerAdvancedMode": true,
   "SpoilerBlurEnabled": true,
@@ -312,11 +313,11 @@
   "SpoilerStripTags": false,
   "SyncSeerrWatchlist": true,
   "TagCacheServerMode": false,
-  "TagsCacheTtlDays": 1274,
+  "TagsCacheTtlDays": 1275,
   "TagsHideOnHover": true,
   "ThemeSelectorEnabled": true,
   "TmdbEnabled": true,
-  "ToastDuration": 1277,
+  "ToastDuration": 1278,
   "UseIcons": false,
-  "VideoCodecTagOrder": 1280
+  "VideoCodecTagOrder": 1281
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/PluginConfiguration.cs
@@ -85,6 +85,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
             WatchProgressDefaultMode = "percentage";
             WatchProgressTimeFormat = "hours";
             ShowFileSizes = false;
+            ShowFileSource = false;
             RemoveContinueWatchingEnabled = false;
             HideFavoritesTab = false;
             ShowAudioLanguages = true;
@@ -479,6 +480,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         public string WatchProgressDefaultMode { get; set; }
         public string WatchProgressTimeFormat { get; set; }
         public bool ShowFileSizes { get; set; }
+        public bool ShowFileSource { get; set; }
         public bool RemoveContinueWatchingEnabled { get; set; }
 
         /// <summary>

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/SettingDescriptors.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/SettingDescriptors.cs
@@ -166,6 +166,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
                 PublicUser("RandomUnwatchedOnly", c => c.RandomUnwatchedOnly, nameof(UserSettings.RandomUnwatchedOnly)),
                 PublicUser("ShowWatchProgress", c => c.ShowWatchProgress, nameof(UserSettings.ShowWatchProgress)),
                 PublicUser("ShowFileSizes", c => c.ShowFileSizes, nameof(UserSettings.ShowFileSizes)),
+                PublicUser("ShowFileSource", c => c.ShowFileSource, nameof(UserSettings.ShowFileSource)),
                 PublicUser("RemoveContinueWatchingEnabled", c => c.RemoveContinueWatchingEnabled, nameof(UserSettings.RemoveContinueWatchingEnabled)),
                 PublicUser("HideFavoritesTab", c => c.HideFavoritesTab, nameof(UserSettings.HideFavoritesTab)),
                 PublicUser("ShowAudioLanguages", c => c.ShowAudioLanguages, nameof(UserSettings.ShowAudioLanguages)),

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/UserConfiguration.cs
@@ -39,6 +39,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
         public string WatchProgressMode { get; set; } = "percentage";
         public string WatchProgressTimeFormat { get; set; } = "hours";
         public bool ShowFileSizes { get; set; }
+        public bool ShowFileSource { get; set; }
         public bool ShowAudioLanguages { get; set; }
         public bool QualityTagsEnabled { get; set; }
         public bool ShowResolutionTag { get; set; } = true;

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -247,6 +247,11 @@
                                 <div class="fieldDescription">Display the file size of each item on item detail pages or collections pages.</div>
                             </div>
 
+                            <div class="checkboxContainer"><label><input id="showFileSource" data-config-key="ShowFileSource" is="emby-checkbox" type="checkbox"/><span>Show file source on item detail pages</span></label></div>
+                            <div class="jc-setting-description" data-desc-for="showFileSource">
+                                <div class="fieldDescription">Display a normalized physical-media source such as BluRay or DVD independently of poster source tags.</div>
+                            </div>
+
                             <div class="checkboxContainer"><label><input id="showAudioLanguages" data-config-key="ShowAudioLanguages" is="emby-checkbox" type="checkbox"/><span>Show available audio languages on item detail page</span></label></div>
                             <div class="jc-setting-description" data-desc-for="showAudioLanguages">
                                 <div class="fieldDescription">List the audio language flags available for each title on its detail page.</div>

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -1090,6 +1090,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 WatchProgressMode = string.IsNullOrWhiteSpace(defaultConfig.WatchProgressDefaultMode) ? "percentage" : defaultConfig.WatchProgressDefaultMode,
                 WatchProgressTimeFormat = string.IsNullOrWhiteSpace(defaultConfig.WatchProgressTimeFormat) ? "hours" : defaultConfig.WatchProgressTimeFormat,
                 ShowFileSizes = defaultConfig.ShowFileSizes,
+                ShowFileSource = defaultConfig.ShowFileSource,
                 ShowAudioLanguages = defaultConfig.ShowAudioLanguages,
                 QualityTagsEnabled = defaultConfig.QualityTagsEnabled,
                 ShowResolutionTag = defaultConfig.ShowResolutionTag,

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ar.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} بحث",
   "toast_home": "{{icon:home}} الرئيسية",
   "toast_dashboard": "{{icon:dashboard}} لوحة التحكم",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/bg.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Търсене",
   "toast_home": "{{icon:home}} Начало",
   "toast_dashboard": "{{icon:dashboard}} Табло",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ca.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Buscar",
   "toast_home": "{{icon:home}} Inici",
   "toast_dashboard": "{{icon:dashboard}} Panell",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/cs.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Hledat",
   "toast_home": "{{icon:home}} Domů",
   "toast_dashboard": "{{icon:dashboard}} Nástěnka",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/da.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Søg",
   "toast_home": "{{icon:home}} Hjem",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/de.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Suche",
   "toast_home": "{{icon:home}} Startseite",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-GB.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Search",
   "toast_home": "{{icon:home}} Home",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en-US.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Search",
   "toast_home": "{{icon:home}} Home",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Search",
   "toast_home": "{{icon:home}} Home",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/es.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Buscar",
   "toast_home": "{{icon:home}} Inicio",
   "toast_dashboard": "{{icon:dashboard}} Panel",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/fr.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Recherche",
   "toast_home": "{{icon:home}} Accueil",
   "toast_dashboard": "{{icon:dashboard}} Tableau de bord",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/he.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} חיפוש",
   "panel_settings_language_display_desc": "Select the language for Jellyfin Canopy interface. Changes take effect after page refresh.",
   "discovery_more_with_tag": "More with the tag - \"{tag}\"",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/hu.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Keresés",
   "toast_home": "{{icon:home}} Kezdőlap",
   "toast_dashboard": "{{icon:dashboard}} Műszerfal",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/it.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Cerca",
   "toast_home": "{{icon:home}} Home",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/nl.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Zoeken",
   "toast_home": "{{icon:home}} Home",
   "toast_dashboard": "{{icon:dashboard}} Dashboard",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/no.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Søk",
   "toast_home": "{{icon:home}} Hjem",
   "toast_dashboard": "{{icon:dashboard}} Dashbord",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pl.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Szukaj",
   "toast_home": "{{icon:home}} Strona główna",
   "toast_dashboard": "{{icon:dashboard}} Kokpit",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pr.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Searchin' the Seas",
   "toast_home": "{{icon:home}} Back to Port",
   "toast_dashboard": "{{icon:dashboard}} Cap'n's Quarters",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt-BR.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Pesquisar",
   "toast_home": "{{icon:home}} Início",
   "toast_dashboard": "{{icon:dashboard}} Painel",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/pt.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Pesquisar",
   "toast_home": "{{icon:home}} Início",
   "toast_dashboard": "{{icon:dashboard}} Painel",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/ru.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Поиск",
   "toast_home": "{{icon:home}} Главная",
   "toast_dashboard": "{{icon:dashboard}} Панель управления",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sk.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Hľadať",
   "toast_home": "{{icon:home}} Domov",
   "toast_dashboard": "{{icon:dashboard}} Nástenka",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/sv.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Sök",
   "toast_home": "{{icon:home}} Hem",
   "toast_dashboard": "{{icon:dashboard}} Instrumentpanel",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/tr.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} Ara",
   "toast_home": "{{icon:home}} Ana Sayfa",
   "toast_dashboard": "{{icon:dashboard}} Kontrol Paneli",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-CN.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} 搜寻",
   "toast_home": "{{icon:home}} 首页",
   "toast_dashboard": "{{icon:dashboard}} 控制台",

--- a/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
+++ b/Jellyfin.Plugin.JellyfinCanopy/js/locales/zh-HK.json
@@ -1,4 +1,7 @@
 {
+  "panel_settings_ui_file_source": "Show File Source",
+  "panel_settings_ui_file_source_desc": "Display BluRay, DVD, or other physical-media source on Movie and Episode detail pages independently of poster source tags.",
+  "file_source_tooltip": "File Source",
   "toast_search": "{{icon:search}} 搜尋",
   "toast_home": "{{icon:home}} 首頁",
   "toast_dashboard": "{{icon:dashboard}} 控制台",

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/file-source.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/file-source.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { detectFileSource, FILE_SOURCE_VALUES } from './file-source';
+
+describe('file-source detector', () => {
+    it.each([
+        ['/media/Movie.BluRay.disc', 'BluRay'],
+        ['/media/Movie.blu-ray.disc', 'BluRay'],
+        ['/media/Movie.BluRayRemux.disc', 'BluRay'],
+        ['/media/Movie.BluRay-Rip.disc', 'BluRay'],
+        ['/media/Movie.BD-RIP.disc', 'BluRay'],
+        ['/media/Movie.BDRemux.disc', 'BluRay'],
+        ['/media/Movie.HD-DVD.disc', 'HD DVD'],
+        ['/media/Movie.HD DVD.disc', 'HD DVD'],
+        ['/media/Movie.DVDRip.disc', 'DVD'],
+        ['/media/Movie.DVD-REMUX.disc', 'DVD'],
+        ['/media/Movie.VHS.disc', 'VHS'],
+        ['/media/Movie.HDTV.disc', 'HDTV'],
+        ['/media/Movie.disc', 'Physical'],
+    ])('normalizes %s to %s', (Path, expected) => {
+        expect(detectFileSource({ Path })).toBe(expected);
+    });
+
+    it('exports the stable poster/details vocabulary in display order', () => {
+        expect(FILE_SOURCE_VALUES).toEqual(['BluRay', 'HD DVD', 'DVD', 'VHS', 'HDTV', 'Physical']);
+    });
+
+    it.each([
+        null,
+        undefined,
+        '',
+        [],
+        {},
+        { Path: '/media/Movie.BluRay.mkv' },
+        { Path: 42, Name: false },
+        { MediaSources: 'not-an-array' },
+    ])('keeps malformed, ordinary, or unsupported input %# silent', (value) => {
+        expect(detectFileSource(value)).toBeNull();
+    });
+
+    it('does not promote a DVD substring without token boundaries', () => {
+        expect(detectFileSource({ Path: '/media/notdvd.disc' })).toBe('Physical');
+    });
+
+    it('uses item metadata when no usable MediaSources exist', () => {
+        expect(detectFileSource({
+            Name: 'Movie BluRay',
+            Path: '/media/Movie.disc',
+            MediaSources: [{}, null, 42],
+        })).toBe('BluRay');
+    });
+
+    it('accepts unanimous multi-version values independent of order', () => {
+        const left = { Path: '/media/A.BluRay.disc' };
+        const right = { Name: 'B blu-ray', Path: '/media/B.disc' };
+        expect(detectFileSource({ MediaSources: [left, right] })).toBe('BluRay');
+        expect(detectFileSource({ MediaSources: [right, left] })).toBe('BluRay');
+    });
+
+    it.each([
+        [[{ Path: '/media/A.BluRay.disc' }, { Path: '/media/B.DVD.disc' }]],
+        [[{ Path: '/media/A.BluRay.disc' }, { Path: '/media/B.mkv' }]],
+        [[{ Path: '/media/A.BluRay.disc' }, { Path: '/media/B.disc' }]],
+    ])('keeps conflicting or partly unresolved multi-version input silent', (MediaSources) => {
+        expect(detectFileSource({ MediaSources })).toBeNull();
+    });
+
+    it('merges generic item/source evidence symmetrically and rejects specific conflicts', () => {
+        expect(detectFileSource({
+            Path: '/media/Item.DVD.disc',
+            MediaSources: [{ Path: '/media/Version.BluRay.disc' }],
+        })).toBeNull();
+        expect(detectFileSource({
+            Path: '/media/Item.disc',
+            MediaSources: [{ Path: '/media/Version.BluRay.disc' }],
+        })).toBe('BluRay');
+        expect(detectFileSource({
+            Name: 'Item BluRay',
+            Path: '/media/Item.disc',
+            MediaSources: [{ Path: '/media/Version.disc' }],
+        })).toBe('BluRay');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/file-source.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/file-source.ts
@@ -1,0 +1,90 @@
+/** Canonical file-source values shared by poster badges and item details. */
+export const FILE_SOURCE_VALUES = [
+    'BluRay',
+    'HD DVD',
+    'DVD',
+    'VHS',
+    'HDTV',
+    'Physical',
+] as const;
+
+export type FileSource = typeof FILE_SOURCE_VALUES[number];
+
+/**
+ * Bump when detection semantics change so persisted quality-tag results cannot
+ * disagree with the details surface after an upgrade.
+ */
+export const FILE_SOURCE_DETECTION_VERSION = 3;
+
+interface FileSourceRecord {
+    Name?: unknown;
+    Path?: unknown;
+}
+
+interface FileSourceItem extends FileSourceRecord {
+    MediaSources?: unknown;
+}
+
+const SPECIFIC_PATTERNS: ReadonlyArray<readonly [FileSource, RegExp]> = [
+    ['BluRay', /(?:^|[^a-z0-9])(?:blu[ ._-]?ray(?:[ ._-]?(?:rip|remux))?|bd[ ._-]?(?:rip|remux))(?=$|[^a-z0-9])/],
+    ['HD DVD', /(?:^|[^a-z0-9])hd[ ._-]?dvd(?=$|[^a-z0-9])/],
+    ['DVD', /(?:^|[^a-z0-9])dvd(?:[ ._-]?(?:rip|remux))?(?=$|[^a-z0-9])/],
+    ['VHS', /(?:^|[^a-z0-9])vhs(?=$|[^a-z0-9])/],
+    ['HDTV', /(?:^|[^a-z0-9])hdtv(?=$|[^a-z0-9])/],
+];
+
+function asSignal(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function hasUsableSignal(record: FileSourceRecord): boolean {
+    return Boolean(asSignal(record.Name) || asSignal(record.Path));
+}
+
+/** Resolve one item/version record without inspecting any other version. */
+function detectRecord(record: FileSourceRecord): FileSource | null {
+    const context = [asSignal(record.Name), asSignal(record.Path)]
+        .filter(Boolean)
+        .join(' | ')
+        .toLowerCase();
+    if (!context.includes('.disc')) return null;
+
+    for (const [source, pattern] of SPECIFIC_PATTERNS) {
+        if (pattern.test(context)) return source;
+    }
+    return 'Physical';
+}
+
+/**
+ * Detect a Jellyfin media-stub source without guessing across versions.
+ *
+ * Every usable MediaSource must resolve to the same canonical value. A mix of
+ * ordinary/unknown and recognized versions, or conflicting recognized values,
+ * is ambiguous and therefore silent. When Jellyfin supplies no usable source
+ * records, the item's own Name/Path is the fallback used by legacy poster data.
+ */
+export function detectFileSource(value: unknown): FileSource | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const item = value as FileSourceItem;
+    const sources = Array.isArray(item.MediaSources)
+        ? item.MediaSources.filter((source): source is FileSourceRecord =>
+            Boolean(source) && typeof source === 'object' && !Array.isArray(source)
+                && hasUsableSignal(source as FileSourceRecord))
+        : [];
+
+    if (sources.length === 0) return detectRecord(item);
+
+    const detected = sources.map(detectRecord);
+    if (detected.some((source) => source === null)) return null;
+    const distinct = new Set(detected as FileSource[]);
+    if (distinct.size !== 1) return null;
+
+    const source = detected[0] as FileSource;
+    // Item and source DTOs are two fidelity views of the same version. Generic
+    // Physical evidence on either side yields to a specific signal; only two
+    // different specific values are genuinely ambiguous.
+    const itemSource = detectRecord(item);
+    if (!itemSource || itemSource === source || itemSource === 'Physical') return source;
+    if (source === 'Physical') return itemSource;
+    return null;
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
@@ -817,7 +817,7 @@ JC.loadSettings = (): UserSettings => {
         subtitleVerticalPosition: 85, subtitleHorizontalPosition: 50,
         randomButtonEnabled: true,
         randomIncludeMovies: true, randomIncludeShows: true, randomUnwatchedOnly: false,
-        showWatchProgress: false, showFileSizes: false, showAudioLanguages: true, removeContinueWatchingEnabled: false, hideFavoritesTab: false,
+        showWatchProgress: false, showFileSizes: false, showFileSource: false, showAudioLanguages: true, removeContinueWatchingEnabled: false, hideFavoritesTab: false,
         watchProgressMode: 'percentage',
         watchProgressTimeFormat: 'hours',
         pauseScreenEnabled: true,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.identity.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { JC } from '../../globals';
 import {
     displayAudioLanguages,
+    displayFileSource,
     displayWatchProgress,
     resetDetailsMediaInfo,
 } from './details-media-info';
@@ -100,6 +101,57 @@ describe('details media-info identity lifecycle', () => {
 
         expect(plugin).toHaveBeenCalledTimes(1);
         expect(container.querySelector('.mediaInfoItem-watchProgress')).toBeNull();
+    });
+
+    it('renders only the canonical file-source enum and replaces same-item metadata', () => {
+        const container = mountContainer();
+        displayFileSource('source-item', container, {
+            Type: 'Movie',
+            Name: '<img src=x onerror=alert(1)>',
+            Path: '/private/<secret>/Movie.BluRay.disc',
+        });
+
+        const chip = container.querySelector<HTMLElement>('.mediaInfoItem-fileSource');
+        expect(chip?.dataset.itemId).toBe('source-item');
+        expect(chip?.dataset.fileSource).toBe('BluRay');
+        expect(chip?.textContent).toBe('albumBluRay');
+        expect(chip?.getAttribute('aria-label')).toBe('file_source_tooltip: BluRay');
+        expect(container.innerHTML).not.toContain('/private/');
+        expect(container.querySelector('img')).toBeNull();
+
+        displayFileSource('source-item', container, {
+            Type: 'Movie', MediaSources: [{ Path: '/media/Movie.DVD.disc' }],
+        });
+        expect(container.querySelector<HTMLElement>('.mediaInfoItem-fileSource')?.dataset.fileSource).toBe('DVD');
+        expect(container.querySelectorAll('.mediaInfoItem-fileSource')).toHaveLength(1);
+    });
+
+    it('keeps unknown and ambiguous source metadata silent and reset-owned', () => {
+        const container = mountContainer();
+        displayFileSource('source-item', container, {
+            Type: 'Episode', MediaSources: [{ Path: '/media/Episode.HDTV.disc' }],
+        });
+        expect(container.querySelector('.mediaInfoItem-fileSource')).not.toBeNull();
+
+        displayFileSource('source-item', container, {
+            Type: 'Episode',
+            MediaSources: [
+                { Path: '/media/A.BluRay.disc' },
+                { Path: '/media/B.DVD.disc' },
+            ],
+        });
+        expect(container.querySelector('.mediaInfoItem-fileSource')).toBeNull();
+
+        displayFileSource('source-item', container, {
+            Type: 'Episode', MediaSources: [{ Path: '/media/Episode.mkv' }],
+        });
+        expect(container.querySelector('.mediaInfoItem-fileSource')).toBeNull();
+
+        displayFileSource('source-item', container, {
+            Type: 'Episode', MediaSources: [{ Path: '/media/Episode.HDTV.disc' }],
+        });
+        resetDetailsMediaInfo();
+        expect(container.querySelector('.mediaInfoItem-fileSource')).toBeNull();
     });
 
     it('uses the captured account for audio metadata and drops A language results', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-media-info.ts
@@ -1,6 +1,6 @@
 // src/enhanced/features/details-media-info.ts
 //
-// Details-page media-info chips: watch progress, file size and audio languages.
+// Details chips: watch progress, file size/source and audio languages.
 // (Converted from js/enhanced/features-details-media-info.js — bodies semantically
 // identical; the JC.internals.features pieces are now real module exports.)
 
@@ -13,6 +13,7 @@ import {
 } from '../../core/media-language';
 import type { MediaLanguageIdentity } from '../../core/media-language';
 import { injectCss } from '../../core/ui-kit';
+import { detectFileSource } from '../../core/file-source';
 import { getItemCached } from '../helpers';
 import type { IdentityContext } from '../../types/jc';
 
@@ -167,8 +168,44 @@ export function resetDetailsMediaInfo(): void {
     audioLanguageCache.clear();
     document.getElementById(AUDIO_LANGUAGES_SCROLL_STYLE_ID)?.remove();
     document.querySelectorAll(
-        '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-audioLanguage',
+        '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-fileSource, .mediaInfoItem-audioLanguage',
     ).forEach((node) => node.remove());
+}
+
+/**
+ * Shows a normalized physical-media source on Movie/Episode detail pages.
+ * The caller owns item authorization and current-page identity; this renderer
+ * is synchronous so it cannot publish into a later or hidden page.
+ */
+export function displayFileSource(itemId: string, container: HTMLElement, item: unknown): void {
+    const source = detectFileSource(item);
+    const existing = container.querySelector<HTMLElement>('.mediaInfoItem-fileSource');
+    if (!source) {
+        existing?.remove();
+        return;
+    }
+    if (existing?.dataset.itemId === itemId && existing.dataset.fileSource === source) return;
+    existing?.remove();
+
+    const chip = document.createElement('div');
+    chip.className = 'mediaInfoItem mediaInfoItem-fileSource';
+    chip.dataset.itemId = itemId;
+    chip.dataset.fileSource = source;
+    chip.title = JC.t!('file_source_tooltip');
+    chip.setAttribute('aria-label', `${JC.t!('file_source_tooltip')}: ${source}`);
+    chip.style.display = 'flex';
+    chip.style.verticalAlign = 'middle';
+    chip.style.alignItems = 'center';
+    chip.style.margin = '0 1em 0 0 !important';
+
+    const icon = document.createElement('span');
+    icon.className = 'material-icons';
+    icon.style.fontSize = 'inherit';
+    icon.style.marginRight = '0.3em';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = 'album';
+    chip.append(icon, document.createTextNode(source));
+    container.appendChild(chip);
 }
 
 /** Effective read-side TTL: transient errors expire fast (PERF(R9)), real answers keep the full TTL. */

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.identity.test.ts
@@ -13,6 +13,12 @@ async function flushPromises(): Promise<void> {
     for (let index = 0; index < 8; index++) await Promise.resolve();
 }
 
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+}
+
 function mountDetailsPage(itemId: string): HTMLElement {
     window.history.replaceState(null, '', `/web/index.html#/details?id=${itemId}`);
     const page = document.createElement('div');
@@ -111,6 +117,98 @@ describe('details-page identity dispatcher', () => {
         await flushPromises();
 
         expect(getItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the details source independently from poster settings without another item request', async () => {
+        mountDetailsPage('source-independent');
+        const getItem = vi.spyOn(ApiClient, 'getItem').mockResolvedValue({
+            Id: 'source-independent',
+            Type: 'Movie',
+            MediaSources: [{ Path: '/media/Movie.BluRay.disc' }],
+        });
+        JC.currentSettings = {
+            showFileSource: true,
+            qualityTagsEnabled: false,
+            showSourceTag: false,
+        };
+
+        initializeDetailsPage();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+
+        const chip = document.querySelector<HTMLElement>('.mediaInfoItem-fileSource');
+        expect(chip?.dataset.fileSource).toBe('BluRay');
+        expect(getItem).toHaveBeenCalledTimes(1);
+        expect(getItem).toHaveBeenCalledWith('pageusera', 'source-independent');
+    });
+
+    it('removes a stale source when the host reuses the details page for an unknown item', async () => {
+        const page = mountDetailsPage('source-a');
+        const getItem = vi.spyOn(ApiClient, 'getItem')
+            .mockResolvedValueOnce({
+                Id: 'source-a', Type: 'Movie',
+                MediaSources: [{ Path: '/media/A.DVD.disc' }],
+            })
+            .mockResolvedValueOnce({
+                Id: 'source-b', Type: 'Movie',
+                MediaSources: [{ Path: '/media/B.mkv' }],
+            });
+        JC.currentSettings = { showFileSource: true };
+
+        initializeDetailsPage();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        expect(page.querySelector<HTMLElement>('.mediaInfoItem-fileSource')?.dataset.fileSource).toBe('DVD');
+
+        window.history.replaceState(null, '', '/web/index.html#/details?id=source-b');
+        recordDetailsViewShown(page);
+        initializeDetailsPage();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+
+        expect(getItem).toHaveBeenCalledTimes(2);
+        expect(page.querySelector('.mediaInfoItem-fileSource')).toBeNull();
+    });
+
+    it('cannot publish a held old item after a newer details source owns the page', async () => {
+        const page = mountDetailsPage('held-source-a');
+        const held = deferred<unknown>();
+        vi.spyOn(ApiClient, 'getItem')
+            .mockReturnValueOnce(held.promise)
+            .mockResolvedValueOnce({
+                Id: 'held-source-b', Type: 'Episode',
+                MediaSources: [{ Path: '/media/B.HDTV.disc' }],
+            });
+        JC.currentSettings = { showFileSource: true };
+
+        initializeDetailsPage();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+
+        window.history.replaceState(null, '', '/web/index.html#/details?id=held-source-b');
+        recordDetailsViewShown(page);
+        initializeDetailsPage();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        vi.advanceTimersByTime(100);
+        await flushPromises();
+        expect(page.querySelector<HTMLElement>('.mediaInfoItem-fileSource')?.dataset.fileSource).toBe('HDTV');
+
+        held.resolve({
+            Id: 'held-source-a', Type: 'Movie',
+            MediaSources: [{ Path: '/media/A.BluRay.disc' }],
+        });
+        await flushPromises();
+        vi.advanceTimersByTime(1_000);
+        await flushPromises();
+
+        expect(page.querySelector<HTMLElement>('.mediaInfoItem-fileSource')?.dataset.fileSource).toBe('HDTV');
     });
 
     it('retries a first-activation Spoiler-only detail exactly once after readiness', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details-page.ts
@@ -13,6 +13,7 @@ import { getItemCached } from '../helpers';
 import {
     displayWatchProgress,
     displayItemSize,
+    displayFileSource,
     displayAudioLanguages,
     resetDetailsMediaInfo,
 } from './details-media-info';
@@ -27,6 +28,7 @@ import type { IdentityContext } from '../../types/jc';
 // Cache the last item id and type to avoid repeated ApiClient calls
 let lastDetailsItemId: string | null = null;
 let lastDetailsItemType: string | null = null;
+let lastDetailsItem: any = null;
 let itemTypeFetchInProgress: Promise<unknown> | null = null;
 // PERF(R9): fail open — a transient failure of the item-type fetch used to
 // leave the page bare for the whole view (nothing re-runs the dispatcher on a
@@ -83,6 +85,9 @@ const SPOILER_GUARD_READY_EVENT = 'jc:spoiler-guard-ready';
 
 // Types that support file size and watch progress
 const FEATURES_SUPPORTED_TYPES = ['Episode', 'Season', 'Series', 'Movie', 'BoxSet', 'Playlist'];
+// A physical source belongs to one playable file. Containers/aggregates would
+// require choosing a representative child and therefore remain silent.
+const FILE_SOURCE_SUPPORTED_TYPES = ['Episode', 'Movie'];
 // Types that support audio languages (excludes BoxSet and Playlist)
 const AUDIO_LANGUAGES_SUPPORTED_TYPES = ['Episode', 'Season', 'Series', 'Movie', 'BoxSet'];
 
@@ -435,6 +440,7 @@ function runHandleItemDetails(context: IdentityContext): void {
             clearSpoilerReadiness();
             lastDetailsItemId = itemId;
             lastDetailsItemType = null;
+            lastDetailsItem = null;
             itemTypeFetchInProgress = null;
             itemTypeFetchAttempts = 0;
             for (const timer of itemTypeRetryTimers) clearTimeout(timer);
@@ -463,6 +469,7 @@ function runHandleItemDetails(context: IdentityContext): void {
                             scheduleHandleItemDetails(context);
                             return;
                         }
+                        lastDetailsItem = item;
                         lastDetailsItemType = item?.Type || null;
                         itemTypeFetchAttempts = 0;
                         // Re-run once type is known to render features
@@ -560,6 +567,11 @@ function runHandleItemDetails(context: IdentityContext): void {
         if (JC?.currentSettings?.showFileSizes) {
             void displayItemSize(itemId, container);
         }
+        if (JC?.currentSettings?.showFileSource
+            && FILE_SOURCE_SUPPORTED_TYPES.includes(lastDetailsItemType)
+            && lastDetailsItem) {
+            displayFileSource(itemId, container, lastDetailsItem);
+        }
         if (JC?.currentSettings?.showAudioLanguages && AUDIO_LANGUAGES_SUPPORTED_TYPES.includes(lastDetailsItemType)) {
             void displayAudioLanguages(itemId, container);
         }
@@ -604,6 +616,7 @@ export function resetDetailsPage(): void {
     }
     lastDetailsItemId = null;
     lastDetailsItemType = null;
+    lastDetailsItem = null;
     itemTypeFetchInProgress = null;
     itemTypeFetchAttempts = 0;
     for (const timer of itemTypeRetryTimers) clearTimeout(timer);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details.feature.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/details.feature.ts
@@ -5,6 +5,7 @@ import { initializeDetailsPage, installDetailsPage } from './details-page';
 export function isDetailsEnhancementsEnabled(): boolean {
     return JC.currentSettings?.showWatchProgress === true
         || JC.currentSettings?.showFileSizes === true
+        || JC.currentSettings?.showFileSource === true
         || JC.currentSettings?.showAudioLanguages === true
         || (JC.pluginConfig?.ShowReleaseDates === true && JC.pluginConfig?.TmdbEnabled === true)
         || JC.pluginConfig?.HiddenContentEnabled === true

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/editor-context.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/editor-context.ts
@@ -169,7 +169,7 @@ const TARGET_SETTING_DEFAULTS: Record<string, unknown> = {
     usingCustomColors: false, disableCustomSubtitleStyles: false,
     subtitleVerticalPosition: 85, subtitleHorizontalPosition: 50,
     randomButtonEnabled: true, randomIncludeMovies: true, randomIncludeShows: true, randomUnwatchedOnly: false,
-    showWatchProgress: false, showFileSizes: false, showAudioLanguages: true, removeContinueWatchingEnabled: false, hideFavoritesTab: false,
+    showWatchProgress: false, showFileSizes: false, showFileSource: false, showAudioLanguages: true, removeContinueWatchingEnabled: false, hideFavoritesTab: false,
     watchProgressMode: 'percentage', watchProgressTimeFormat: 'hours',
     pauseScreenEnabled: true, pauseScreenDelaySeconds: 5,
     qualityTagsEnabled: false, genreTagsEnabled: false, languageTagsEnabled: false, ratingTagsEnabled: false, peopleTagsEnabled: false, tagsHideOnHover: false,

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.identity.test.ts
@@ -6,7 +6,7 @@ import type { PanelContext } from './panel';
 const TOGGLE_IDS = [
     'autoPauseToggle', 'autoResumeToggle', 'autoPipToggle', 'autoSkipIntroToggle',
     'autoSkipOutroToggle', 'randomButtonToggle', 'randomUnwatchedOnly',
-    'showWatchProgressToggle', 'showFileSizesToggle', 'showAudioLanguagesToggle',
+    'showWatchProgressToggle', 'showFileSizesToggle', 'showFileSourceToggle', 'showAudioLanguagesToggle',
     'removeContinueWatchingToggle', 'hideFavoritesTabToggle', 'qualityTagsToggle', 'genreTagsToggle',
     'pauseScreenToggle', 'languageTagsToggle', 'ratingTagsToggle', 'peopleTagsToggle',
     'tagsHideOnHoverToggle', 'disableCustomSubtitleStyles', 'longPress2xEnabled'
@@ -39,7 +39,7 @@ describe('settings panel document listener identity cleanup', () => {
         wireSettingsListeners({
             identityContext: contextA,
             registerCleanup: (cleanup: () => void) => cleanups.push(cleanup),
-            createToast: () => '',
+            createToast: () => 'saved',
             resetAutoCloseTimer: vi.fn(),
         } as unknown as PanelContext);
 
@@ -55,5 +55,38 @@ describe('settings panel document listener identity cleanup', () => {
         expect(JC.currentSettings.subtitleHorizontalPosition).toBeUndefined();
         expect(JC.currentSettings.subtitleVerticalPosition).toBeUndefined();
         expect(save).not.toHaveBeenCalled();
+    });
+
+    it('removes the acting user file-source chip synchronously when disabled', async () => {
+        document.body.innerHTML = '';
+        JC.identity.transition('server-a', 'user-a', 'settings-source-toggle');
+        const cleanups: Array<() => void> = [];
+        for (const id of TOGGLE_IDS) {
+            const input = document.createElement('input');
+            input.id = id;
+            input.type = 'checkbox';
+            document.body.appendChild(input);
+        }
+        const chip = document.createElement('div');
+        chip.className = 'mediaInfoItem-fileSource';
+        document.body.appendChild(chip);
+        JC.currentSettings = { showFileSource: true };
+        const save = vi.fn().mockResolvedValue(undefined);
+        JC.saveUserSettings = save;
+        wireSettingsListeners({
+            identityContext: JC.identity.capture(),
+            registerCleanup: (cleanup: () => void) => cleanups.push(cleanup),
+            createToast: () => 'saved',
+            resetAutoCloseTimer: vi.fn(),
+        } as unknown as PanelContext);
+
+        const toggle = document.getElementById('showFileSourceToggle') as HTMLInputElement;
+        toggle.checked = false;
+        toggle.dispatchEvent(new Event('change'));
+
+        expect(JC.currentSettings.showFileSource).toBe(false);
+        expect(document.querySelector('.mediaInfoItem-fileSource')).toBeNull();
+        await vi.waitFor(() => expect(save).toHaveBeenCalled());
+        cleanups.forEach((cleanup) => cleanup());
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.pause-delay.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.pause-delay.test.ts
@@ -28,7 +28,7 @@ const TOGGLE_IDS = [
     'autoPauseToggle', 'autoResumeToggle', 'autoPipToggle',
     'autoSkipIntroToggle', 'autoSkipOutroToggle',
     'randomButtonToggle', 'randomUnwatchedOnly',
-    'showWatchProgressToggle', 'showFileSizesToggle', 'showAudioLanguagesToggle',
+    'showWatchProgressToggle', 'showFileSizesToggle', 'showFileSourceToggle', 'showAudioLanguagesToggle',
     'removeContinueWatchingToggle', 'hideFavoritesTabToggle',
     'qualityTagsToggle', 'genreTagsToggle', 'pauseScreenToggle',
     'languageTagsToggle', 'ratingTagsToggle', 'peopleTagsToggle',

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.preferred-audio.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.preferred-audio.test.ts
@@ -16,7 +16,7 @@ const TOGGLE_IDS = [
     'autoPauseToggle', 'autoResumeToggle', 'autoPipToggle',
     'autoSkipIntroToggle', 'autoSkipOutroToggle',
     'randomButtonToggle', 'randomUnwatchedOnly',
-    'showWatchProgressToggle', 'showFileSizesToggle', 'showAudioLanguagesToggle',
+    'showWatchProgressToggle', 'showFileSizesToggle', 'showFileSourceToggle', 'showAudioLanguagesToggle',
     'removeContinueWatchingToggle', 'hideFavoritesTabToggle',
     'qualityTagsToggle', 'genreTagsToggle', 'pauseScreenToggle',
     'languageTagsToggle', 'ratingTagsToggle', 'peopleTagsToggle',

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
@@ -357,6 +357,7 @@ export function wireSettingsListeners(ctx: PanelContext): void {
             if (appliesToActor && id === 'hideFavoritesTabToggle') (JC as any).applyHideFavoritesTab?.();
             if (appliesToActor && id === 'showWatchProgressToggle' && !(e.target as HTMLInputElement).checked) document.querySelectorAll('.mediaInfoItem-watchProgress').forEach(el => el.remove());
             if (appliesToActor && id === 'showFileSizesToggle' && !(e.target as HTMLInputElement).checked) document.querySelectorAll('.mediaInfoItem-fileSize').forEach(el => el.remove());
+            if (appliesToActor && id === 'showFileSourceToggle' && !(e.target as HTMLInputElement).checked) document.querySelectorAll('.mediaInfoItem-fileSource').forEach(el => el.remove());
             if (appliesToActor && id === 'showAudioLanguagesToggle' && !(e.target as HTMLInputElement).checked) document.querySelectorAll('.mediaInfoItem-audioLanguage').forEach(el => el.remove());
             resetAutoCloseTimer();
         });
@@ -388,6 +389,7 @@ export function wireSettingsListeners(ctx: PanelContext): void {
                 });
             }
     addSettingToggleListener('showFileSizesToggle', 'showFileSizes', 'feature_file_size_display');
+    addSettingToggleListener('showFileSourceToggle', 'showFileSource', 'panel_settings_ui_file_source');
     addSettingToggleListener('showAudioLanguagesToggle', 'showAudioLanguages', 'feature_audio_language_display');
     addSettingToggleListener('removeContinueWatchingToggle', 'removeContinueWatchingEnabled', 'feature_remove_continue_watching');
     addSettingToggleListener('hideFavoritesTabToggle', 'hideFavoritesTab', 'feature_hide_favorites_tab');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/styles.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/styles.ts
@@ -112,6 +112,7 @@ export function injectGlobalStyles(): void {
                 box-shadow: 0 1px 1px rgba(0,0,0,0.2);
             }
             .mediaInfoItem-fileSize .material-icons,
+            .mediaInfoItem-fileSource .material-icons,
             .mediaInfoItem-watchProgress .material-icons,
             .mediaInfoItem-audioLanguage .material-icons {
               font-family: 'Material Symbols Rounded' !important;
@@ -131,19 +132,25 @@ export function injectGlobalStyles(): void {
                roughly 540–700px because its sibling action row keeps its
                intrinsic size. Reserve a usable metadata column and let those
                actions wrap only while Canopy chips are actually mounted. */
-            @media (min-width: 500px) and (max-width: 709px) {
+            @media (min-width: 500px) and (max-width: 710px) {
                 .jc-modern-layout #itemDetailPage:not(.hide)
                 .detailRibbon:has(
                     .mediaInfoItem-watchProgress,
                     .mediaInfoItem-fileSize,
+                    .mediaInfoItem-fileSource,
                     .mediaInfoItem-audioLanguage
                 ) .infoWrapper {
                     min-width: 7.5rem !important;
                 }
                 .jc-modern-layout #itemDetailPage:not(.hide)
+                .detailRibbon:has(.mediaInfoItem-fileSource) .infoWrapper {
+                    min-width: 14rem !important;
+                }
+                .jc-modern-layout #itemDetailPage:not(.hide)
                 .detailRibbon:has(
                     .mediaInfoItem-watchProgress,
                     .mediaInfoItem-fileSize,
+                    .mediaInfoItem-fileSource,
                     .mediaInfoItem-audioLanguage
                 ) .mainDetailButtons {
                     min-width: 0 !important;

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/target-mode.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/target-mode.test.ts
@@ -135,7 +135,7 @@ const TOGGLE_IDS = [
     'autoPauseToggle', 'autoResumeToggle', 'autoPipToggle',
     'autoSkipIntroToggle', 'autoSkipOutroToggle',
     'randomButtonToggle', 'randomUnwatchedOnly',
-    'showWatchProgressToggle', 'showFileSizesToggle', 'showAudioLanguagesToggle',
+    'showWatchProgressToggle', 'showFileSizesToggle', 'showFileSourceToggle', 'showAudioLanguagesToggle',
     'removeContinueWatchingToggle', 'hideFavoritesTabToggle',
     'qualityTagsToggle', 'genreTagsToggle', 'pauseScreenToggle',
     'languageTagsToggle', 'ratingTagsToggle', 'peopleTagsToggle',
@@ -290,6 +290,10 @@ describe('admin target pane isolation', () => {
     it('persists target toggles without applying any actor DOM/runtime side effect', async () => {
         settingsDom();
         const editor = targetEditor();
+        editor.settings.showFileSource = true;
+        const actorSourceChip = document.createElement('div');
+        actorSourceChip.className = 'mediaInfoItem-fileSource';
+        document.body.appendChild(actorSourceChip);
         const initializeQuality = vi.fn();
         const addRandom = vi.fn();
         const hideFavorites = vi.fn();
@@ -307,11 +311,16 @@ describe('admin target pane isolation', () => {
         const random = document.getElementById('randomButtonToggle') as HTMLInputElement;
         random.checked = true;
         random.dispatchEvent(new Event('change'));
-        await vi.waitFor(() => expect(editor.saveSettings).toHaveBeenCalledTimes(2));
-        await vi.waitFor(() => expect(toast).toHaveBeenCalledTimes(2));
+        const fileSource = document.getElementById('showFileSourceToggle') as HTMLInputElement;
+        fileSource.checked = false;
+        fileSource.dispatchEvent(new Event('change'));
+        await vi.waitFor(() => expect(editor.saveSettings).toHaveBeenCalledTimes(3));
+        await vi.waitFor(() => expect(toast).toHaveBeenCalledTimes(3));
 
         expect(editor.settings.qualityTagsEnabled).toBe(true);
         expect(editor.settings.randomButtonEnabled).toBe(true);
+        expect(editor.settings.showFileSource).toBe(false);
+        expect(document.querySelector('.mediaInfoItem-fileSource')).toBe(actorSourceChip);
         expect(initializeQuality).not.toHaveBeenCalled();
         expect(addRandom).not.toHaveBeenCalled();
         expect(hideFavorites).not.toHaveBeenCalled();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/template.ts
@@ -374,6 +374,12 @@ export function buildPanelHtml(ctx: PanelContext): string {
                             </div>
                             <div style="margin-bottom: 16px; padding: 12px; background: ${presetBoxBackground}; border-radius: 6px; border-left: 3px solid ${toggleAccentColor};">
                                 <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
+                                    <input type="checkbox" id="showFileSourceToggle" ${settings.showFileSource ? 'checked' : ''} style="width:18px; height:18px; accent-color:${toggleAccentColor}; cursor:pointer;">
+                                    <div><div style="font-weight:500;">${JC.t!('panel_settings_ui_file_source')}</div><div style="font-size:12px; color:rgba(255,255,255,0.6); margin-top:2px;">${JC.t!('panel_settings_ui_file_source_desc')}</div></div>
+                                </label>
+                            </div>
+                            <div style="margin-bottom: 16px; padding: 12px; background: ${presetBoxBackground}; border-radius: 6px; border-left: 3px solid ${toggleAccentColor};">
+                                <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
                                     <input type="checkbox" id="showAudioLanguagesToggle" ${settings.showAudioLanguages ? 'checked' : ''} style="width:18px; height:18px; accent-color:${toggleAccentColor}; cursor:pointer;">
                                     <div><div style="font-weight:500;">${JC.t!('panel_settings_ui_audio_languages')}</div><div style="font-size:12px; color:rgba(255,255,255,0.6); margin-top:2px;">${JC.t!('panel_settings_ui_audio_languages_desc')}</div></div>
                                 </label>

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.test.ts
@@ -139,6 +139,24 @@ describe('built-in detail integration catalog', () => {
         }
     });
 
+    it('loads details for the file-source setting without coupling it to poster source tags', () => {
+        const details = descriptor('details-enhancements');
+        JC.pluginConfig = {};
+        JC.currentSettings = {
+            showFileSource: true,
+            qualityTagsEnabled: false,
+            showSourceTag: false,
+        };
+        expect(details.isEnabled(state)).toBe(true);
+
+        JC.currentSettings = {
+            showFileSource: false,
+            qualityTagsEnabled: true,
+            showSourceTag: true,
+        };
+        expect(details.isEnabled(state)).toBe(false);
+    });
+
     it('enforces TMDB prerequisites independently for release dates, Elsewhere, and TMDB reviews', () => {
         JC.currentSettings = { showWatchProgress: false };
         JC.pluginConfig = {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/entries/feature-catalog.ts
@@ -295,6 +295,7 @@ export const builtInFeatureDescriptors: readonly ClientFeatureDescriptor[] = Obj
         isEnabled: (state) => Boolean(state.identity) && (
             JC.currentSettings?.showWatchProgress === true
             || JC.currentSettings?.showFileSizes === true
+            || JC.currentSettings?.showFileSource === true
             || JC.currentSettings?.showAudioLanguages === true
             || (JC.pluginConfig?.ShowReleaseDates === true && JC.pluginConfig?.TmdbEnabled === true)
             || JC.pluginConfig?.HiddenContentEnabled === true

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/qualitytags.file-source.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/qualitytags.file-source.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import type { TagPipelineLike } from '../types/jc';
+import { disposeAllTagRenderers } from '../core/tag-renderer-base';
+import { getEnhancedQuality, installQualityTagsFacade } from './qualitytags';
+
+type RegisteredRenderer = {
+    render(el: HTMLElement, item: unknown, extras?: unknown): void;
+    renderFromCache?(el: HTMLElement, itemId: string): boolean;
+    renderFromServerCache(el: HTMLElement, entry: unknown, itemId: string): void;
+};
+
+function host(): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const target = document.createElement('div');
+    card.appendChild(target);
+    document.body.appendChild(card);
+    return target;
+}
+
+function labels(target: HTMLElement): string[] {
+    return Array.from(target.querySelectorAll<HTMLElement>('.quality-overlay-label'))
+        .map((label) => label.textContent || '');
+}
+
+describe('quality tag file-source integration', () => {
+    let renderer: RegisteredRenderer;
+    let uninstall: () => void;
+
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        localStorage.clear();
+        JC.identity.transition('server-a', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'quality-source-test');
+        JC.currentSettings = {
+            qualityTagsEnabled: true,
+            showResolutionTag: false,
+            showSourceTag: true,
+            showDynamicRangeTag: false,
+            showSpecialFormatTag: false,
+            showVideoCodecTag: false,
+            showAudioInfoTag: false,
+            showFileSource: false,
+        };
+        JC.pluginConfig = { TagCacheServerMode: true };
+        JC.tagPipeline = {
+            registerRenderer: (_name, candidate) => {
+                renderer = candidate as unknown as RegisteredRenderer;
+            },
+            unregisterRenderer: vi.fn(),
+        } as TagPipelineLike;
+        uninstall = installQualityTagsFacade();
+        (JC as typeof JC & { initializeQualityTags?: () => void }).initializeQualityTags?.();
+    });
+
+    afterEach(() => {
+        uninstall();
+        disposeAllTagRenderers();
+        document.body.innerHTML = '';
+        localStorage.clear();
+        JC.currentSettings = {};
+        JC.pluginConfig = {};
+        JC.tagPipeline = undefined;
+        JC._hotCache = undefined;
+    });
+
+    it('keeps item-only, live, and projected server source values aligned', () => {
+        expect(getEnhancedQuality(null, null, { Path: '/media/Item.BluRay.disc' })).toEqual(['BluRay']);
+
+        const live = host();
+        renderer.render(live, {
+            Id: 'live-source',
+            Type: 'Movie',
+            MediaSources: [{ Path: '/media/Item.BluRay.disc' }],
+        });
+        const projected = host();
+        renderer.renderFromServerCache(projected, {
+            StreamData: {
+                ItemName: 'Item',
+                ItemPath: '/media/Item.disc',
+                Streams: [],
+                Sources: [{ Path: '/media/Item.BluRay.disc' }],
+            },
+        }, 'server-source');
+
+        expect(labels(live)).toEqual(['BluRay']);
+        expect(labels(projected)).toEqual(labels(live));
+        expect(live.querySelector('.other-quality')?.getAttribute('data-quality')).toBe('BluRay');
+    });
+
+    it('keeps ambiguous multi-version source data silent on both poster paths', () => {
+        const sources = [
+            { Path: '/media/A.BluRay.disc' },
+            { Path: '/media/B.DVD.disc' },
+        ];
+        const live = host();
+        renderer.render(live, { Id: 'live-ambiguous', Type: 'Movie', MediaSources: sources });
+        const projected = host();
+        renderer.renderFromServerCache(projected, {
+            StreamData: { ItemName: 'Item', ItemPath: '', Streams: [], Sources: sources },
+        }, 'server-ambiguous');
+
+        expect(labels(live)).toEqual([]);
+        expect(labels(projected)).toEqual([]);
+    });
+
+    it('keeps the poster category independent from the details toggle', () => {
+        JC.currentSettings = { ...JC.currentSettings, showSourceTag: false, showFileSource: true };
+        const posterOff = host();
+        renderer.render(posterOff, {
+            Id: 'poster-off', Type: 'Movie', MediaSources: [{ Path: '/media/Item.DVD.disc' }],
+        });
+        expect(labels(posterOff)).toEqual([]);
+
+        JC.currentSettings = { ...JC.currentSettings, showSourceTag: true, showFileSource: false };
+        const posterOn = host();
+        renderer.render(posterOn, {
+            Id: 'poster-on', Type: 'Movie', MediaSources: [{ Path: '/media/Item.DVD.disc' }],
+        });
+        expect(labels(posterOn)).toEqual(['DVD']);
+    });
+
+    it('rejects a hot entry created before the shared detector version', () => {
+        const initial = host();
+        renderer.render(initial, {
+            Id: 'legacy-cache', Type: 'Movie', MediaSources: [{ Path: '/media/Item.DVD.disc' }],
+        });
+        const hot = JC._hotCache?.quality as { get(key: string): Record<string, unknown> | undefined };
+        const entry = hot.get('legacy-cache')!;
+        delete entry.fileSourceDetectionVersion;
+
+        const replay = host();
+        expect(renderer.renderFromCache?.(replay, 'legacy-cache')).toBe(false);
+        expect(labels(replay)).toEqual([]);
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/tags/qualitytags.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/tags/qualitytags.ts
@@ -13,6 +13,11 @@ import { register, reinitialize, resolvePosition } from '../core/tag-renderer-ba
 import type { TagRendererContext, TagSpec } from '../types/jc';
 import { resolveQualityResolution } from './quality-resolution';
 import {
+    detectFileSource,
+    FILE_SOURCE_DETECTION_VERSION,
+    FILE_SOURCE_VALUES,
+} from '../core/file-source';
+import {
     AUDIO_SELECTION_VERSION,
     describeSelectedAudioTrack,
     resolveEffectiveAudioLanguagePreference,
@@ -34,7 +39,7 @@ const containerClass = 'quality-overlay-container';
 
 // Within-category sort orders (more important = lower index inside each category).
 const resolutionOrder = ['8K', '4K', '1440p', '1080p', '720p', '480p', 'LOW-RES', 'SD'];
-const sourceOrder = ['BluRay', 'HD DVD', 'DVD', 'VHS', 'HDTV', 'Physical'];
+const sourceOrder: string[] = [...FILE_SOURCE_VALUES];
 const dynamicRangeOrder = ['Dolby Vision', 'HDR10+', 'HDR10', 'HDR'];
 const specialFormatOrder = ['IMAX', '3D'];
 const codecOrder = ['AV1', 'HEVC', 'H265', 'VP9', 'H264', 'VP8', 'XVID', 'DIVX', 'WMV', 'MPEG2', 'MPEG4', 'MJPEG', 'THEORA'];
@@ -114,6 +119,7 @@ interface QualityCacheEntry {
     qualities: string[];
     timestamp: number;
     audioSelectionKey: string;
+    fileSourceDetectionVersion: number;
 }
 
 // Computed quality labels derived from server cache entries. The preference
@@ -194,7 +200,7 @@ export function getEnhancedQuality(
     itemData: any = null,
     preferredAudioLanguage = effectiveAudioPreference(),
 ): string[] {
-    if (!mediaStreams && !mediaSources) return [];
+    if (!mediaStreams && !mediaSources && !itemData) return [];
 
     const qualities = new Set<string>();
     let videoStreams: any[] = [];
@@ -400,45 +406,13 @@ export function getEnhancedQuality(
     }
 
     // --- MEDIA STUB TAG LOGIC ---
-    // Detect media stubs (.disc files) for BluRay, DVD, or generic Physical media
-    const stubSignals: string[] = [];
-    if (itemData) {
-        stubSignals.push(
-            itemData.Name || '',
-            itemData.Path || ''
-        );
-    }
-    if (Array.isArray(mediaSources)) {
-        mediaSources.forEach((source: any) => {
-            stubSignals.push(source?.Path || '', source?.Name || '');
-        });
-    }
-
-    const stubContext = stubSignals.filter(Boolean).join(' | ').toLowerCase();
-
-    // Check for .disc extension (media stub indicator)
-    if (stubContext.includes('.disc')) {
-        // Parse filename/path for specific media type patterns
-        const blurayRegex = /bluray|blu-ray|bdrip|bd-rip|bdremux/;
-        const hddvdRegex = /hddvd|hd-dvd|hd dvd/;
-        const dvdRegex = /dvd|dvdrip|dvd-rip|dvdremux/;
-        const vhsRegex = /vhs/;
-        const hdtvRegex = /hdtv/;
-
-        if (blurayRegex.test(stubContext)) {
-            qualities.add('BluRay');
-        } else if (hddvdRegex.test(stubContext)) {
-            qualities.add('HD DVD');
-        } else if (dvdRegex.test(stubContext)) {
-            qualities.add('DVD');
-        } else if (vhsRegex.test(stubContext)) {
-            qualities.add('VHS');
-        } else if (hdtvRegex.test(stubContext)) {
-            qualities.add('HDTV');
-        } else {
-            qualities.add('Physical');
-        }
-    }
+    // Poster and details surfaces deliberately share one ambiguity-safe owner.
+    const fileSource = detectFileSource({
+        Name: itemData?.Name,
+        Path: itemData?.Path,
+        MediaSources: mediaSources,
+    });
+    if (fileSource) qualities.add(fileSource);
 
     return Array.from(qualities);
 }
@@ -678,6 +652,7 @@ const spec: TagSpec = {
             // Check hot cache first
             const hot = ctx.hot?.get(itemId) as QualityCacheEntry | undefined;
             if (hot && hot.audioSelectionKey === selectionKey
+                && hot.fileSourceDetectionVersion === FILE_SOURCE_DETECTION_VERSION
                 && (Date.now() - hot.timestamp) < ctx.cacheTtl) {
                 insertOverlay(ctx, el, hot.qualities);
                 return;
@@ -697,6 +672,7 @@ const spec: TagSpec = {
                     qualities,
                     timestamp: Date.now(),
                     audioSelectionKey: selectionKey,
+                    fileSourceDetectionVersion: FILE_SOURCE_DETECTION_VERSION,
                 };
                 ctx.setPersistent(itemId, cached);
                 ctx.hot?.set(itemId, cached);
@@ -710,6 +686,7 @@ const spec: TagSpec = {
             const hot = ctx.hot?.get(itemId) as QualityCacheEntry | undefined;
             const cached = hot || (ctx.getPersistent(itemId) as QualityCacheEntry | undefined);
             if (cached?.audioSelectionKey === audioSelectionKey()
+                && cached.fileSourceDetectionVersion === FILE_SOURCE_DETECTION_VERSION
                 && Array.isArray(cached.qualities) && cached.qualities.length > 0) {
                 insertOverlay(ctx, el, cached.qualities);
                 return true;
@@ -722,17 +699,26 @@ const spec: TagSpec = {
             const selectionKey = audioSelectionKey();
             // Check local computed cache first (avoids re-running quality detection)
             const cached = serverQualityCache.get(itemId);
-            if (cached?.audioSelectionKey === selectionKey) {
+            if (cached?.audioSelectionKey === selectionKey
+                && cached.fileSourceDetectionVersion === FILE_SOURCE_DETECTION_VERSION) {
                 if (cached.qualities.length > 0) insertOverlay(ctx, el, cached.qualities);
                 return;
             }
             const sd = entry.StreamData;
             if (!sd || !sd.Streams) {
-                serverQualityCache.set(itemId, { audioSelectionKey: selectionKey, qualities: [] });
+                serverQualityCache.set(itemId, {
+                    audioSelectionKey: selectionKey,
+                    fileSourceDetectionVersion: FILE_SOURCE_DETECTION_VERSION,
+                    qualities: [],
+                });
                 return;
             }
             const qualities = getEnhancedQuality(sd.Streams, sd.Sources, { Name: sd.ItemName, Path: sd.ItemPath });
-            serverQualityCache.set(itemId, { audioSelectionKey: selectionKey, qualities });
+            serverQualityCache.set(itemId, {
+                audioSelectionKey: selectionKey,
+                fileSourceDetectionVersion: FILE_SOURCE_DETECTION_VERSION,
+                qualities,
+            });
             if (qualities.length > 0) insertOverlay(ctx, el, qualities);
         },
         onServerCacheRefresh(ctx, updatedIds) {

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -22,7 +22,7 @@ The panel is a settings view with a section list on the left (full-screen with t
 - **Shortcuts** — customize the keyboard shortcuts (see [Advanced keyboard shortcuts](#advanced-keyboard-shortcuts)).
 - **Playback, Auto-Skip, Subtitles, Random Button, UI, Hidden Content, Spoiler Guard, Language** — enable or disable features and adjust positions, sizes, colors, and modes, one section at a time.
 
-Toggling a feature applies **immediately** — no restart, no page reload. The toggles you'll find here include Quality Tags, Genre Tags, Language Tags, Rating Tags, People Tags, Pause Screen, Auto-skip Intros, Auto-skip Outros, Auto Picture-in-Picture, Show Watch Progress, Show File Sizes, Show Audio Languages, and more.
+Toggling a feature applies **immediately** — no restart, no page reload. The toggles you'll find here include Quality Tags, Genre Tags, Language Tags, Rating Tags, People Tags, Pause Screen, Auto-skip Intros, Auto-skip Outros, Auto Picture-in-Picture, Show Watch Progress, Show File Sizes, Show File Source, Show Audio Languages, and more.
 
 ### Settings persistence
 
@@ -401,6 +401,7 @@ Poster tags are computed once on the server and served in a single request, so t
 Beyond poster overlays, a few per-user toggles add useful facts to a title's detail page.
 
 - **Show File Sizes** — displays each item's file size on its detail and collection pages. Per-user, in the **Settings** tab.
+- **Show File Source** — displays the normalized physical-media source (`BluRay`, `HD DVD`, `DVD`, `VHS`, `HDTV`, or generic `Physical`) on Movie and Episode detail pages. It is independent of the poster Quality Tags **Source** category, so you can keep poster source badges off while retaining the detail-page chip. Detection remains limited to Jellyfin `.disc` media stubs; ordinary files, unsupported data, and conflicting or partly unknown multi-version items stay silent instead of guessing. Per-user, default off, in the **Settings** tab.
 - **Show Audio Languages** — lists a title's available audio languages on its detail page. For Collections it shows the same bounded, access-safe full/partial/unknown member coverage as the poster instead of choosing a representative title. Explicit BCP-47 country regions use the same validated flag as poster Language Tags; ambiguous tags stay as descriptive text without an inferred national flag. Per-user, in the **Settings** tab. (This is the text list on the detail page — distinct from the poster [Language Tags](#language-tags) overlay.)
 
 There's also an admin-only chip for release dates:

--- a/e2e/details-file-source.spec.ts
+++ b/e2e/details-file-source.spec.ts
@@ -1,0 +1,193 @@
+// #670 — file source is an independent details-page chip. Exercise a real
+// Jellyfin 12 item whose probed media-source path contains the `.disc` marker,
+// cached details navigation, the poster-source setting boundary, and the real
+// acknowledged per-user toggle. The exact original setting is restored.
+import type { Page, Response } from 'playwright/test';
+import {
+    test,
+    expect,
+    loginAs,
+    showRoute,
+    waitForHash,
+    assertNoRuntimeErrors,
+} from './fixtures/auth';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const FILE_SOURCE_PATH = '/media/Movies/JC File Source BluRay.disc.mkv';
+
+async function openUiPane(page: Page) {
+    const panel = page.locator('#jellyfin-canopy-panel');
+    if (!await panel.isVisible()) {
+        await page.evaluate(() => { void (window as any).JellyfinCanopy.showEnhancedPanel(); });
+    }
+    await expect(panel).toBeVisible({ timeout: 15_000 });
+    await panel.locator('.tab-button[data-tab="ui"]').click();
+    await expect(panel.locator('.jc-pane[data-pane="ui"]')).toBeVisible();
+    return panel;
+}
+
+async function readPersistedToggle(page: Page): Promise<boolean> {
+    return page.evaluate(async () => {
+        const api = (window as any).ApiClient;
+        const value = await api.ajax({
+            type: 'GET',
+            url: api.getUrl(
+                `/JellyfinCanopy/user-settings/${encodeURIComponent(api.getCurrentUserId())}/settings.json`
+            ),
+            dataType: 'json',
+        });
+        return (value.ShowFileSource ?? value.showFileSource) === true;
+    });
+}
+
+interface PosterSettingsSnapshot {
+    qualityTagsEnabled: boolean;
+    showSourceTag: boolean;
+}
+
+async function readPersistedPosterSettings(page: Page): Promise<PosterSettingsSnapshot> {
+    return page.evaluate(async () => {
+        const api = (window as any).ApiClient;
+        const value = await api.ajax({
+            type: 'GET',
+            url: api.getUrl(
+                `/JellyfinCanopy/user-settings/${encodeURIComponent(api.getCurrentUserId())}/settings.json`
+            ),
+            dataType: 'json',
+        });
+        return {
+            qualityTagsEnabled: (value.QualityTagsEnabled ?? value.qualityTagsEnabled) === true,
+            showSourceTag: (value.ShowSourceTag ?? value.showSourceTag) === true,
+        };
+    });
+}
+
+async function applyLivePosterSettings(page: Page, settings: PosterSettingsSnapshot): Promise<void> {
+    await page.evaluate((values) => {
+        const canopy = (window as any).JellyfinCanopy;
+        canopy.currentSettings.qualityTagsEnabled = values.qualityTagsEnabled;
+        canopy.currentSettings.showSourceTag = values.showSourceTag;
+        canopy.reinitializeQualityTags();
+    }, settings);
+}
+
+function isExactSaveResponse(response: Response, on: boolean): boolean {
+    if (!response.ok()
+        || response.request().method() !== 'POST'
+        || !/\/JellyfinCanopy\/user-settings\/[^/?]+\/settings\.json(?:\?|$)/.test(response.url())) {
+        return false;
+    }
+    const body = response.request().postDataJSON() as Record<string, unknown> | null;
+    return (body?.ShowFileSource ?? body?.showFileSource) === on;
+}
+
+async function setToggle(page: Page, on: boolean): Promise<void> {
+    const panel = await openUiPane(page);
+    const toggle = panel.locator('#showFileSourceToggle');
+    await toggle.scrollIntoViewIfNeeded();
+    expect(await toggle.isChecked(), 'each helper call must perform a real mutation').not.toBe(on);
+    const [response] = await Promise.all([
+        page.waitForResponse((candidate) => isExactSaveResponse(candidate, on), { timeout: 30_000 }),
+        toggle.setChecked(on),
+    ]);
+    const acknowledgement = await response.json() as Record<string, any>;
+    const data = acknowledgement.Data ?? acknowledgement.data;
+    expect(acknowledgement.Success ?? acknowledgement.success, 'settings write was acknowledged').toBe(true);
+    expect(acknowledgement.File ?? acknowledgement.file).toBe('settings.json');
+    expect(data?.ShowFileSource ?? data?.showFileSource).toBe(on);
+    await page.keyboard.press('Escape');
+    await expect(panel).toBeHidden({ timeout: 10_000 });
+}
+
+test.describe('details file source (#670)', () => {
+    test('real .disc source is independent, navigation-safe, and removed live when disabled', async ({
+        page,
+        consoleErrors,
+    }) => {
+        await loginAs(page, 'admin', consoleErrors);
+        const originalToggle = await readPersistedToggle(page);
+        const originalPosterSettings = await readPersistedPosterSettings(page);
+        const fixture = await page.evaluate(async (path) => {
+            const api = (window as any).ApiClient;
+            const result = await api.getItems(api.getCurrentUserId(), {
+                IncludeItemTypes: 'Movie',
+                Recursive: true,
+                Fields: 'Path,MediaSources,MediaStreams',
+                Limit: 100,
+            });
+            const items = result?.Items || [];
+            const matches = items.filter((item: any) => item.Path === path);
+            const ordinary = items.find((item: any) => item.Path !== path && !String(item.Path || '').includes('.disc'));
+            const item = matches[0];
+            return {
+                matchCount: matches.length,
+                itemId: item?.Id || '',
+                mediaSourcePathCount: (item?.MediaSources || []).filter(
+                    (source: any) => source?.Path === path
+                ).length,
+                ordinaryId: ordinary?.Id || '',
+            };
+        }, FILE_SOURCE_PATH);
+        expect(fixture.matchCount).toBe(1);
+        expect(fixture.mediaSourcePathCount).toBe(1);
+        expect(fixture.itemId).not.toBe('');
+        expect(fixture.ordinaryId).not.toBe('');
+
+        try {
+            if (!originalToggle) await setToggle(page, true);
+
+            await showRoute(page, `/details?id=${fixture.itemId}`);
+            await waitForHash(page, fixture.itemId);
+            const visible = page.locator('#itemDetailPage:not(.hide)');
+            const chip = visible.locator(
+                `.mediaInfoItem-fileSource[data-item-id="${fixture.itemId}"]`
+            );
+            await expect(chip).toBeVisible({ timeout: 30_000 });
+            await expect(chip).toContainText('BluRay');
+            await expect(chip).not.toContainText('/media');
+
+            // Apply the poster-only values after the persisted details toggle
+            // write, then restore them before any later full-settings POST.
+            await applyLivePosterSettings(page, {
+                qualityTagsEnabled: true,
+                showSourceTag: false,
+            });
+            await expect(visible.locator('.quality-overlay-label')).not.toHaveCount(0, { timeout: 30_000 });
+            await expect(visible.locator('.quality-overlay-label[data-quality="BluRay"]')).toHaveCount(0);
+            await expect(chip).toContainText('BluRay');
+
+            await showRoute(page, `/details?id=${fixture.ordinaryId}`);
+            await waitForHash(page, fixture.ordinaryId);
+            await expect(page.locator('#itemDetailPage:not(.hide) .mediaInfoItem-fileSource')).toHaveCount(0);
+
+            await page.goBack();
+            await waitForHash(page, fixture.itemId);
+            await expect(page.locator(
+                `#itemDetailPage:not(.hide) .mediaInfoItem-fileSource[data-item-id="${fixture.itemId}"]`
+            )).toContainText('BluRay', { timeout: 30_000 });
+
+            await applyLivePosterSettings(page, originalPosterSettings);
+            await setToggle(page, false);
+            await expect(page.locator('.mediaInfoItem-fileSource')).toHaveCount(0);
+
+            // Ensure finally always performs an acknowledged restoration write.
+            if (!originalToggle) await setToggle(page, true);
+        } finally {
+            if (!page.isClosed()) {
+                await applyLivePosterSettings(page, originalPosterSettings);
+                const current = await readPersistedToggle(page);
+                if (current !== originalToggle) await setToggle(page, originalToggle);
+                await applyLivePosterSettings(page, originalPosterSettings);
+            }
+        }
+
+        expect(await readPersistedToggle(page), 'the exact original server value is restored')
+            .toBe(originalToggle);
+        expect(
+            await readPersistedPosterSettings(page),
+            'temporary poster values never reach persisted settings'
+        ).toEqual(originalPosterSettings);
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});

--- a/e2e/details-media-info-responsive.spec.ts
+++ b/e2e/details-media-info-responsive.spec.ts
@@ -1,6 +1,6 @@
 // #466 finding 5 — Jellyfin 12 modern compresses the details metadata row
 // between its native action buttons at intermediate phone/tablet widths.
-// Exercise the real details page, all three Canopy media-info chips, and both
+// Exercise the real details page, all four Canopy media-info chips, and the
 // supported modern layout across the complete breakpoint-island sweep.
 import type { Locator, Page } from 'playwright/test';
 import {
@@ -64,13 +64,13 @@ async function capture(page: Page, ribbon: Locator, fileName: string): Promise<v
     });
 }
 
-/** Choose a movie whose eventual audio chip stays deterministic and compact. */
-async function movieWithAtMostThreeAudioLanguages(page: Page): Promise<string> {
+/** Choose the real .disc fixture whose audio chip stays deterministic and compact. */
+async function fileSourceMovieWithAtMostThreeAudioLanguages(page: Page): Promise<string> {
     const itemId = await page.evaluate(async () => {
         const api = (window as any).ApiClient;
         const url = api.getUrl(
             '/Items?IncludeItemTypes=Movie&Recursive=true&Limit=50'
-            + '&Fields=MediaSources,MediaStreams'
+            + '&Fields=Path,MediaSources,MediaStreams'
             + `&userId=${api.getCurrentUserId()}`
         );
         const result = await api.ajax({ type: 'GET', url, dataType: 'json' });
@@ -89,11 +89,12 @@ async function movieWithAtMostThreeAudioLanguages(page: Page): Promise<string> {
                     .map((stream: any) => stream.Language || stream.DisplayLanguage)
                     .filter(Boolean)
             );
-            return languages.size <= 3;
+            return item.Path === '/media/Movies/JC File Source BluRay.disc.mkv'
+                && languages.size <= 3;
         });
-        return suitable?.Id || items[0]?.Id || null;
+        return suitable?.Id || null;
     });
-    expect(itemId, 'the seeded library must contain a movie').toBeTruthy();
+    expect(itemId, 'the seeded library must contain the exact .disc file-source fixture').toBeTruthy();
     return itemId as string;
 }
 
@@ -109,6 +110,7 @@ interface DetailsGeometry {
     chipContentsWithinClient: boolean[];
     visibleChipCount: number;
     maxActionOverlapArea: number;
+    trackSelectionsOverlapArea: number;
     visibleActionCount: number;
     buttonsWithinActions: boolean;
     hostWithinInfoWrapper: boolean;
@@ -129,8 +131,9 @@ async function readDetailsGeometry(page: Page, width: number): Promise<DetailsGe
         const infoWrapper = visiblePage.querySelector<HTMLElement>('.infoWrapper')!;
         const host = visiblePage.querySelector<HTMLElement>('.itemMiscInfo-primary')!;
         const actions = visiblePage.querySelector<HTMLElement>('.mainDetailButtons')!;
+        const trackSelections = visiblePage.querySelector<HTMLElement>('.trackSelections')!;
         const chips = Array.from(host.querySelectorAll<HTMLElement>(
-            '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-audioLanguage'
+            '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-fileSource, .mediaInfoItem-audioLanguage'
         ));
         const actionButtons = Array.from(actions.querySelectorAll<HTMLElement>('button, .detailButton'))
             .filter((button) => button.getClientRects().length > 0);
@@ -245,6 +248,10 @@ async function readDetailsGeometry(page: Page, width: number): Promise<DetailsGe
             chipContentsWithinClient: chips.map(contentWithinClientHorizontally),
             visibleChipCount: chips.filter((chip) => chip.getClientRects().length > 0).length,
             maxActionOverlapArea: Math.max(0, ...overlapAreas),
+            trackSelectionsOverlapArea: intersectionArea(
+                hostRect,
+                trackSelections.getBoundingClientRect()
+            ),
             visibleActionCount: actionButtons.length,
             buttonsWithinActions: actionButtons.every((button) =>
                 withinClientHorizontally(button.getBoundingClientRect(), actions)),
@@ -316,11 +323,12 @@ test.describe('responsive details media info (#466 finding 5)', () => {
 
             // This is page-local test setup, not persisted user/config state.
             // Setting it before navigation makes the real details feature
-            // loader activate all three chips on the target route.
+            // loader activate all four chips on the target route.
             await page.evaluate(() => {
                 const canopy = (window as any).JellyfinCanopy;
                 canopy.currentSettings.showWatchProgress = true;
                 canopy.currentSettings.showFileSizes = true;
+                canopy.currentSettings.showFileSource = true;
                 canopy.currentSettings.showAudioLanguages = true;
                 canopy.currentSettings.watchProgressMode = 'percentage';
             });
@@ -341,7 +349,7 @@ test.describe('responsive details media info (#466 finding 5)', () => {
             }));
 
             try {
-                const itemId = await movieWithAtMostThreeAudioLanguages(page);
+                const itemId = await fileSourceMovieWithAtMostThreeAudioLanguages(page);
                 await showRoute(page, `/details?id=${itemId}`);
                 await waitForHash(page, itemId);
 
@@ -349,14 +357,16 @@ test.describe('responsive details media info (#466 finding 5)', () => {
                 const host = visible.locator('.itemMiscInfo-primary');
                 const watchProgress = host.locator('.mediaInfoItem-watchProgress');
                 const fileSize = host.locator('.mediaInfoItem-fileSize');
+                const fileSource = host.locator('.mediaInfoItem-fileSource');
                 const audioLanguages = host.locator('.mediaInfoItem-audioLanguage');
                 await expect(host).toBeVisible({ timeout: 30_000 });
                 await expect(watchProgress).toContainText('42%', { timeout: 30_000 });
                 await expect(fileSize).toContainText(/\d[\d.]*\s*GB/, { timeout: 30_000 });
+                await expect(fileSource).toContainText('BluRay', { timeout: 30_000 });
                 await expect(audioLanguages).toBeVisible({ timeout: 30_000 });
                 await expect(host.locator(
-                    '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-audioLanguage'
-                )).toHaveCount(3);
+                    '.mediaInfoItem-watchProgress, .mediaInfoItem-fileSize, .mediaInfoItem-fileSource, .mediaInfoItem-audioLanguage'
+                )).toHaveCount(4);
 
                 for (const width of WIDTHS) {
                     await page.setViewportSize({ width, height: 900 });
@@ -375,8 +385,8 @@ test.describe('responsive details media info (#466 finding 5)', () => {
                         .toBeGreaterThan(0);
                     expect(geometry.visibleActionCount, `${width}px native actions remain present`)
                         .toBeGreaterThan(0);
-                    expect(geometry.visibleChipCount, `${width}px all three Canopy chips remain present`)
-                        .toBe(3);
+                    expect(geometry.visibleChipCount, `${width}px all four Canopy chips remain present`)
+                        .toBe(4);
                     expect(geometry.hostOverflow, `${width}px metadata host overflow`)
                         .toBeLessThanOrEqual(1);
                     expect(geometry.infoWrapperOverflow, `${width}px info wrapper overflow`)
@@ -400,6 +410,10 @@ test.describe('responsive details media info (#466 finding 5)', () => {
                     expect(
                         geometry.maxActionOverlapArea,
                         `${width}px Canopy chips do not overlap native action buttons`
+                    ).toBeLessThanOrEqual(1);
+                    expect(
+                        geometry.trackSelectionsOverlapArea,
+                        `${width}px metadata does not overlap native track selectors`
                     ).toBeLessThanOrEqual(1);
                     expect(geometry.actionsWithinRibbon, `${width}px actions stay in ribbon`)
                         .toBe(true);

--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -270,6 +270,10 @@ REGIONAL_LANGUAGE_CONTAINER_PATH="/media/${REGIONAL_LANGUAGE_RELATIVE_PATH}"
 MULTILINGUAL_AUDIO_NAME="Echo Meridian"
 MULTILINGUAL_AUDIO_RELATIVE_PATH="Movies/Echo Meridian (2025).mkv"
 MULTILINGUAL_AUDIO_CONTAINER_PATH="/media/${MULTILINGUAL_AUDIO_RELATIVE_PATH}"
+FILE_SOURCE_NAME="$(jq -er '.fileSource.name | select(type == "string" and length > 0)' "${FIXTURE_CONTRACT}")"
+FILE_SOURCE_RELATIVE_PATH="$(jq -er '.fileSource.relativePath | select(type == "string" and endswith(".disc.mkv"))' "${FIXTURE_CONTRACT}")"
+FILE_SOURCE_CANONICAL_VALUE="$(jq -er '.fileSource.canonicalValue | select(. == "BluRay")' "${FIXTURE_CONTRACT}")"
+FILE_SOURCE_CONTAINER_PATH="/media/${FILE_SOURCE_RELATIVE_PATH}"
 
 # ── 1. clean state + plugin install ─────────────────────────────────────────
 log "resetting project ${E2E_PROJECT} state under ${STATE_DIR} (config/cache/media/mock)"
@@ -390,6 +394,7 @@ make_clip "Movies/Gamma Quest (2023).mp4" 660
 # the pinned Jellyfin 12 image exposes the regional tag before Playwright runs.
 make_clip "${REGIONAL_LANGUAGE_RELATIVE_PATH}" 770 5 pt-BR
 make_multilingual_clip "${MULTILINGUAL_AUDIO_RELATIVE_PATH}"
+make_clip "${FILE_SOURCE_RELATIVE_PATH}" 825
 log "generating dedicated Auto-Skip movie (${AUTOSKIP_DURATION}s, seed ${SEED_NONCE})"
 mkdir -p "${MEDIA_DIR}/${AUTOSKIP_RELATIVE_DIR}"
 make_clip "${AUTOSKIP_RELATIVE_PATH}" 880 "${AUTOSKIP_DURATION}"
@@ -701,6 +706,8 @@ REGIONAL_LANGUAGE_MATCH_COUNT=0
 REGIONAL_LANGUAGE_TAGS='[]'
 MULTILINGUAL_AUDIO_MATCH_COUNT=0
 MULTILINGUAL_AUDIO_TRACKS='[]'
+FILE_SOURCE_MATCH_COUNT=0
+FILE_SOURCE_MEDIA_PATH_COUNT=0
 for _ in $(seq 1 60); do
     AUTOSKIP_SCAN_JSON="$(api GET "/Items?IncludeItemTypes=Movie&Recursive=true&userId=${ADMIN_ID}&Fields=Path,MediaSources,MediaStreams")"
     MOVIES="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r '.TotalRecordCount // 0')"
@@ -743,19 +750,29 @@ for _ in $(seq 1 60); do
             }]
          | unique_by(.language, .codec, .channels, .isDefault)
          | sort_by(.language)')"
-    if [ "${MOVIES}" -ge 6 ] 2>/dev/null \
+    FILE_SOURCE_MATCH_COUNT="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r \
+        --arg path "${FILE_SOURCE_CONTAINER_PATH}" \
+        '[.Items[]? | select(.Path == $path)] | length')"
+    FILE_SOURCE_MEDIA_PATH_COUNT="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r \
+        --arg path "${FILE_SOURCE_CONTAINER_PATH}" \
+        '[first(.Items[]? | select(.Path == $path)) as $item
+          | ($item.MediaSources // [])[]?
+          | select(.Path == $path)] | length')"
+    if [ "${MOVIES}" -ge 7 ] 2>/dev/null \
         && [ "${AUTOSKIP_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
         && [ "${AUTOSKIP_SCAN_SOURCE_COUNT}" -ge 1 ] 2>/dev/null \
         && [ "${AUTOSKIP_SCAN_TICKS}" -ge "${AUTOSKIP_MIN_TICKS}" ] 2>/dev/null \
         && [ "${REGIONAL_LANGUAGE_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
         && [ "${REGIONAL_LANGUAGE_TAGS}" = '["pt-br"]' ] \
         && [ "${MULTILINGUAL_AUDIO_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
-        && [ "${MULTILINGUAL_AUDIO_TRACKS}" = '[{"language":"en-us","codec":"aac","channels":6,"isDefault":true},{"language":"pt-br","codec":"eac3","channels":2,"isDefault":false}]' ]; then
+        && [ "${MULTILINGUAL_AUDIO_TRACKS}" = '[{"language":"en-us","codec":"aac","channels":6,"isDefault":true},{"language":"pt-br","codec":"eac3","channels":2,"isDefault":false}]' ] \
+        && [ "${FILE_SOURCE_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
+        && [ "${FILE_SOURCE_MEDIA_PATH_COUNT}" -eq 1 ] 2>/dev/null; then
         break
     fi
     sleep 5
 done
-[ "${MOVIES}" -ge 6 ] || fail "library scan indexed only ${MOVIES} movies (expected at least 6)"
+[ "${MOVIES}" -ge 7 ] || fail "library scan indexed only ${MOVIES} movies (expected at least 7)"
 [ "${AUTOSKIP_MATCH_COUNT}" -eq 1 ] \
     || fail "Auto-Skip fixture '${AUTOSKIP_NAME}' (ID <missing>, duration <missing>) was not indexed at ${AUTOSKIP_CONTAINER_PATH}"
 [ "${AUTOSKIP_SCAN_SOURCE_COUNT}" -ge 1 ] 2>/dev/null \
@@ -772,6 +789,11 @@ log "verified regional-language fixture tags: ${REGIONAL_LANGUAGE_TAGS}"
 [ "${MULTILINGUAL_AUDIO_TRACKS}" = '[{"language":"en-us","codec":"aac","channels":6,"isDefault":true},{"language":"pt-br","codec":"eac3","channels":2,"isDefault":false}]' ] \
     || fail "multilingual-audio fixture exposed ${MULTILINGUAL_AUDIO_TRACKS}; expected the pinned en-US default AAC 5.1 and pt-BR E-AC-3 stereo tracks"
 log "verified multilingual-audio fixture tracks: ${MULTILINGUAL_AUDIO_TRACKS}"
+[ "${FILE_SOURCE_MATCH_COUNT}" -eq 1 ] \
+    || fail "file-source fixture '${FILE_SOURCE_NAME}' was not indexed at ${FILE_SOURCE_CONTAINER_PATH}"
+[ "${FILE_SOURCE_MEDIA_PATH_COUNT}" -eq 1 ] \
+    || fail "file-source fixture '${FILE_SOURCE_NAME}' did not expose its exact .disc media-source path"
+log "verified file-source fixture: ${FILE_SOURCE_CANONICAL_VALUE} at ${FILE_SOURCE_CONTAINER_PATH}"
 
 log "waiting for the explicit library scan to complete before metadata writes"
 LIBRARY_SCAN_STATE=""

--- a/e2e/fixtures/media-fixtures.json
+++ b/e2e/fixtures/media-fixtures.json
@@ -6,5 +6,10 @@
     "segmentStartSeconds": 2,
     "segmentEndSeconds": 25,
     "minimumMarginSeconds": 10
+  },
+  "fileSource": {
+    "name": "JC File Source BluRay",
+    "relativePath": "Movies/JC File Source BluRay.disc.mkv",
+    "canonicalValue": "BluRay"
   }
 }

--- a/e2e/perf/jank-benchmark.js
+++ b/e2e/perf/jank-benchmark.js
@@ -151,7 +151,7 @@ function initScript() {
         '.genre-overlay-container', '.quality-overlay-container',
         '.language-overlay-container', '.rating-overlay-container',
         '.arr-link', '.arr-dropdown', '.arr-badge',
-        '.mediaInfoItem-watchProgress', '.mediaInfoItem-fileSize', '.mediaInfoItem-audioLanguage',
+        '.mediaInfoItem-watchProgress', '.mediaInfoItem-fileSize', '.mediaInfoItem-fileSource', '.mediaInfoItem-audioLanguage',
         '#streaming-result-container', '.jellyfin-elsewhere'
     ].join(',');
     const isJeNode = (node) => {
@@ -206,7 +206,7 @@ function initScript() {
     const HEADER_ANCHOR = '.MuiToolbar-root';
     const HEADER_DECOR = '#randomItemButton,#enhancedSettingsBtn';
     const DETAIL_ANCHOR = '.mainDetailButtons';
-    const DETAIL_DECOR = '.arr-link,.mediaInfoItem-watchProgress,.mediaInfoItem-fileSize,.mediaInfoItem-audioLanguage,#streaming-result-container';
+    const DETAIL_DECOR = '.arr-link,.mediaInfoItem-watchProgress,.mediaInfoItem-fileSize,.mediaInfoItem-fileSource,.mediaInfoItem-audioLanguage,#streaming-result-container';
     const cardTimes = new WeakMap();
     const seenDecor = new WeakSet();
     const anchorTimes = { header: -1, detail: -1 };

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -38,6 +38,7 @@
     "e2e/code-splitting.spec.ts › manifest-owned code splitting › a failed static boot child retries the complete graph in a new path namespace",
     "e2e/code-splitting.spec.ts › manifest-owned code splitting › cold authenticated home excludes disabled and off-route feature entries",
     "e2e/code-splitting.spec.ts › manifest-owned code splitting › concurrent generation triggers share one applicable route-module load",
+    "e2e/details-file-source.spec.ts › details file source (#670) › real .disc source is independent, navigation-safe, and removed live when disabled",
     "e2e/details-media-info-responsive.spec.ts › responsive details media info (#466 finding 5) › modern: chips fit and stay clear of native actions from 500px through 710px",
     "e2e/details-view-cache.spec.ts › details view-cache (chips land in the visible page) › a wiped misc-info row is re-populated (observer gate is alive with cached duplicates)",
     "e2e/details-view-cache.spec.ts › details view-cache (chips land in the visible page) › chips survive late item-data (host innerHTML wipe after the fill)",

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 179,
+    "maxOutputCount": 181,
     "maxEsmEntryCount": 38,
-    "maxEsmOutputCount": 86,
+    "maxEsmOutputCount": 87,
     "maxIndividualEsmRawBytes": 262144,
     "maxBootRequests": 17,
     "maxBootRawBytes": 524288,
@@ -11,15 +11,15 @@
     "maxColdHomeRequests": 24,
     "maxColdHomeRawBytes": 202227,
     "maxColdHomeGzipBytes": 67825,
-    "maxFeatureRequests": 19,
+    "maxFeatureRequests": 20,
     "maxFeatureRawBytes": 524288,
     "maxFeatureGzipBytes": 196608,
     "maxFeatureExpandedRequests": 22,
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7386974,
+    "maxTotalRawBytes": 7399777,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7474232
+    "maxPublishedRawBytes": 7487782
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,20 +25,20 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2920, totalLines: 3305 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45111, totalLines: 54905 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2944, totalLines: 3329 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45122, totalLines: 54910 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 2920,
-        maximumCoveredLines: 2920,
+        minimumCoveredLines: 2944,
+        maximumCoveredLines: 2944,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 5,
-        minimumCoveredLines: 45101,
-        maximumCoveredLines: 45111,
+        minimumCoveredLines: 45115,
+        maximumCoveredLines: 45122,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 10);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,34 +10,34 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2920,
-        "totalLines": 3305
+        "coveredLines": 2944,
+        "totalLines": 3329
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 2920,
-        "maximumCoveredLines": 2920
+        "minimumCoveredLines": 2944,
+        "maximumCoveredLines": 2944
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "Issue #669 adds media-type and stable UI-surface rating-tag scope resolution, admin/user deny-list precedence, live stale-tag invalidation, same-item surface-recycling and async personal-review ownership fencing, and acknowledgement-safe per-user persistence. Two clean full client runs on this exact 3,305-line core scope and 2,359-test tree both passed every test and measured 2,920/3,305 (88.351%), advancing the prior 2,919-line high-water by one covered line with no instrumentation spread. The reviewed observed high-water and exact observed floor are therefore both 2,920/3,305 with zero tolerance. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "Issue #670 adds the shared ambiguity-safe file-source detector used by poster badges and item details, including canonical source normalization, symmetric generic-versus-specific evidence merging, legacy BluRay suffix compatibility, and multi-version consensus handling. Two clean full client runs on this exact 3,329-line core scope and 2,399-test tree both passed every test and measured 2,944/3,329 (88.435%), advancing the prior 2,943-line high-water by one fully covered line and improving the reviewed ratio from 88.431% with no instrumentation spread. The reviewed observed high-water and exact observed floor are therefore both 2,944/3,329 with zero tolerance. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
       }
     },
     "server": {
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 45111,
-        "totalLines": 54905
+        "coveredLines": 45122,
+        "totalLines": 54910
       },
       "observations": {
         "cleanRuns": 5,
-        "minimumCoveredLines": 45101,
-        "maximumCoveredLines": 45111
+        "minimumCoveredLines": 45115,
+        "maximumCoveredLines": 45122
       },
       "tolerance": {
-        "missingCoveredLines": 10,
-        "rationale": "Issue #669 adds the versioned rating-tag scope policy, canonical admin and per-user persistence, malformed-payload rejection, public configuration projection, and focused server contract/snapshot coverage. Five clean full-suite runs on this exact 54,905-line source and 4,300-test scope passed every test: two local .NET 10.0.9 runs measured 45,102 and 45,101 covered lines, and three hosted GitHub Actions runs measured 45,106, 45,107, and 45,111. The reviewed high-water is therefore 45,111/54,905 (82.162%) and the exact observed floor is 45,101/54,905 (82.144%); the ten-line timing-dependent instrumentation spread is 0.018 percentage points, far inside the 0.15pp policy bound and improves the prior reviewed ratio. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 7,
+        "rationale": "Issue #670 adds the independently persisted ShowFileSource setting to the canonical admin and per-user configuration contracts and covers the fail-closed unknown-target and unsupported-evidence branches in the admin target settings controller. Three clean local .NET 10.0.10 full-suite runs on this exact 54,910-line source and 4,302-test scope passed every test and each measured 45,115/54,910 covered lines (82.162%). The first hosted Unit run at exact head bdf916990739dc39f273601544d7546e50614e68 also passed all 4,302 tests and measured 45,121/54,910 (82.173%): https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/31081606003/job/92551460291. The next hosted Unit run at exact amended head f0bd15ebdb818629302bb49b033167b2c53cf4db again passed all 4,302 tests and measured 45,122/54,910 (82.174%): https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/31098714654/job/92606837612. The reviewed high-water is therefore 45,122/54,910, while the directly observed identical-scope floor remains 45,115/54,910; the seven-line spread is 0.012748 percentage points, within the 0.15-point policy maximum. One separate non-clean 4,301/4,302 local run is excluded from the five-run coverage envelope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
## Description

Adds an independent, default-off file-source chip to Movie and Episode details for issue #670.

The details surface now reuses one import-pure detector shared with poster quality tags, so BluRay, DVD, and HDTV values remain canonical across both consumers. Unsupported, conflicting, and ambiguous evidence stays silent, including multi-version items unless every relevant version resolves to the same normalized source.

Refs #670

## User impact

- Users can enable a file-source chip on item details without enabling poster source tags.
- The chip uses the exact already-fetched, identity-fenced item and makes no additional request.
- Turning the setting off removes stale chips synchronously.
- Legacy poster behavior remains supported, including existing BluRay suffix forms.
- The setting defaults to off for existing installations and has independent administrator and per-user persistence.

## Implementation

- Extracts the shared detector into `src/core/file-source.ts`.
- Adds canonical generic/specific evidence merging and unanimity-only multi-version resolution.
- Adds the `ShowFileSource` descriptor, admin control, per-user editor control, snapshots, compatibility reads, and revision-safe persistence.
- Integrates the details chip with content-ready rendering, lifecycle cleanup, navigation/identity fences, and responsive native media-info layout.
- Advances the poster detector cache semantic version.
- Adds all 26 locale strings and user documentation.
- Adds a deterministic Jellyfin 12 `.disc` fixture and required Playwright coverage.

## Validation

- Client coverage: 260 files, 2,399/2,399 tests; exact ratchet 2,944/3,329 lines.
- Server coverage: five clean 4,302/4,302 runs on the identical 54,910-line scope (three local at 45,115, first hosted head at 45,121, second hosted head at 45,122); reviewed high-water 45,122/54,910, floor 45,115/54,910, seven-line / 0.012748pp tolerance.
- Coverage policy: 14/14 tests.
- Repository scripts: 655/655 tests.
- TypeScript: strict source and legacy typechecks pass.
- Translations: all 26 catalogs pass at 979/979 keys.
- Documentation: content, permissions, assets, strict pinned MkDocs build, and support contract pass.
- Performance-rules guard passes across 269 files.
- Bundle: two byte-identical 181-file builds, ID `391680cff143396577ae185cd8f44d26d11d8546e1baf527e436c1adf9c566a4`; exact totals 7,399,777 raw bytes / 7,487,782 published bytes; ESM boot 17 requests at 153.8 KB raw / 52.4 KB gzip; cold Home union 22 requests at 193.4 KB raw / 65.3 KB gzip.
- `git diff --check` passes.
- Independent whole-diff review: APPROVE with no blocking findings after both prior P2s were repaired; the owner-approved two-file hosted-coverage amendment received a separate read-only APPROVE with exact boundary verification.

## Jellyfin 12 / UI evidence

A fresh two-CPU Jellyfin 12.0.0 server pinned to digest `sha256:f961d7bd9f38457b2bce2aea3a22f120ab50b3885573b184abf46e892dd59119` passed:

- `details-file-source.spec.ts`
- `details-media-info-responsive.spec.ts`

Result: 2/2, with the exact BluRay `.disc` fixture, poster/details independence, persisted-setting restoration, no real console errors, and explicit native track-selector no-overlap geometry at 540, 568, 656, 700, and 710 px. The disposable containers and network were removed after evidence capture.

## Excluded/non-code signals

- One separate full server run passed 4,301/4,302 and is excluded from the clean coverage envelope. It emitted no retained test-result log; the next identical detailed run passed all 4,302 tests and measured the same exact coverage as the other two clean runs.
- The first combined docs command reached MkDocs only after all repository content/asset checks passed, then stopped because system Python lacked MkDocs. Re-running from the repository's hash-locked `requirements-docs.txt` environment passed the complete strict docs gate.
- ESLint findings are repository-policy advisory; invocation/configuration failures remain blocking. The earlier complete invocation succeeded with the existing advisory repository findings, while all blocking static, unit, guard, and runtime checks above pass.

## Compatibility and breaking changes

- Jellyfin 12 modern React/MUI remains the supported layout.
- Unsupported classic-layout selection remains inactive and usable.
- No API route is added and no extra details request is made.
- No breaking change; the new setting is independently default-off.
- Local browser proof used the repository's Chromium Playwright lane; hosted checks remain authoritative for the full required matrix.

## AI assistance

This PR was developed with Codex assistance. I reviewed and tested the changes, understand the implementation, and will respond to review feedback.