### PR TITLE
Apply pause-screen delay changes live and contain editor keys

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/config.ts
@@ -552,6 +552,10 @@ function reconcileAcknowledgedUserSettings(
     owner: SaveIntent['owner'],
 ): void {
     if (fileName !== 'settings.json') return;
+    if (JC.identity.isCurrent(owner)) {
+        const pauseDelay = Number(JC.currentSettings?.pauseScreenDelaySeconds ?? 5);
+        JC._pauseScreenInstance?.setDelaySeconds(Number.isFinite(pauseDelay) ? pauseDelay : 5);
+    }
     const runtime = JC.core.clientRuntime;
     if (!runtime) return;
     void runtime.reconcileUserSettings(owner).catch((error: unknown) => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.test.ts
@@ -76,6 +76,21 @@ describe('pause-screen singleton + teardown', () => {
         expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function), { capture: true });
     });
 
+    it('applies a live delay to the retained instance and clamps its public boundary', () => {
+        initPauseScreen();
+        const instance = jc()._pauseScreenInstance as {
+            pauseScreenDelayMs: number;
+            setDelaySeconds: (seconds: number) => void;
+        };
+
+        instance.setDelaySeconds(12.9);
+        expect(instance.pauseScreenDelayMs).toBe(12_000);
+        instance.setDelaySeconds(0);
+        expect(instance.pauseScreenDelayMs).toBe(1_000);
+        instance.setDelaySeconds(90);
+        expect(instance.pauseScreenDelayMs).toBe(60_000);
+    });
+
     it('releases a held stale overlay when prior teardown throws during re-init', () => {
         initPauseScreen();
         const stale = jc()._pauseScreenInstance as {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.test.ts
@@ -91,6 +91,60 @@ describe('pause-screen singleton + teardown', () => {
         expect(instance.pauseScreenDelayMs).toBe(60_000);
     });
 
+    it('shortens the current pause deadline from the original idle instant', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        try {
+            initPauseScreen();
+            const instance = jc()._pauseScreenInstance as {
+                currentVideo: { paused: boolean; ended: boolean };
+                lastUserInteractionAt: number;
+                setDelaySeconds: (seconds: number) => void;
+                showOverlay: () => void;
+            };
+            instance.currentVideo = { paused: true, ended: false };
+            instance.lastUserInteractionAt = 0;
+            const show = vi.spyOn(instance, 'showOverlay').mockImplementation(() => undefined);
+
+            instance.setDelaySeconds(10);
+            vi.advanceTimersByTime(4_000);
+            instance.setDelaySeconds(5);
+            vi.advanceTimersByTime(999);
+            expect(show).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(1);
+            expect(show).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('lengthens the current pause deadline without resetting its idle instant', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        try {
+            initPauseScreen();
+            const instance = jc()._pauseScreenInstance as {
+                currentVideo: { paused: boolean; ended: boolean };
+                lastUserInteractionAt: number;
+                setDelaySeconds: (seconds: number) => void;
+                showOverlay: () => void;
+            };
+            instance.currentVideo = { paused: true, ended: false };
+            instance.lastUserInteractionAt = 0;
+            const show = vi.spyOn(instance, 'showOverlay').mockImplementation(() => undefined);
+
+            instance.setDelaySeconds(5);
+            vi.advanceTimersByTime(2_000);
+            instance.setDelaySeconds(10);
+            vi.advanceTimersByTime(7_999);
+            expect(show).not.toHaveBeenCalled();
+            vi.advanceTimersByTime(1);
+            expect(show).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it('releases a held stale overlay when prior teardown throws during re-init', () => {
         initPauseScreen();
         const stale = jc()._pauseScreenInstance as {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/pausescreen.ts
@@ -569,6 +569,19 @@ function initializePauseScreen(): void {
         this.schedulePauseOverlayDelay();
       }
 
+      /**
+       * Applies a saved settings-panel delay without rebuilding the feature.
+       * The current pause keeps its original idle origin, so shortening the
+       * delay can show the overlay promptly while lengthening it pushes the
+       * existing deadline out.
+       */
+      setDelaySeconds(seconds: number) {
+        if (this.disposed || !Number.isFinite(seconds)) return;
+        const normalized = Math.max(1, Math.min(60, Math.trunc(seconds)));
+        this.pauseScreenDelayMs = normalized * 1000;
+        this.schedulePauseOverlayDelay();
+      }
+
       schedulePauseOverlayDelay() {
         if (this.pauseScreenTimer) {
           clearTimeout(this.pauseScreenTimer);
@@ -602,7 +615,11 @@ function initializePauseScreen(): void {
           this.pauseScreenTimer = window.setTimeout(tryShowWhenIdle, remainingDelay);
         };
 
-        this.pauseScreenTimer = window.setTimeout(tryShowWhenIdle, this.pauseScreenDelayMs);
+        const idleFor = Math.max(0, Date.now() - this.lastUserInteractionAt);
+        this.pauseScreenTimer = window.setTimeout(
+          tryShowWhenIdle,
+          Math.max(0, this.pauseScreenDelayMs - idleFor)
+        );
       }
 
       setupInteractionListeners() {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.pause-delay.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.pause-delay.test.ts
@@ -20,6 +20,24 @@ import '../config'; // registers the real JC.saveUserSettings
 const realSaveUserSettings = JC.saveUserSettings!;
 const realShowEnhancedPanel = JC.showEnhancedPanel;
 const realApplyHideFavoritesTab = JC.applyHideFavoritesTab;
+let sessionSequence = 0;
+
+function startSession() {
+    JC.identity.transition('', '', 'pause-delay-test-logout');
+    sessionSequence += 1;
+    return JC.identity.transition('pause-delay-server', `pause-delay-user-${sessionSequence}`, 'pause-delay-test-login')!;
+}
+
+function ownedSettings(value: Record<string, unknown>) {
+    const settings = JC.identity.own(value, JC.identity.capture());
+    JC.currentSettings = settings;
+    JC.rememberUserSettingsSnapshot!('settings.json', settings);
+    return settings;
+}
+
+function httpError(status: number) {
+    return Object.assign(new Error(`HTTP ${status}`), { status });
+}
 
 // Every element wireSettingsListeners() touches synchronously at wiring time is
 // an addSettingToggleListener target (`getElementById(id)!.addEventListener`),
@@ -62,6 +80,11 @@ function makeCtx(editor?: PanelEditorContext): PanelContext {
 describe('pause-screen delay persistence (ENH-1)', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
+        startSession();
+        vi.spyOn(ApiClient, 'getCurrentUserId').mockReturnValue(`pause-delay-user-${sessionSequence}`);
+        vi.spyOn(ApiClient as JellyfinApiClient & { serverId: () => string }, 'serverId')
+            .mockReturnValue('pause-delay-server');
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
         JC.currentSettings = {};
         JC._pauseScreenInstance = undefined;
     });
@@ -91,7 +114,7 @@ describe('pause-screen delay persistence (ENH-1)', () => {
         );
     });
 
-    it('applies the delay to the active viewer instance and contains host key shortcuts', async () => {
+    it('applies the delay to the active viewer instance and contains the full editor key matrix', async () => {
         const delayInput = buildSettingsDom();
         const applyDelay = vi.fn();
         JC._pauseScreenInstance = {
@@ -103,7 +126,15 @@ describe('pause-screen delay persistence (ENH-1)', () => {
         document.addEventListener('keydown', documentKeydown);
 
         wireSettingsListeners(makeCtx());
-        delayInput.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true }));
+        for (const init of [
+            { key: '7', code: 'Digit7' },
+            { key: '&', code: 'Digit7', shiftKey: true },
+            { key: '7', code: 'Digit7', ctrlKey: true },
+            { key: 'Enter', code: 'Enter' },
+            { key: 'ArrowUp', code: 'ArrowUp' },
+        ]) {
+            delayInput.dispatchEvent(new KeyboardEvent('keydown', { ...init, bubbles: true }));
+        }
         delayInput.value = '12';
         delayInput.dispatchEvent(new Event('change'));
 
@@ -114,51 +145,107 @@ describe('pause-screen delay persistence (ENH-1)', () => {
         document.removeEventListener('keydown', documentKeydown);
     });
 
-    it('restores the acknowledged runtime delay after the latest save fails', async () => {
+    it('restores the acknowledged runtime delay through the real failed-save queue', async () => {
         const delayInput = buildSettingsDom();
         const applyDelay = vi.fn();
         JC._pauseScreenInstance = {
             destroy: vi.fn(),
             setDelaySeconds: applyDelay,
         };
-        JC.currentSettings = { pauseScreenDelaySeconds: 5 };
-        JC.saveUserSettings = vi.fn(() => Promise.resolve().then(() => {
-            JC.currentSettings!.pauseScreenDelaySeconds = 5;
-            throw new Error('rejected');
+        const settings = ownedSettings({ Revision: 0, pauseScreenDelaySeconds: 5 });
+        JC.saveUserSettings = realSaveUserSettings;
+        vi.spyOn(ApiClient, 'ajax').mockRejectedValue(httpError(400));
+
+        wireSettingsListeners(makeCtx());
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+
+        await vi.waitFor(() => expect(settings.pauseScreenDelaySeconds).toBe(5));
+        await vi.waitFor(() => expect(applyDelay).toHaveBeenCalledTimes(2));
+        expect(applyDelay.mock.calls).toEqual([[12], [5]]);
+        expect(settings.pauseScreenDelaySeconds).toBe(5);
+    });
+
+    it('reconciles after the delay save and a later whole-object carrier both fail', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = {
+            destroy: vi.fn(),
+            setDelaySeconds: applyDelay,
+        };
+        const settings = ownedSettings({ Revision: 0, pauseScreenDelaySeconds: 5, autoPauseEnabled: false });
+        JC.saveUserSettings = realSaveUserSettings;
+        let rejectFirst!: (reason: unknown) => void;
+        const first = new Promise<never>((_resolve, reject) => { rejectFirst = reject; });
+        const ajax = vi.spyOn(ApiClient, 'ajax')
+            .mockReturnValueOnce(first)
+            .mockRejectedValueOnce(httpError(400));
+
+        wireSettingsListeners(makeCtx());
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(1));
+        const unrelatedToggle = document.getElementById('autoPauseToggle') as HTMLInputElement;
+        unrelatedToggle.checked = true;
+        unrelatedToggle.dispatchEvent(new Event('change'));
+        rejectFirst(httpError(400));
+
+        await vi.waitFor(() => expect(ajax).toHaveBeenCalledTimes(2));
+        await vi.waitFor(() => expect(applyDelay.mock.calls.at(-1)).toEqual([5]));
+        expect(settings.pauseScreenDelaySeconds).toBe(5);
+        expect(settings.autoPauseEnabled).toBe(false);
+    });
+
+    it('rolls back the runtime after the originating panel lease ends', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = { destroy: vi.fn(), setDelaySeconds: applyDelay };
+        const settings = ownedSettings({ Revision: 0, pauseScreenDelaySeconds: 5 });
+        JC.saveUserSettings = realSaveUserSettings;
+        let rejectSave!: (reason: unknown) => void;
+        vi.spyOn(ApiClient, 'ajax').mockReturnValue(new Promise<never>((_resolve, reject) => {
+            rejectSave = reject;
+        }));
+        const actor = JC.identity.capture()!;
+        let panelCurrent = true;
+        const editor = await createPanelEditorContext({
+            actor,
+            signal: new AbortController().signal,
+            isLaunchCurrent: () => panelCurrent,
+        });
+
+        wireSettingsListeners(makeCtx(editor));
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+        await vi.waitFor(() => expect(applyDelay).toHaveBeenCalledWith(12));
+        panelCurrent = false;
+        rejectSave(httpError(400));
+
+        await vi.waitFor(() => expect(applyDelay.mock.calls.at(-1)).toEqual([5]));
+        expect(settings.pauseScreenDelaySeconds).toBe(5);
+    });
+
+    it('never rolls an old actor delay into the next account runtime', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = { destroy: vi.fn(), setDelaySeconds: applyDelay };
+        ownedSettings({ Revision: 0, pauseScreenDelaySeconds: 5 });
+        JC.saveUserSettings = realSaveUserSettings;
+        let rejectSave!: (reason: unknown) => void;
+        vi.spyOn(ApiClient, 'ajax').mockReturnValue(new Promise<never>((_resolve, reject) => {
+            rejectSave = reject;
         }));
 
         wireSettingsListeners(makeCtx());
         delayInput.value = '12';
         delayInput.dispatchEvent(new Event('change'));
-
-        await vi.waitFor(() => expect(applyDelay).toHaveBeenCalledTimes(2));
-        expect(applyDelay.mock.calls).toEqual([[12], [5]]);
-    });
-
-    it('does not let a superseded failed save roll back the latest runtime intent', async () => {
-        const delayInput = buildSettingsDom();
-        const applyDelay = vi.fn();
-        JC._pauseScreenInstance = {
-            destroy: vi.fn(),
-            setDelaySeconds: applyDelay,
-        };
-        let rejectFirst!: (reason?: unknown) => void;
-        let resolveSecond!: (value: UserSettingsSaveResult) => void;
-        JC.saveUserSettings = vi.fn()
-            .mockReturnValueOnce(new Promise<UserSettingsSaveResult>((_resolve, reject) => { rejectFirst = reject; }))
-            .mockReturnValueOnce(new Promise<UserSettingsSaveResult>((resolve) => { resolveSecond = resolve; }));
-
-        wireSettingsListeners(makeCtx());
-        delayInput.value = '12';
-        delayInput.dispatchEvent(new Event('change'));
-        delayInput.value = '18';
-        delayInput.dispatchEvent(new Event('change'));
-        resolveSecond({} as UserSettingsSaveResult);
-        rejectFirst(new Error('superseded'));
-
-        await vi.waitFor(() => expect(JC.saveUserSettings).toHaveBeenCalledTimes(2));
+        await vi.waitFor(() => expect(applyDelay).toHaveBeenCalledTimes(1));
+        startSession();
+        rejectSave(httpError(400));
         await Promise.resolve();
-        expect(applyDelay.mock.calls).toEqual([[12], [18]]);
+        await Promise.resolve();
+
+        expect(applyDelay.mock.calls).toEqual([[12]]);
     });
 
     it('never applies target-user delay edits to the active viewer instance', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.pause-delay.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.pause-delay.test.ts
@@ -63,6 +63,7 @@ describe('pause-screen delay persistence (ENH-1)', () => {
     beforeEach(() => {
         document.body.innerHTML = '';
         JC.currentSettings = {};
+        JC._pauseScreenInstance = undefined;
     });
 
     afterEach(() => {
@@ -70,6 +71,7 @@ describe('pause-screen delay persistence (ENH-1)', () => {
         JC.saveUserSettings = realSaveUserSettings;
         JC.showEnhancedPanel = realShowEnhancedPanel;
         JC.applyHideFavoritesTab = realApplyHideFavoritesTab;
+        JC._pauseScreenInstance = undefined;
     });
 
     it('POSTs settings.json with the new delay when the delay input changes', () => {
@@ -87,6 +89,103 @@ describe('pause-screen delay persistence (ENH-1)', () => {
             'settings.json',
             expect.objectContaining({ pauseScreenDelaySeconds: 12 }),
         );
+    });
+
+    it('applies the delay to the active viewer instance and contains host key shortcuts', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = {
+            destroy: vi.fn(),
+            setDelaySeconds: applyDelay,
+        };
+        JC.saveUserSettings = vi.fn(() => Promise.resolve({} as UserSettingsSaveResult));
+        const documentKeydown = vi.fn();
+        document.addEventListener('keydown', documentKeydown);
+
+        wireSettingsListeners(makeCtx());
+        delayInput.dispatchEvent(new KeyboardEvent('keydown', { key: '7', bubbles: true }));
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+
+        await vi.waitFor(() => expect(JC.saveUserSettings).toHaveBeenCalledTimes(1));
+        expect(documentKeydown).not.toHaveBeenCalled();
+        expect(applyDelay).toHaveBeenCalledTimes(1);
+        expect(applyDelay).toHaveBeenCalledWith(12);
+        document.removeEventListener('keydown', documentKeydown);
+    });
+
+    it('restores the acknowledged runtime delay after the latest save fails', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = {
+            destroy: vi.fn(),
+            setDelaySeconds: applyDelay,
+        };
+        JC.currentSettings = { pauseScreenDelaySeconds: 5 };
+        JC.saveUserSettings = vi.fn(() => Promise.resolve().then(() => {
+            JC.currentSettings!.pauseScreenDelaySeconds = 5;
+            throw new Error('rejected');
+        }));
+
+        wireSettingsListeners(makeCtx());
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+
+        await vi.waitFor(() => expect(applyDelay).toHaveBeenCalledTimes(2));
+        expect(applyDelay.mock.calls).toEqual([[12], [5]]);
+    });
+
+    it('does not let a superseded failed save roll back the latest runtime intent', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = {
+            destroy: vi.fn(),
+            setDelaySeconds: applyDelay,
+        };
+        let rejectFirst!: (reason?: unknown) => void;
+        let resolveSecond!: (value: UserSettingsSaveResult) => void;
+        JC.saveUserSettings = vi.fn()
+            .mockReturnValueOnce(new Promise<UserSettingsSaveResult>((_resolve, reject) => { rejectFirst = reject; }))
+            .mockReturnValueOnce(new Promise<UserSettingsSaveResult>((resolve) => { resolveSecond = resolve; }));
+
+        wireSettingsListeners(makeCtx());
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+        delayInput.value = '18';
+        delayInput.dispatchEvent(new Event('change'));
+        resolveSecond({} as UserSettingsSaveResult);
+        rejectFirst(new Error('superseded'));
+
+        await vi.waitFor(() => expect(JC.saveUserSettings).toHaveBeenCalledTimes(2));
+        await Promise.resolve();
+        expect(applyDelay.mock.calls).toEqual([[12], [18]]);
+    });
+
+    it('never applies target-user delay edits to the active viewer instance', async () => {
+        const delayInput = buildSettingsDom();
+        const applyDelay = vi.fn();
+        JC._pauseScreenInstance = {
+            destroy: vi.fn(),
+            setDelaySeconds: applyDelay,
+        };
+        const actor = JC.identity.capture()!;
+        const saveTargetSettings = vi.fn(() => Promise.resolve({} as UserSettingsSaveResult));
+        const targetEditor = {
+            mode: 'admin-target', actor, targetUserId: 'target-user', targetDisplayName: 'Target',
+            appliesToActor: false,
+            settings: { pauseScreenDelaySeconds: 5 },
+            shortcuts: {}, activeShortcuts: {},
+            isCurrent: () => true,
+            saveSettings: saveTargetSettings,
+            saveShortcuts: vi.fn(() => Promise.resolve({} as UserSettingsSaveResult)),
+        } as PanelEditorContext;
+
+        wireSettingsListeners(makeCtx(targetEditor));
+        delayInput.value = '12';
+        delayInput.dispatchEvent(new Event('change'));
+
+        await vi.waitFor(() => expect(saveTargetSettings).toHaveBeenCalledTimes(1));
+        expect(applyDelay).not.toHaveBeenCalled();
     });
 
     it('coalesces failed-write reconciliation and rebuilds the open panel from rollback state', async () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
@@ -128,6 +128,7 @@ export function wireSettingsListeners(ctx: PanelContext): void {
     };
     let pendingAudioGeneration: AudioGeneration | null = null;
     let ratingScopeIntent = 0;
+    let pauseDelayIntent = 0;
     let acknowledgedRatingScopeGeneration = 0;
     let acknowledgedRatingScope: unknown = settings.ratingTagScopeOverrides;
     type RatingScopeGeneration = {
@@ -560,11 +561,28 @@ export function wireSettingsListeners(ctx: PanelContext): void {
 
     const pauseScreenDelayInput = document.getElementById('pauseScreenDelayInput') as HTMLInputElement | null;
     if (pauseScreenDelayInput) {
+        // Jellyfin owns document-level digit shortcuts too. Returning early in
+        // Canopy's dispatcher is insufficient: contain editing keys at the
+        // control so the host player cannot interpret them as percentage seeks.
+        pauseScreenDelayInput.addEventListener('keydown', (event) => event.stopPropagation());
         pauseScreenDelayInput.addEventListener('change', () => {
             const val = Math.max(1, Math.min(60, parseInt(pauseScreenDelayInput.value, 10) || 5));
             pauseScreenDelayInput.value = String(val);
             settings.pauseScreenDelaySeconds = val;
-            void persistSettings();
+            const intent = ++pauseDelayIntent;
+            const applyToActor = (seconds: number) => {
+                if (appliesToActor && editor.isCurrent() && JC.identity.isCurrent(editor.actor)) {
+                    JC._pauseScreenInstance?.setDelaySeconds(seconds);
+                }
+            };
+            applyToActor(val);
+            void persistSettings().then((saved) => {
+                if (saved || intent !== pauseDelayIntent || !editor.isCurrent()) return;
+                const acknowledged = appliesToActor && JC.identity.isCurrent(editor.actor)
+                    ? JC.currentSettings?.pauseScreenDelaySeconds
+                    : settings.pauseScreenDelaySeconds;
+                applyToActor(Number(acknowledged ?? 5));
+            });
         });
     }
     addSettingToggleListener('languageTagsToggle', 'languageTagsEnabled', 'feature_language_tags', true);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/settings-panel/settings.ts
@@ -128,7 +128,6 @@ export function wireSettingsListeners(ctx: PanelContext): void {
     };
     let pendingAudioGeneration: AudioGeneration | null = null;
     let ratingScopeIntent = 0;
-    let pauseDelayIntent = 0;
     let acknowledgedRatingScopeGeneration = 0;
     let acknowledgedRatingScope: unknown = settings.ratingTagScopeOverrides;
     type RatingScopeGeneration = {
@@ -569,20 +568,12 @@ export function wireSettingsListeners(ctx: PanelContext): void {
             const val = Math.max(1, Math.min(60, parseInt(pauseScreenDelayInput.value, 10) || 5));
             pauseScreenDelayInput.value = String(val);
             settings.pauseScreenDelaySeconds = val;
-            const intent = ++pauseDelayIntent;
-            const applyToActor = (seconds: number) => {
-                if (appliesToActor && editor.isCurrent() && JC.identity.isCurrent(editor.actor)) {
-                    JC._pauseScreenInstance?.setDelaySeconds(seconds);
-                }
-            };
-            applyToActor(val);
-            void persistSettings().then((saved) => {
-                if (saved || intent !== pauseDelayIntent || !editor.isCurrent()) return;
-                const acknowledged = appliesToActor && JC.identity.isCurrent(editor.actor)
-                    ? JC.currentSettings?.pauseScreenDelaySeconds
-                    : settings.pauseScreenDelaySeconds;
-                applyToActor(Number(acknowledged ?? 5));
-            });
+            if (appliesToActor && editor.isCurrent() && JC.identity.isCurrent(editor.actor)) {
+                JC._pauseScreenInstance?.setDelaySeconds(val);
+            }
+            // The central settings queue reconciles the live pause runtime
+            // after the final whole-object carrier is acknowledged or rolled back.
+            void persistSettings();
         });
     }
     addSettingToggleListener('languageTagsToggle', 'languageTagsEnabled', 'feature_language_tags', true);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -846,7 +846,11 @@ export interface JEGlobal extends JellyfinCanopyPublicApi {
      * down via destroy() before constructing a new one — instead of stacking a
      * duplicate overlay + capturing keydown listener each time.
      */
-    _pauseScreenInstance?: { destroy(): void };
+    _pauseScreenInstance?: {
+        destroy(): void;
+        /** Apply a validated per-user delay to the active playback lifecycle. */
+        setDelaySeconds(seconds: number): void;
+    };
     /**
      * PERF(R7): in-flight tag-cache GET started by js/plugin.js as soon as
      * public config lands (boot Stage 1), so the tag pipeline's init awaits an

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7399777,
+    "maxTotalRawBytes": 7402968,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7487782
+    "maxPublishedRawBytes": 7490973
   }
 }

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7402968,
+    "maxTotalRawBytes": 7402537,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7490973
+    "maxPublishedRawBytes": 7490542
   }
 }


### PR DESCRIPTION
## Summary

- apply pause-screen delay changes immediately to the active viewer while preserving the original paused-at deadline
- contain the complete number-input editing key matrix before Jellyfin player shortcuts can interpret it
- reconcile the active runtime from the final server-acknowledged settings after successful saves or safe rollbacks
- preserve admin-target and account-switch isolation, including failed saves after the panel lease ends
- add real save-queue, deadline, carrier-failure, teardown, and identity regression coverage
- set raw and published bundle ceilings to the exact measured artifacts

## Validation

- focused client tests: 4 files, 67 tests passed
- full client coverage: 260 files, 2,408 tests passed; reviewed line high-water unchanged at 2,944/3,329
- source and JavaScript typechecks passed
- syntax and performance architecture guards passed
- deterministic bundle build repeated byte-identically
- exact bundle totals: 7,402,537 raw; 7,490,542 published
- independent review: approved after requested rollback and lifecycle fixes

Closes #708