### PR TITLE
Color common bare certification labels consistently

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/ratings-css.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/ratings-css.test.ts
@@ -28,6 +28,19 @@ function stripComments(css: string): string {
     return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
+function ratingBackgrounds(css: string): Map<string, string> {
+    const backgrounds = new Map<string, string>();
+    const live = stripComments(css);
+    const rulePattern = /((?:\.mediaInfoOfficialRating\[rating='[^']+'\]\s*,?\s*)+)\{[^}]*background-color:\s*(#[0-9a-fA-F]{3,8})/g;
+
+    for (const rule of live.matchAll(rulePattern)) {
+        for (const selector of rule[1].matchAll(/rating='([^']+)'/g)) {
+            backgrounds.set(selector[1], rule[2].toUpperCase());
+        }
+    }
+    return backgrounds;
+}
+
 describe('ratings.css lint guards', () => {
     it('loaded the stylesheet', () => {
         expect(CSS.length).toBeGreaterThan(0);
@@ -75,5 +88,27 @@ describe('ratings.css lint guards', () => {
         expect(values.length).toBeGreaterThan(0);
         const named = values.filter((v) => !/^#[0-9a-fA-F]{3,8}$/.test(v));
         expect(named, `non-hex background-color value(s): ${named.join(', ')}`).toEqual([]);
+    });
+
+    it('classifies supported bare certification labels in their existing tiers', () => {
+        const backgrounds = ratingBackgrounds(CSS);
+        const equivalents: Array<[string, string]> = [
+            ['L', 'BR-L'],
+            ['12+', 'AT-12+'],
+            ['14', 'BR-14'],
+            ['U/A 13+', 'IN-U/A 13+'],
+            ['NC16', 'SG-NC16'],
+        ];
+
+        for (const [bare, prefixed] of equivalents) {
+            expect(backgrounds.get(bare), `${bare} is not classified`).toBe(backgrounds.get(prefixed));
+        }
+    });
+
+    it('does not broaden bare-label matching to similar unknown values', () => {
+        const backgrounds = ratingBackgrounds(CSS);
+        for (const unknown of ['L+', '12++', '14 YEARS', 'U/A 13', 'NC-16']) {
+            expect(backgrounds.has(unknown), `${unknown} was unexpectedly classified`).toBe(false);
+        }
     });
 });

--- a/css/ratings.css
+++ b/css/ratings.css
@@ -91,6 +91,7 @@
 .mediaInfoOfficialRating[rating='BE-TOUS'],                /* 🇧🇪 Belgium — Tous publics (Kijkwijzer, French) */
 .mediaInfoOfficialRating[rating='BE-KT'],                  /* 🇧🇪 Belgium — Kinderen Toegelaten (legacy, pre-2020) */
 .mediaInfoOfficialRating[rating='BR-L'],                   /* 🇧🇷 Brazil — Livre */
+.mediaInfoOfficialRating[rating='L'],                      /* 🇧🇷 Brazil — Livre (bare label) */
 .mediaInfoOfficialRating[rating='CA-G'],                   /* 🇨🇦 Canada — General (all provinces + Quebec) */
 .mediaInfoOfficialRating[rating='CA-E'],                   /* 🇨🇦 Canada — Exempt */
 .mediaInfoOfficialRating[rating='C8'],                     /* 🇨🇦 Canada — C8 (legacy bare label) */
@@ -172,6 +173,7 @@
 .mediaInfoOfficialRating[rating='AT-8'],                   /* 🇦🇹 Austria — ab 8 Jahren */
 .mediaInfoOfficialRating[rating='AT-8+'],                  /* 🇦🇹 Austria — 8+ */
 .mediaInfoOfficialRating[rating='AT-12+'],                 /* 🇦🇹 Austria — 12+ */
+.mediaInfoOfficialRating[rating='12+'],                    /* 🌍 Generic 12+ (bare label) */
 .mediaInfoOfficialRating[rating='BE-6'],                   /* 🇧🇪 Belgium — 6 (Kijkwijzer) */
 .mediaInfoOfficialRating[rating='BE-9'],                   /* 🇧🇪 Belgium — 9 (Kijkwijzer) */
 .mediaInfoOfficialRating[rating='BR-6'],                   /* 🇧🇷 Brazil — 6 anos (introduced 2025) */
@@ -254,6 +256,7 @@
 .mediaInfoOfficialRating[rating='M'],                      /* 🇦🇺 Australia / 🇺🇸 US (Legacy) */
 .mediaInfoOfficialRating[rating='AT-10'],                  /* 🇦🇹 Austria */
 .mediaInfoOfficialRating[rating='BR-14'],                  /* 🇧� Brazil */
+.mediaInfoOfficialRating[rating='14'],                     /* 🌍 Generic 14 (bare label) */
 .mediaInfoOfficialRating[rating='BE-14'],                  /* 🇧� Belgium — 14 (Kijkwijzer) */
 .mediaInfoOfficialRating[rating='14+'],                    /* 🇨🇦 Canada */
 .mediaInfoOfficialRating[rating='CA-14+'],                 /* 🇨🇦 Canada */
@@ -275,6 +278,7 @@
 .mediaInfoOfficialRating[rating='IN-UA-13'],               /* 🇮🇳 India — UA 13+ */
 .mediaInfoOfficialRating[rating='IN-U/A 13+'],             /* 🇮🇳 India — U/A 13+ (CBFC format) */
 .mediaInfoOfficialRating[rating='IN-UA 13+'],              /* 🇮🇳 India — UA 13+ (alternate spacing) */
+.mediaInfoOfficialRating[rating='U/A 13+'],                /* 🇮🇳 India — U/A 13+ (bare CBFC format) */
 .mediaInfoOfficialRating[rating='ID-13+'],                 /* 🇮🇩 Indonesia */
 .mediaInfoOfficialRating[rating='IE-15A'],                 /* 🇮🇪 Ireland */
 .mediaInfoOfficialRating[rating='IE-15'],                  /* 🇮🇪 Ireland */
@@ -351,6 +355,7 @@
 .mediaInfoOfficialRating[rating='PT-M/16'],                /* 🇵🇹 Portugal */
 .mediaInfoOfficialRating[rating='RU-16+'],                 /* 🇷🇺 Russia */
 .mediaInfoOfficialRating[rating='SG-NC16'],                /* 🇸🇬 Singapore */
+.mediaInfoOfficialRating[rating='NC16'],                   /* 🇸🇬 Singapore — NC16 (bare label) */
 .mediaInfoOfficialRating[rating='ZA-13'],                  /* 🇿🇦 South Africa */
 .mediaInfoOfficialRating[rating='ES-16'],                  /* 🇪🇸 Spain */
 .mediaInfoOfficialRating[rating='SE-15'],                  /* 🇸🇪 Sweden */

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -61,7 +61,7 @@ Gives each activity type on the Dashboard a distinct Material Design icon in its
 
 ### Colored Ratings Backgrounds
 
-Adds value-based colored backgrounds to the rating chips on detail pages, with different colors per rating type. It supports TMDB, IMDb, and Rotten Tomatoes scores, so a strong rating reads differently from a weak one at a glance.
+Adds value-based colored backgrounds to the rating chips on detail pages, with different colors per rating type. It supports TMDB, IMDb, and Rotten Tomatoes scores, so a strong rating reads differently from a weak one at a glance. Jellyfin's text certification badge is also grouped by age tier, including exact bare labels such as `L`, `12+`, `14`, `U/A 13+`, and `NC16` when metadata providers omit a region prefix.
 
 ![Colored Ratings](images/ratings.png)
 


### PR DESCRIPTION
Closes #721

## Summary
- classify the exact bare certification labels `L`, `12+`, `14`, `U/A 13+`, and `NC16` in their existing age tiers
- preserve current labels, regional selectors, and FSK-specific overrides
- document the supported provider-label behavior and add exact-selector/near-neighbor regression coverage

## Validation
- independent review: approved
- focused rating stylesheet tests: 7/7 passed
- source typecheck, syntax, performance rules, strict docs, and diff checks passed
- client bundle is byte-identical to `main` (7,402,537 raw / 7,490,542 published)
- representative light/dark computed-style and contrast probes passed