### PR TITLE
fix: resolve effective streaming regions

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/StreamingRegionConfigurationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/StreamingRegionConfigurationTests.cs
@@ -1,0 +1,26 @@
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Configuration;
+
+public sealed class StreamingRegionConfigurationTests
+{
+    [Theory]
+    [InlineData(" us ", "US")]
+    [InlineData("xk", "XK")]
+    [InlineData("", "US")]
+    [InlineData("  ", "US")]
+    [InlineData("USA", "US")]
+    [InlineData("1A", "US")]
+    [InlineData(null, "US")]
+    public void UpdateNormalization_IsDeterministicAndPreservesValidUncommonSyntax(
+        string? persisted,
+        string expected)
+    {
+        var config = new PluginConfiguration { DEFAULT_REGION = persisted! };
+
+        JellyfinCanopy.NormalizeDefaultStreamingRegionForUpdate(config);
+
+        Assert.Equal(expected, config.DEFAULT_REGION);
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/StreamingRegionConfigurationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Configuration/StreamingRegionConfigurationTests.cs
@@ -12,6 +12,7 @@ public sealed class StreamingRegionConfigurationTests
     [InlineData("  ", "US")]
     [InlineData("USA", "US")]
     [InlineData("1A", "US")]
+    [InlineData("ZZ", "US")]
     [InlineData(null, "US")]
     public void UpdateNormalization_IsDeterministicAndPreservesValidUncommonSyntax(
         string? persisted,
@@ -22,5 +23,25 @@ public sealed class StreamingRegionConfigurationTests
         JellyfinCanopy.NormalizeDefaultStreamingRegionForUpdate(config);
 
         Assert.Equal(expected, config.DEFAULT_REGION);
+    }
+
+    [Fact]
+    public void SupportedCatalog_IsExactAndPreservesUncommonCodes()
+    {
+        Assert.Equal(139, StreamingRegionNormalizer.SupportedCount);
+        Assert.True(StreamingRegionNormalizer.IsSupported("xk"));
+        Assert.Equal("XK", StreamingRegionNormalizer.Normalize(" xk "));
+        Assert.False(StreamingRegionNormalizer.IsSupported("ZZ"));
+    }
+
+    [Fact]
+    public void UserOverrides_InheritForUnknownAndFilterManualRegions()
+    {
+        Assert.Equal(string.Empty, StreamingRegionNormalizer.NormalizeOverride("ZZ"));
+        Assert.Equal(string.Empty, StreamingRegionNormalizer.NormalizeOverride("malformed"));
+        Assert.Equal("XK", StreamingRegionNormalizer.NormalizeOverride(" xk "));
+        Assert.Equal(
+            new[] { "CA", "XK" },
+            StreamingRegionNormalizer.NormalizeOverrides(new[] { "ca", "ZZ", "XK", "CA", "bad" }));
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/Seerr/SeerrParentalFilterTests.cs
@@ -151,6 +151,38 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services.Seerr
                 provider);
         }
 
+        private static (SeerrParentalFilter Filter, RecordingHttpMessageHandler Handler, SeerrCache Cache)
+            BuildRegionalFilter(string persistedRegion, string detail)
+        {
+            var handler = new RecordingHttpMessageHandler();
+            handler.AddResponse("/movie/900", detail);
+            var provider = new FakePluginConfigProvider(new PluginConfiguration
+            {
+                SeerrEnabled = true,
+                SeerrRespectParentalRatings = true,
+                SeerrUrls = "http://seerr:5055",
+                SeerrApiKey = "key",
+                DEFAULT_REGION = persistedRegion,
+            });
+            var user = new User("regional-kid", "Prov", "PwProv")
+            {
+                MaxParentalRatingScore = 13,
+                MaxParentalRatingSubScore = 0,
+            };
+            var cache = new SeerrCache(provider);
+            var filter = new SeerrParentalFilter(
+                new RecordingHttpClientFactory(handler),
+                NullLogger<SeerrParentalFilter>.Instance,
+                new StubPolicyUserManager(
+                    Guid.Parse(CallerGuid),
+                    user,
+                    new UserPolicy { BlockUnratedItems = Array.Empty<UnratedItem>() }),
+                new FakeLocalization(),
+                cache,
+                provider);
+            return (filter, handler, cache);
+        }
+
         private static Task<SeerrParentalResult> ApplyAsync(
             string body,
             string apiPath,
@@ -412,6 +444,43 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services.Seerr
             Assert.False(await filter.IsBlockedAsync("movie", 100, restricted));  // PG-13 -> allowed
             Assert.True(await filter.IsBlockedAsync("movie", 999, restricted));   // unverifiable -> fail closed
             Assert.True(await filter.IsBlockedAsync("movie", 0, restricted));     // unparseable id -> fail closed
+        }
+
+        [Fact]
+        public async Task UnsupportedPersistedRegion_UsesUsCertificationAndUsCachePartition()
+        {
+            const string detail = @"{ ""releases"": { ""results"": [
+                { ""iso_3166_1"": ""ZZ"", ""release_dates"": [ { ""type"": 3, ""certification"": ""G"" } ] },
+                { ""iso_3166_1"": ""US"", ""release_dates"": [ { ""type"": 3, ""certification"": ""R"" } ] }
+            ] } }";
+            var (filter, handler, cache) = BuildRegionalFilter("ZZ", detail);
+            var caller = new SeerrCaller(CallerGuid, false);
+
+            Assert.True(await filter.IsBlockedAsync("movie", 900, caller));
+            Assert.True(await filter.IsBlockedAsync("movie", 900, caller));
+
+            Assert.Single(handler.Requests);
+            var cacheKey = Assert.Single(cache.CertScoreCache.Keys);
+            Assert.StartsWith("movie:900:US|cfg:", cacheKey, StringComparison.Ordinal);
+            Assert.DoesNotContain(":ZZ|", cacheKey, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task SupportedUncommonRegion_UsesItsCertificationAndCachePartition()
+        {
+            const string detail = @"{ ""releases"": { ""results"": [
+                { ""iso_3166_1"": ""US"", ""release_dates"": [ { ""type"": 3, ""certification"": ""R"" } ] },
+                { ""iso_3166_1"": ""XK"", ""release_dates"": [ { ""type"": 3, ""certification"": ""G"" } ] }
+            ] } }";
+            var (filter, handler, cache) = BuildRegionalFilter(" xk ", detail);
+            var caller = new SeerrCaller(CallerGuid, false);
+
+            Assert.False(await filter.IsBlockedAsync("movie", 900, caller));
+            Assert.False(await filter.IsBlockedAsync("movie", 900, caller));
+
+            Assert.Single(handler.Requests);
+            var cacheKey = Assert.Single(cache.CertScoreCache.Keys);
+            Assert.StartsWith("movie:900:XK|cfg:", cacheKey, StringComparison.Ordinal);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/StreamingRegionNormalizer.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/StreamingRegionNormalizer.cs
@@ -1,24 +1,70 @@
+using System.Collections.Frozen;
+
 namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
 {
-    /// <summary>Normalizes the syntax of TMDB/Seerr two-letter region keys.</summary>
+    /// <summary>Normalizes TMDB/Seerr region keys against the mirrored supported catalog.</summary>
     internal static class StreamingRegionNormalizer
     {
         internal const string Fallback = "US";
 
+        // Release snapshot of Jellyfin-Elsewhere resources/regions.txt. Runtime
+        // config updates cannot depend on the network-backed asset cache, so this
+        // is the synchronous membership authority shared with effective-region.ts
+        // and the admin page. The mirror remains the display-name source.
+        private const string SupportedCodeList =
+            "AD AE AG AL AO AR AT AU AZ BA BB BE BF BG BH BM BO BR BS BY BZ CA CD CH CI CL CM CO CR CU CV CY CZ DE DK DO DZ EC EE EG ES FI FJ FR GB GF GH GI GP GQ GR GT GY HK HN HR HU ID IE IL IN IQ IS IT JM JO JP KE KR KW LB LC LI LT LU LV LY MA MC MD ME MG MK ML MT MU MW MX MY MZ NE NG NI NL NO NZ OM PA PE PF PG PH PK PL PS PT PY QA RO RS RU SA SC SE SG SI SK SM SN SV TC TD TH TN TR TT TW TZ UA UG US UY VA VE XK YE ZA ZM ZW";
+
+        private static readonly FrozenSet<string> SupportedCodes = SupportedCodeList
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .ToFrozenSet(StringComparer.Ordinal);
+
+        internal static int SupportedCount => SupportedCodes.Count;
+
+        internal static bool IsSupported(string? value)
+        {
+            var normalized = NormalizeSyntax(value);
+            return normalized != null && SupportedCodes.Contains(normalized);
+        }
+
         /// <summary>
-        /// Returns an uppercase two-letter code, or US for empty/malformed state.
-        /// Catalog membership is intentionally enforced by the catalog-backed admin
-        /// selector: preserving an uncommon syntactically valid code here prevents a
-        /// transient mirror failure from destroying persisted configuration.
+        /// Returns an uppercase supported code, or US for empty, malformed, or
+        /// unsupported state. The built-in membership snapshot preserves uncommon
+        /// supported codes without depending on a catalog refresh.
         /// </summary>
         internal static string Normalize(string? value)
+            => NormalizeSupported(value) ?? Fallback;
+
+        /// <summary>
+        /// Returns an uppercase supported override, or empty to inherit the current
+        /// administrator default for empty, malformed, or unsupported state.
+        /// </summary>
+        internal static string NormalizeOverride(string? value)
+            => NormalizeSupported(value) ?? string.Empty;
+
+        /// <summary>Normalizes, filters, and de-duplicates manual-search regions.</summary>
+        internal static List<string> NormalizeOverrides(IEnumerable<string>? values)
+            => (values ?? Array.Empty<string>())
+                .Select(NormalizeOverride)
+                .Where(region => region.Length != 0)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+        private static string? NormalizeSupported(string? value)
+        {
+            var normalized = NormalizeSyntax(value);
+            return normalized != null && SupportedCodes.Contains(normalized)
+                ? normalized
+                : null;
+        }
+
+        private static string? NormalizeSyntax(string? value)
         {
             var normalized = value?.Trim().ToUpperInvariant();
             return normalized?.Length == 2
                 && normalized[0] is >= 'A' and <= 'Z'
                 && normalized[1] is >= 'A' and <= 'Z'
                     ? normalized
-                    : Fallback;
+                    : null;
         }
     }
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/StreamingRegionNormalizer.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/StreamingRegionNormalizer.cs
@@ -1,0 +1,24 @@
+namespace Jellyfin.Plugin.JellyfinCanopy.Configuration
+{
+    /// <summary>Normalizes the syntax of TMDB/Seerr two-letter region keys.</summary>
+    internal static class StreamingRegionNormalizer
+    {
+        internal const string Fallback = "US";
+
+        /// <summary>
+        /// Returns an uppercase two-letter code, or US for empty/malformed state.
+        /// Catalog membership is intentionally enforced by the catalog-backed admin
+        /// selector: preserving an uncommon syntactically valid code here prevents a
+        /// transient mirror failure from destroying persisted configuration.
+        /// </summary>
+        internal static string Normalize(string? value)
+        {
+            var normalized = value?.Trim().ToUpperInvariant();
+            return normalized?.Length == 2
+                && normalized[0] is >= 'A' and <= 'Z'
+                && normalized[1] is >= 'A' and <= 'Z'
+                    ? normalized
+                    : Fallback;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
@@ -2578,6 +2578,7 @@
         // enums, validated text, list builders, arr instances) stays hand-written in
         // loadConfig/buildConfigFromForm.
         var JC_DEFAULT_STREAMING_REGION = 'US';
+        var JC_SUPPORTED_STREAMING_REGIONS = new Set('AD AE AG AL AO AR AT AU AZ BA BB BE BF BG BH BM BO BR BS BY BZ CA CD CH CI CL CM CO CR CU CV CY CZ DE DK DO DZ EC EE EG ES FI FJ FR GB GF GH GI GP GQ GR GT GY HK HN HR HU ID IE IL IN IQ IS IT JM JO JP KE KR KW LB LC LI LT LU LV LY MA MC MD ME MG MK ML MT MU MW MX MY MZ NE NG NI NL NO NZ OM PA PE PF PG PH PK PL PS PT PY QA RO RS RU SA SC SE SG SI SK SM SN SV TC TD TH TN TR TT TW TZ UA UG US UY VA VE XK YE ZA ZM ZW'.split(' '));
         var JC_REGION_CATALOG_CDN_URL = 'https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt';
         var _jcRegionCatalogLoadToken = 0;
 
@@ -2585,6 +2586,11 @@
             if (typeof value !== 'string') return null;
             var normalized = value.trim().toUpperCase();
             return /^[A-Z]{2}$/.test(normalized) ? normalized : null;
+        }
+
+        function jcNormalizeSupportedStreamingRegion(value) {
+            var normalized = jcNormalizeStreamingRegion(value);
+            return normalized && JC_SUPPORTED_STREAMING_REGIONS.has(normalized) ? normalized : null;
         }
 
         function jcParseStreamingRegionCatalog(text) {
@@ -2596,7 +2602,7 @@
                 if (!trimmed || trimmed.startsWith('#')) return;
                 var separator = line.indexOf('\t');
                 if (separator < 0) return;
-                var code = jcNormalizeStreamingRegion(line.slice(0, separator));
+                var code = jcNormalizeSupportedStreamingRegion(line.slice(0, separator));
                 var name = line.slice(separator + 1).trim();
                 if (!code || !name || seen.has(code)) return;
                 seen.add(code);
@@ -2606,7 +2612,7 @@
         }
 
         function jcResolveCatalogStreamingRegion(value, entries, catalogLoaded) {
-            var normalized = jcNormalizeStreamingRegion(value) || JC_DEFAULT_STREAMING_REGION;
+            var normalized = jcNormalizeSupportedStreamingRegion(value) || JC_DEFAULT_STREAMING_REGION;
             if (!catalogLoaded) return normalized;
             return entries.some(function (entry) { return entry.code === normalized; })
                 ? normalized
@@ -2637,7 +2643,7 @@
             var select = document.getElementById('DEFAULT_REGION');
             if (!select) return;
             var token = ++_jcRegionCatalogLoadToken;
-            var persisted = jcNormalizeStreamingRegion(config.DEFAULT_REGION) || JC_DEFAULT_STREAMING_REGION;
+            var persisted = jcNormalizeSupportedStreamingRegion(config.DEFAULT_REGION) || JC_DEFAULT_STREAMING_REGION;
             var url = config.AssetCacheEnabled === false
                 ? JC_REGION_CATALOG_CDN_URL
                 : ApiClient.getUrl('/JellyfinCanopy/assets/elsewhere/regions.txt');
@@ -2652,8 +2658,9 @@
                 jcSetDefaultRegionOptions(select, entries, persisted, true);
             } catch (error) {
                 if (token !== _jcRegionCatalogLoadToken || !select.isConnected) return;
-                // Keep the normalized saved code selectable. A mirror refresh or
-                // direct-CDN outage must not silently rewrite an uncommon region.
+                // Keep a supported normalized saved code selectable. A mirror
+                // refresh or direct-CDN outage must not silently rewrite an
+                // uncommon region, while unknown legacy values still fall to US.
                 jcSetDefaultRegionOptions(select, [], persisted, false);
                 console.warn('Jellyfin Canopy: region catalog unavailable; preserving the saved region.', error);
             } finally {
@@ -2667,7 +2674,7 @@
                     jcSetDefaultRegionOptions(el, [], value, false);
                 },
                 save: function (el) {
-                    return jcNormalizeStreamingRegion(el.value) || JC_DEFAULT_STREAMING_REGION;
+                    return jcNormalizeSupportedStreamingRegion(el.value) || JC_DEFAULT_STREAMING_REGION;
                 }
             },
             // isNaN/min-max clamps preserved verbatim from the old per-field save sites.

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
@@ -2577,7 +2577,99 @@
         // semantics via CONFIG_FIELD_OVERRIDES below. Anything more complex (multi-element
         // enums, validated text, list builders, arr instances) stays hand-written in
         // loadConfig/buildConfigFromForm.
+        var JC_DEFAULT_STREAMING_REGION = 'US';
+        var JC_REGION_CATALOG_CDN_URL = 'https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt';
+        var _jcRegionCatalogLoadToken = 0;
+
+        function jcNormalizeStreamingRegion(value) {
+            if (typeof value !== 'string') return null;
+            var normalized = value.trim().toUpperCase();
+            return /^[A-Z]{2}$/.test(normalized) ? normalized : null;
+        }
+
+        function jcParseStreamingRegionCatalog(text) {
+            if (typeof text !== 'string') return [];
+            var seen = new Set();
+            var entries = [];
+            text.split(/\r?\n/).forEach(function (line) {
+                var trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith('#')) return;
+                var separator = line.indexOf('\t');
+                if (separator < 0) return;
+                var code = jcNormalizeStreamingRegion(line.slice(0, separator));
+                var name = line.slice(separator + 1).trim();
+                if (!code || !name || seen.has(code)) return;
+                seen.add(code);
+                entries.push({ code: code, name: name });
+            });
+            return entries;
+        }
+
+        function jcResolveCatalogStreamingRegion(value, entries, catalogLoaded) {
+            var normalized = jcNormalizeStreamingRegion(value) || JC_DEFAULT_STREAMING_REGION;
+            if (!catalogLoaded) return normalized;
+            return entries.some(function (entry) { return entry.code === normalized; })
+                ? normalized
+                : JC_DEFAULT_STREAMING_REGION;
+        }
+
+        function jcSetDefaultRegionOptions(select, entries, selected, catalogLoaded) {
+            var resolved = jcResolveCatalogStreamingRegion(selected, entries, catalogLoaded);
+            var effectiveEntries = entries.slice();
+            if (!effectiveEntries.some(function (entry) { return entry.code === JC_DEFAULT_STREAMING_REGION; })) {
+                effectiveEntries.unshift({ code: JC_DEFAULT_STREAMING_REGION, name: 'United States of America' });
+            }
+            if (!catalogLoaded && !effectiveEntries.some(function (entry) { return entry.code === resolved; })) {
+                effectiveEntries.push({ code: resolved, name: 'Saved region' });
+            }
+            select.replaceChildren();
+            effectiveEntries.forEach(function (entry) {
+                var option = document.createElement('option');
+                option.value = entry.code;
+                option.textContent = entry.name + ' (' + entry.code + ')';
+                select.appendChild(option);
+            });
+            select.value = resolved;
+            return resolved;
+        }
+
+        async function jcLoadDefaultRegionCatalog(config) {
+            var select = document.getElementById('DEFAULT_REGION');
+            if (!select) return;
+            var token = ++_jcRegionCatalogLoadToken;
+            var persisted = jcNormalizeStreamingRegion(config.DEFAULT_REGION) || JC_DEFAULT_STREAMING_REGION;
+            var url = config.AssetCacheEnabled === false
+                ? JC_REGION_CATALOG_CDN_URL
+                : ApiClient.getUrl('/JellyfinCanopy/assets/elsewhere/regions.txt');
+            var controller = new AbortController();
+            var timeout = setTimeout(function () { controller.abort(); }, 5000);
+            try {
+                var response = await fetch(url, { signal: controller.signal, credentials: 'same-origin' });
+                if (!response.ok) throw new Error('Region catalog HTTP ' + response.status);
+                var entries = jcParseStreamingRegionCatalog(await response.text());
+                if (entries.length === 0) throw new Error('Region catalog is empty');
+                if (token !== _jcRegionCatalogLoadToken || !select.isConnected) return;
+                jcSetDefaultRegionOptions(select, entries, persisted, true);
+            } catch (error) {
+                if (token !== _jcRegionCatalogLoadToken || !select.isConnected) return;
+                // Keep the normalized saved code selectable. A mirror refresh or
+                // direct-CDN outage must not silently rewrite an uncommon region.
+                jcSetDefaultRegionOptions(select, [], persisted, false);
+                console.warn('Jellyfin Canopy: region catalog unavailable; preserving the saved region.', error);
+            } finally {
+                clearTimeout(timeout);
+            }
+        }
+
         const CONFIG_FIELD_OVERRIDES = {
+            DEFAULT_REGION: {
+                load: function (el, value) {
+                    jcSetDefaultRegionOptions(el, [], value, false);
+                },
+                save: function (el) {
+                    return jcNormalizeStreamingRegion(el.value) || JC_DEFAULT_STREAMING_REGION;
+                }
+            },
             // isNaN/min-max clamps preserved verbatim from the old per-field save sites.
             AutoMovieRequestMinutesWatched: {
                 save: function (el) {
@@ -2782,6 +2874,7 @@
                 // [data-config-key] element (see applyConfigToBoundFields above).
                 // Complex editors and multi-element settings stay hand-written below.
                 applyConfigToBoundFields(config);
+                void jcLoadDefaultRegionCatalog(config);
 
                 // Restore action checkboxes
                 let savedAction;

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -2042,10 +2042,12 @@
 
                                 <div class="inputContainer">
                                     <label class="inputLabel" for="DEFAULT_REGION">Default Region</label>
-                                    <input id="DEFAULT_REGION" data-config-key="DEFAULT_REGION" is="emby-input" type="text" placeholder="e.g., US"/>
+                                    <select id="DEFAULT_REGION" data-config-key="DEFAULT_REGION" is="emby-select" class="emby-select" aria-describedby="defaultRegionDescription">
+                                        <option value="US">United States of America (US)</option>
+                                    </select>
                                 </div>
                                     <div class="jc-setting-description" data-desc-for="DEFAULT_REGION">
-                                        <div class="fieldDescription">The default two-letter country code for streaming provider lookup. Empty defaults to US. <a class="sectionTitle" href="https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt" target="_blank">Full List</a><br/>Also used by <strong>TMDB Release Dates</strong> and the <strong>Seerr streaming icons</strong>, so it stays editable even when the Elsewhere panel is off.</div>
+                                        <div id="defaultRegionDescription" class="fieldDescription">The default country for streaming provider lookup. The list comes from Canopy's mirrored region catalog; if it cannot be refreshed, the current valid saved code remains selectable. Also used by <strong>TMDB Release Dates</strong> and the <strong>Seerr streaming icons</strong>, so it stays editable even when the Elsewhere panel is off.</div>
                                     </div>
                                 <div class="inputContainer">
                                     <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -2047,7 +2047,7 @@
                                     </select>
                                 </div>
                                     <div class="jc-setting-description" data-desc-for="DEFAULT_REGION">
-                                        <div id="defaultRegionDescription" class="fieldDescription">The default country for streaming provider lookup. The list comes from Canopy's mirrored region catalog; if it cannot be refreshed, the current valid saved code remains selectable. Also used by <strong>TMDB Release Dates</strong> and the <strong>Seerr streaming icons</strong>, so it stays editable even when the Elsewhere panel is off.</div>
+                                        <div id="defaultRegionDescription" class="fieldDescription">The default country for streaming provider lookup. The list comes from Canopy's mirrored region catalog; if it cannot be refreshed, the current supported saved code remains selectable. Unknown legacy values fall back to US. Also used by <strong>TMDB Release Dates</strong> and the <strong>Seerr streaming icons</strong>, so it stays editable even when the Elsewhere panel is off.</div>
                                     </div>
                                 <div class="inputContainer">
                                     <label class="inputLabel" for="DEFAULT_PROVIDERS">Default Providers</label>

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -910,6 +910,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                     settings.RatingTagScopeOverrides = normalizedRatingScope;
                 }
             }
+            else if (state is ElsewhereSettings elsewhere)
+            {
+                // User overrides share the same synchronous supported-region
+                // boundary as the admin configuration and every client consumer.
+                // Empty/invalid means "inherit admin"; additional manual-search
+                // regions are normalized, de-duplicated, and unsupported entries
+                // are discarded before persistence.
+                elsewhere.Region = StreamingRegionNormalizer.NormalizeOverride(elsewhere.Region);
+                elsewhere.Regions = StreamingRegionNormalizer.NormalizeOverrides(elsewhere.Regions);
+            }
         }
 
         private bool IsUserAdministrator(string userId)

--- a/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/JellyfinCanopy.cs
@@ -241,6 +241,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy
 
                 NormalizePreferredAudioLanguageForUpdate(config);
                 NormalizeRatingTagScopePolicyForUpdate(config);
+                NormalizeDefaultStreamingRegionForUpdate(config);
                 SanitizeExternalUrlFields(config);
             }
 
@@ -274,6 +275,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             }
 
             config.RatingTagScopePolicy = normalized;
+        }
+
+        internal static void NormalizeDefaultStreamingRegionForUpdate(PluginConfiguration config)
+        {
+            config.DEFAULT_REGION = StreamingRegionNormalizer.Normalize(config.DEFAULT_REGION);
         }
 
         // Armed while a startup migration failure is being handled. Enhanced import

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/Seerr/SeerrParentalFilter.cs
@@ -452,10 +452,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services.Seerr
         }
 
         private static string ResolveRegion(PluginConfiguration config)
-        {
-            var region = config.DEFAULT_REGION;
-            return string.IsNullOrWhiteSpace(region) ? "US" : region.Trim().ToUpperInvariant();
-        }
+            => StreamingRegionNormalizer.Normalize(config.DEFAULT_REGION);
 
         // ── Detail / single-title decisions ───────────────────────────────────
         private bool IsDetailBodyBlocked(string json, string mediaType, GateContext gate)

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/config-page-region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/config-page-region.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import * as ts from 'typescript';
+import { SUPPORTED_STREAMING_REGION_CODES } from './effective-region';
 
 const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
 const SRC_ROOT = TEST_FILE_PATH.replace(/\/core\/[^/]+$/, '/');
 const CONFIG_PAGE_JS = SRC_ROOT.replace(/src\/$/, 'Configuration/config-page.js');
 const CONFIG_PAGE_HTML = SRC_ROOT.replace(/src\/$/, 'Configuration/configPage.html');
+const SERVER_REGION_NORMALIZER = SRC_ROOT.replace(/src\/$/, 'Configuration/StreamingRegionNormalizer.cs');
 
 function read(path: string): string {
     const source = ts.sys.readFile(path);
@@ -23,6 +25,7 @@ function productionFunction(source: string, name: string): string {
 
 interface AdminRegionHelpers {
     normalize(value: unknown): string | null;
+    normalizeSupported(value: unknown): string | null;
     parse(value: unknown): Array<{ code: string; name: string }>;
     resolve(value: unknown, entries: Array<{ code: string; name: string }>, loaded: boolean): string;
     setOptions(
@@ -35,16 +38,20 @@ interface AdminRegionHelpers {
 
 function regionHelpers(source: string): AdminRegionHelpers {
     const constant = source.match(/^ {8}var JC_DEFAULT_STREAMING_REGION = '[A-Z]{2}';/m);
+    const supported = source.match(/^ {8}var JC_SUPPORTED_STREAMING_REGIONS = new Set\('[A-Z ]+'\.split\(' '\)\);/m);
     expect(constant).toBeTruthy();
+    expect(supported).toBeTruthy();
     // Execute only closed helpers extracted from committed production source.
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     const factory = new Function([
         constant![0],
+        supported![0],
         productionFunction(source, 'jcNormalizeStreamingRegion'),
+        productionFunction(source, 'jcNormalizeSupportedStreamingRegion'),
         productionFunction(source, 'jcParseStreamingRegionCatalog'),
         productionFunction(source, 'jcResolveCatalogStreamingRegion'),
         productionFunction(source, 'jcSetDefaultRegionOptions'),
-        'return { normalize: jcNormalizeStreamingRegion, parse: jcParseStreamingRegionCatalog, resolve: jcResolveCatalogStreamingRegion, setOptions: jcSetDefaultRegionOptions };',
+        'return { normalize: jcNormalizeStreamingRegion, normalizeSupported: jcNormalizeSupportedStreamingRegion, parse: jcParseStreamingRegionCatalog, resolve: jcResolveCatalogStreamingRegion, setOptions: jcSetDefaultRegionOptions };',
     ].join('\n')) as () => AdminRegionHelpers;
     return factory();
 }
@@ -52,6 +59,7 @@ function regionHelpers(source: string): AdminRegionHelpers {
 describe('admin default-region binding', () => {
     const html = read(CONFIG_PAGE_HTML);
     const js = read(CONFIG_PAGE_JS);
+    const server = read(SERVER_REGION_NORMALIZER);
     const helpers = regionHelpers(js);
 
     it('uses a bound accessible select instead of accepting free text', () => {
@@ -61,18 +69,28 @@ describe('admin default-region binding', () => {
         expect(js).toContain("ApiClient.getUrl('/JellyfinCanopy/assets/elsewhere/regions.txt')");
         expect(js).toContain('config.AssetCacheEnabled === false');
         expect(js).toContain('signal: controller.signal');
-        expect(js).toMatch(/DEFAULT_REGION:\s*\{[\s\S]*?load:[\s\S]*?jcSetDefaultRegionOptions[\s\S]*?save:[\s\S]*?jcNormalizeStreamingRegion/);
+        expect(js).toMatch(/DEFAULT_REGION:\s*\{[\s\S]*?load:[\s\S]*?jcSetDefaultRegionOptions[\s\S]*?save:[\s\S]*?jcNormalizeSupportedStreamingRegion/);
     });
 
     it('normalizes legacy persisted syntax and parses the mirrored catalog', () => {
         expect(helpers.normalize(' xk ')).toBe('XK');
         expect(helpers.normalize('United States')).toBeNull();
         expect(helpers.normalize('')).toBeNull();
-        expect(helpers.parse('# header\nus\tUnited States\nXK\tKosovo\nUS\tDuplicate'))
+        expect(helpers.normalizeSupported('xk')).toBe('XK');
+        expect(helpers.normalizeSupported('zz')).toBeNull();
+        expect(helpers.parse('# header\nus\tUnited States\nXK\tKosovo\nUS\tDuplicate\nZZ\tUnsupported'))
             .toEqual([
                 { code: 'US', name: 'United States' },
                 { code: 'XK', name: 'Kosovo' },
             ]);
+    });
+
+    it('keeps the exact 139-code runtime contract synchronized across client, admin, and server', () => {
+        const adminCodes = js.match(/JC_SUPPORTED_STREAMING_REGIONS = new Set\('([A-Z ]+)'/)?.[1].split(' ');
+        const serverCodes = server.match(/SupportedCodeList =\s*\n\s*"([A-Z ]+)";/)?.[1].split(' ');
+        expect(adminCodes).toEqual(SUPPORTED_STREAMING_REGION_CODES);
+        expect(serverCodes).toEqual(SUPPORTED_STREAMING_REGION_CODES);
+        expect(adminCodes).toHaveLength(139);
     });
 
     it('rejects unknown codes with a loaded catalog but preserves uncommon syntax on failure', () => {
@@ -80,6 +98,7 @@ describe('admin default-region binding', () => {
         expect(helpers.resolve('zz', catalog, true)).toBe('US');
         expect(helpers.resolve('xk', catalog, true)).toBe('XK');
         expect(helpers.resolve('xk', [], false)).toBe('XK');
+        expect(helpers.resolve('zz', [], false)).toBe('US');
         expect(helpers.resolve('', [], false)).toBe('US');
 
         const select = document.createElement('select');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/config-page-region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/config-page-region.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import * as ts from 'typescript';
+
+const TEST_FILE_PATH = decodeURIComponent(new URL(import.meta.url).pathname);
+const SRC_ROOT = TEST_FILE_PATH.replace(/\/core\/[^/]+$/, '/');
+const CONFIG_PAGE_JS = SRC_ROOT.replace(/src\/$/, 'Configuration/config-page.js');
+const CONFIG_PAGE_HTML = SRC_ROOT.replace(/src\/$/, 'Configuration/configPage.html');
+
+function read(path: string): string {
+    const source = ts.sys.readFile(path);
+    expect(source, `missing source: ${path}`).toBeTruthy();
+    return source!;
+}
+
+function productionFunction(source: string, name: string): string {
+    const match = source.match(new RegExp(
+        `^ {8}(?:async )?function ${name}\\([^\\n]*\\) \\{[\\s\\S]*?^ {8}\\}`,
+        'm',
+    ));
+    expect(match, `missing production helper: ${name}`).toBeTruthy();
+    return match![0];
+}
+
+interface AdminRegionHelpers {
+    normalize(value: unknown): string | null;
+    parse(value: unknown): Array<{ code: string; name: string }>;
+    resolve(value: unknown, entries: Array<{ code: string; name: string }>, loaded: boolean): string;
+    setOptions(
+        select: HTMLSelectElement,
+        entries: Array<{ code: string; name: string }>,
+        selected: unknown,
+        loaded: boolean,
+    ): string;
+}
+
+function regionHelpers(source: string): AdminRegionHelpers {
+    const constant = source.match(/^ {8}var JC_DEFAULT_STREAMING_REGION = '[A-Z]{2}';/m);
+    expect(constant).toBeTruthy();
+    // Execute only closed helpers extracted from committed production source.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const factory = new Function([
+        constant![0],
+        productionFunction(source, 'jcNormalizeStreamingRegion'),
+        productionFunction(source, 'jcParseStreamingRegionCatalog'),
+        productionFunction(source, 'jcResolveCatalogStreamingRegion'),
+        productionFunction(source, 'jcSetDefaultRegionOptions'),
+        'return { normalize: jcNormalizeStreamingRegion, parse: jcParseStreamingRegionCatalog, resolve: jcResolveCatalogStreamingRegion, setOptions: jcSetDefaultRegionOptions };',
+    ].join('\n')) as () => AdminRegionHelpers;
+    return factory();
+}
+
+describe('admin default-region binding', () => {
+    const html = read(CONFIG_PAGE_HTML);
+    const js = read(CONFIG_PAGE_JS);
+    const helpers = regionHelpers(js);
+
+    it('uses a bound accessible select instead of accepting free text', () => {
+        expect(html).toMatch(/<select id="DEFAULT_REGION"[^>]*data-config-key="DEFAULT_REGION"[^>]*aria-describedby="defaultRegionDescription"/);
+        expect(html).not.toMatch(/<input id="DEFAULT_REGION"/);
+        expect(html).toContain('mirrored region catalog');
+        expect(js).toContain("ApiClient.getUrl('/JellyfinCanopy/assets/elsewhere/regions.txt')");
+        expect(js).toContain('config.AssetCacheEnabled === false');
+        expect(js).toContain('signal: controller.signal');
+        expect(js).toMatch(/DEFAULT_REGION:\s*\{[\s\S]*?load:[\s\S]*?jcSetDefaultRegionOptions[\s\S]*?save:[\s\S]*?jcNormalizeStreamingRegion/);
+    });
+
+    it('normalizes legacy persisted syntax and parses the mirrored catalog', () => {
+        expect(helpers.normalize(' xk ')).toBe('XK');
+        expect(helpers.normalize('United States')).toBeNull();
+        expect(helpers.normalize('')).toBeNull();
+        expect(helpers.parse('# header\nus\tUnited States\nXK\tKosovo\nUS\tDuplicate'))
+            .toEqual([
+                { code: 'US', name: 'United States' },
+                { code: 'XK', name: 'Kosovo' },
+            ]);
+    });
+
+    it('rejects unknown codes with a loaded catalog but preserves uncommon syntax on failure', () => {
+        const catalog = helpers.parse('US\tUnited States\nXK\tKosovo');
+        expect(helpers.resolve('zz', catalog, true)).toBe('US');
+        expect(helpers.resolve('xk', catalog, true)).toBe('XK');
+        expect(helpers.resolve('xk', [], false)).toBe('XK');
+        expect(helpers.resolve('', [], false)).toBe('US');
+
+        const select = document.createElement('select');
+        expect(helpers.setOptions(select, catalog, 'zz', true)).toBe('US');
+        expect(select.value).toBe('US');
+        expect([...select.options].map((option) => option.value)).toEqual(['US', 'XK']);
+
+        expect(helpers.setOptions(select, [], 'xk', false)).toBe('XK');
+        expect(select.value).toBe('XK');
+        expect([...select.options].map((option) => option.textContent))
+            .toContain('Saved region (XK)');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+    normalizeStreamingRegion,
+    parseStreamingRegionCatalog,
+    resolveAdminStreamingRegion,
+    resolveCatalogStreamingRegion,
+    resolveEffectiveStreamingRegion,
+} from './effective-region';
+
+describe('effective streaming region', () => {
+    it.each([
+        [' us ', 'US'],
+        ['xk', 'XK'],
+        ['', null],
+        ['USA', null],
+        ['1A', null],
+        [null, null],
+    ])('normalizes %j deterministically', (input, expected) => {
+        expect(normalizeStreamingRegion(input)).toBe(expected);
+    });
+
+    it('gives a valid per-user override precedence and reset inherits the current admin default', () => {
+        expect(resolveEffectiveStreamingRegion(
+            { elsewhere: { Region: 'ca' } },
+            { DEFAULT_REGION: 'gb' },
+        )).toBe('CA');
+        expect(resolveEffectiveStreamingRegion(
+            { elsewhere: { Region: '' } },
+            { DEFAULT_REGION: 'gb' },
+        )).toBe('GB');
+        expect(resolveEffectiveStreamingRegion(
+            { elsewhere: { Region: 'malformed' } },
+            { DEFAULT_REGION: 'de' },
+        )).toBe('DE');
+        expect(resolveAdminStreamingRegion({ DEFAULT_REGION: '' })).toBe('US');
+    });
+
+    it('parses, normalizes, and deduplicates the mirrored catalog', () => {
+        expect(parseStreamingRegionCatalog([
+            '# comment',
+            'us\tUnited States',
+            'XK\tKosovo',
+            'US\tDuplicate',
+            'BAD\tIgnored',
+            'CA\t',
+        ].join('\n'))).toEqual([
+            { code: 'US', name: 'United States' },
+            { code: 'XK', name: 'Kosovo' },
+        ]);
+    });
+
+    it('falls back for an unknown code only with an authoritative catalog', () => {
+        const catalog = parseStreamingRegionCatalog('US\tUnited States\nXK\tKosovo');
+        expect(resolveCatalogStreamingRegion('zz', catalog)).toBe('US');
+        expect(resolveCatalogStreamingRegion('xk', catalog)).toBe('XK');
+        expect(resolveCatalogStreamingRegion('xk', null)).toBe('XK');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
+    SUPPORTED_STREAMING_REGION_CODES,
+    isSupportedStreamingRegion,
     normalizeStreamingRegion,
+    normalizeSupportedStreamingRegion,
     parseStreamingRegionCatalog,
     resolveAdminStreamingRegion,
     resolveCatalogStreamingRegion,
     resolveEffectiveStreamingRegion,
+    type StreamingRegionCode,
 } from './effective-region';
 
 describe('effective streaming region', () => {
@@ -17,6 +21,15 @@ describe('effective streaming region', () => {
         [null, null],
     ])('normalizes %j deterministically', (input, expected) => {
         expect(normalizeStreamingRegion(input)).toBe(expected);
+    });
+
+    it('pins the mirrored supported set while retaining uncommon regions', () => {
+        expect(SUPPORTED_STREAMING_REGION_CODES).toHaveLength(139);
+        expect(new Set(SUPPORTED_STREAMING_REGION_CODES).size).toBe(139);
+        expect(isSupportedStreamingRegion('xk')).toBe(true);
+        expect(normalizeSupportedStreamingRegion(' xk ')).toBe('XK');
+        expect(isSupportedStreamingRegion('ZZ')).toBe(false);
+        expect(normalizeSupportedStreamingRegion('ZZ')).toBeNull();
     });
 
     it('gives a valid per-user override precedence and reset inherits the current admin default', () => {
@@ -32,6 +45,14 @@ describe('effective streaming region', () => {
             { elsewhere: { Region: 'malformed' } },
             { DEFAULT_REGION: 'de' },
         )).toBe('DE');
+        expect(resolveEffectiveStreamingRegion(
+            { elsewhere: { Region: 'ZZ' } },
+            { DEFAULT_REGION: 'ca' },
+        )).toBe('CA');
+        expect(resolveEffectiveStreamingRegion(
+            { elsewhere: { Region: '' } },
+            { DEFAULT_REGION: 'ZZ' },
+        )).toBe('US');
         expect(resolveAdminStreamingRegion({ DEFAULT_REGION: '' })).toBe('US');
     });
 
@@ -42,6 +63,7 @@ describe('effective streaming region', () => {
             'XK\tKosovo',
             'US\tDuplicate',
             'BAD\tIgnored',
+            'ZZ\tUnsupported',
             'CA\t',
         ].join('\n'))).toEqual([
             { code: 'US', name: 'United States' },
@@ -54,5 +76,7 @@ describe('effective streaming region', () => {
         expect(resolveCatalogStreamingRegion('zz', catalog)).toBe('US');
         expect(resolveCatalogStreamingRegion('xk', catalog)).toBe('XK');
         expect(resolveCatalogStreamingRegion('xk', null)).toBe('XK');
+        expect(resolveCatalogStreamingRegion('zz', null)).toBe('US');
+        expect(resolveCatalogStreamingRegion('ca', catalog, 'ZZ' as StreamingRegionCode)).toBe('US');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.ts
@@ -3,6 +3,21 @@ import type { PluginConfig } from '../types/jc';
 
 export const FALLBACK_STREAMING_REGION = 'US' as const;
 
+/**
+ * TMDB watch-provider regions mirrored by Elsewhere's regions.txt catalog.
+ *
+ * Runtime consumers need a synchronous, fail-closed membership boundary before
+ * the asynchronously mirrored catalog is available. Keep this release snapshot
+ * in lockstep with StreamingRegionNormalizer.cs and the config-page guard; the
+ * mirror remains the source of display names and may preserve an existing
+ * supported uncommon value while its refresh is unavailable.
+ */
+export const SUPPORTED_STREAMING_REGION_CODES = Object.freeze(
+    'AD AE AG AL AO AR AT AU AZ BA BB BE BF BG BH BM BO BR BS BY BZ CA CD CH CI CL CM CO CR CU CV CY CZ DE DK DO DZ EC EE EG ES FI FJ FR GB GF GH GI GP GQ GR GT GY HK HN HR HU ID IE IL IN IQ IS IT JM JO JP KE KR KW LB LC LI LT LU LV LY MA MC MD ME MG MK ML MT MU MW MX MY MZ NE NG NI NL NO NZ OM PA PE PF PG PH PK PL PS PT PY QA RO RS RU SA SC SE SG SI SK SM SN SV TC TD TH TN TR TT TW TZ UA UG US UY VA VE XK YE ZA ZM ZW'.split(' '),
+) as readonly StreamingRegionCode[];
+
+const SUPPORTED_STREAMING_REGIONS = new Set<string>(SUPPORTED_STREAMING_REGION_CODES);
+
 /** A normalized two-letter streaming-region code. */
 export type StreamingRegionCode = string & { readonly __streamingRegionCode: unique symbol };
 
@@ -28,9 +43,21 @@ export function normalizeStreamingRegion(value: unknown): StreamingRegionCode | 
         : null;
 }
 
+/** True only for a normalized code supported by TMDB's provider-region contract. */
+export function isSupportedStreamingRegion(value: unknown): boolean {
+    const normalized = normalizeStreamingRegion(value);
+    return normalized !== null && SUPPORTED_STREAMING_REGIONS.has(normalized);
+}
+
+/** Normalize and enforce supported catalog membership synchronously. */
+export function normalizeSupportedStreamingRegion(value: unknown): StreamingRegionCode | null {
+    const normalized = normalizeStreamingRegion(value);
+    return normalized && SUPPORTED_STREAMING_REGIONS.has(normalized) ? normalized : null;
+}
+
 /** Resolve the administrator default, including legacy empty/malformed values. */
 export function resolveAdminStreamingRegion(config: PluginConfig | null | undefined = JC.pluginConfig): StreamingRegionCode {
-    return normalizeStreamingRegion(config?.DEFAULT_REGION)
+    return normalizeSupportedStreamingRegion(config?.DEFAULT_REGION)
         || FALLBACK_STREAMING_REGION as StreamingRegionCode;
 }
 
@@ -49,7 +76,7 @@ export function resolveEffectiveStreamingRegion(
     const elsewhere = record?.elsewhere && typeof record.elsewhere === 'object'
         ? record.elsewhere as ElsewhereRegionSettings
         : null;
-    return normalizeStreamingRegion(elsewhere?.Region)
+    return normalizeSupportedStreamingRegion(elsewhere?.Region)
         || resolveAdminStreamingRegion(pluginConfig);
 }
 
@@ -62,7 +89,7 @@ export function parseStreamingRegionCatalog(text: unknown): readonly RegionCatal
         if (!trimmed || trimmed.startsWith('#')) continue;
         const separator = line.indexOf('\t');
         if (separator < 0) continue;
-        const code = normalizeStreamingRegion(line.slice(0, separator));
+        const code = normalizeSupportedStreamingRegion(line.slice(0, separator));
         const name = line.slice(separator + 1).trim();
         if (!code || !name || byCode.has(code)) continue;
         byCode.set(code, Object.freeze({ code, name }));
@@ -79,7 +106,9 @@ export function resolveCatalogStreamingRegion(
     catalog: readonly RegionCatalogEntry[] | null,
     fallback: StreamingRegionCode = FALLBACK_STREAMING_REGION as StreamingRegionCode,
 ): StreamingRegionCode {
-    const normalized = normalizeStreamingRegion(value) || fallback;
+    const supportedFallback = normalizeSupportedStreamingRegion(fallback)
+        || FALLBACK_STREAMING_REGION as StreamingRegionCode;
+    const normalized = normalizeSupportedStreamingRegion(value) || supportedFallback;
     if (catalog === null) return normalized;
-    return catalog.some((entry) => entry.code === normalized) ? normalized : fallback;
+    return catalog.some((entry) => entry.code === normalized) ? normalized : supportedFallback;
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/core/effective-region.ts
@@ -1,0 +1,85 @@
+import { JC } from '../globals';
+import type { PluginConfig } from '../types/jc';
+
+export const FALLBACK_STREAMING_REGION = 'US' as const;
+
+/** A normalized two-letter streaming-region code. */
+export type StreamingRegionCode = string & { readonly __streamingRegionCode: unique symbol };
+
+export interface ElsewhereRegionSettings {
+    Region?: unknown;
+}
+
+export interface RegionCatalogEntry {
+    readonly code: StreamingRegionCode;
+    readonly name: string;
+}
+
+/**
+ * Normalize the wire syntax shared by TMDB and Seerr region-indexed payloads.
+ * Membership is deliberately separate: a temporary catalog failure must not
+ * erase a syntactically valid uncommon persisted code.
+ */
+export function normalizeStreamingRegion(value: unknown): StreamingRegionCode | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim().toUpperCase();
+    return /^[A-Z]{2}$/.test(normalized)
+        ? normalized as StreamingRegionCode
+        : null;
+}
+
+/** Resolve the administrator default, including legacy empty/malformed values. */
+export function resolveAdminStreamingRegion(config: PluginConfig | null | undefined = JC.pluginConfig): StreamingRegionCode {
+    return normalizeStreamingRegion(config?.DEFAULT_REGION)
+        || FALLBACK_STREAMING_REGION as StreamingRegionCode;
+}
+
+/**
+ * Resolve the current viewer's effective region. A valid per-user override is
+ * isolated to that user and wins; empty/reset or malformed state inherits the
+ * current administrator default.
+ */
+export function resolveEffectiveStreamingRegion(
+    userConfig: unknown = JC.userConfig,
+    pluginConfig: PluginConfig | null | undefined = JC.pluginConfig,
+): StreamingRegionCode {
+    const record = userConfig && typeof userConfig === 'object'
+        ? userConfig as Record<string, unknown>
+        : null;
+    const elsewhere = record?.elsewhere && typeof record.elsewhere === 'object'
+        ? record.elsewhere as ElsewhereRegionSettings
+        : null;
+    return normalizeStreamingRegion(elsewhere?.Region)
+        || resolveAdminStreamingRegion(pluginConfig);
+}
+
+/** Parse the locally mirrored `regions.txt` catalog into a deterministic list. */
+export function parseStreamingRegionCatalog(text: unknown): readonly RegionCatalogEntry[] {
+    if (typeof text !== 'string') return [];
+    const byCode = new Map<StreamingRegionCode, RegionCatalogEntry>();
+    for (const line of text.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const separator = line.indexOf('\t');
+        if (separator < 0) continue;
+        const code = normalizeStreamingRegion(line.slice(0, separator));
+        const name = line.slice(separator + 1).trim();
+        if (!code || !name || byCode.has(code)) continue;
+        byCode.set(code, Object.freeze({ code, name }));
+    }
+    return Object.freeze([...byCode.values()]);
+}
+
+/**
+ * Apply catalog membership only when a non-empty catalog was loaded.
+ * During failure, preserve normalized state instead of silently resetting it.
+ */
+export function resolveCatalogStreamingRegion(
+    value: unknown,
+    catalog: readonly RegionCatalogEntry[] | null,
+    fallback: StreamingRegionCode = FALLBACK_STREAMING_REGION as StreamingRegionCode,
+): StreamingRegionCode {
+    const normalized = normalizeStreamingRegion(value) || fallback;
+    if (catalog === null) return normalized;
+    return catalog.some((entry) => entry.code === normalized) ? normalized : fallback;
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/data.region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/data.region.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../globals';
+import type { ApiApi } from '../types/jc';
+import { fetchRow } from './data';
+
+describe('discovery effective streaming region', () => {
+    beforeEach(() => {
+        const context = JC.identity.capture()!;
+        JC.pluginConfig = { SeerrEnabled: true, DEFAULT_REGION: 'ZZ' };
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'zz' }, context),
+        }, context);
+    });
+
+    afterEach(() => {
+        JC.core.api = undefined;
+        vi.restoreAllMocks();
+    });
+
+    it('never sends unsupported persisted codes as Seerr watchRegion', async () => {
+        const plugin = vi.fn().mockResolvedValue({ results: [] });
+        JC.core.api = { plugin } as unknown as ApiApi;
+
+        await fetchRow({ id: 'streaming:8', kind: 'streaming', param: 8 }, 'movie');
+
+        expect(plugin).toHaveBeenCalledWith(
+            '/seerr/discover/movies?page=1&watchProviders=8&watchRegion=US',
+            expect.objectContaining({
+                cacheKey: 'seerr:/discover/movies?page=1&watchProviders=8&watchRegion=US',
+            }),
+        );
+        expect(JSON.stringify(plugin.mock.calls)).not.toContain('ZZ');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/discovery/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/discovery/data.ts
@@ -10,6 +10,7 @@
 // the core API client with a cache key, inheriting retry / in-flight dedup / the response cache.
 
 import { JC } from '../globals';
+import { resolveEffectiveStreamingRegion } from '../core/effective-region';
 import type { DiscoveryRowSpec, DiscoveryMediaType } from './rows';
 
 function seerrEnabled(): boolean {
@@ -17,8 +18,7 @@ function seerrEnabled(): boolean {
 }
 
 function region(): string {
-    const r = JC.pluginConfig?.DEFAULT_REGION;
-    return encodeURIComponent(typeof r === 'string' && r ? r : 'US');
+    return encodeURIComponent(resolveEffectiveStreamingRegion());
 }
 
 interface ResultsResponse { results?: unknown[] }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.identity.test.ts
@@ -165,4 +165,73 @@ describe('Elsewhere account ownership', () => {
         document.getElementById('cancel-settings')!.click();
         expect(getRefreshSafetyHoldCount('modal')).toBe(0);
     });
+
+    it('uses the effective user region for automatic empty-result lookup and labels', async () => {
+        document.body.innerHTML = `
+            <div class="detailSectionContent">
+                <a href="https://www.themoviedb.org/movie/123">TMDB</a>
+            </div>`;
+        const context = JC.identity.capture()!;
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'ca', Regions: [], Services: [] }, context),
+        }, context);
+        JC.t = (key: string, params?: Record<string, unknown>) =>
+            `${key}:${typeof params?.region === 'string' ? params.region : ''}`;
+        vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+            const url = input instanceof Request
+                ? input.url
+                : input instanceof URL ? input.href : input;
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                text: () => Promise.resolve(
+                    url.includes('providers.txt') ? 'Netflix' : 'US\tUnited States\nCA\tCanada',
+                ),
+            } as Response);
+        }));
+        const apiFetch = vi.fn().mockResolvedValue({ results: {} });
+        JC.core.api = { fetch: apiFetch } as unknown as typeof JC.core.api;
+
+        (JC as typeof JC & { initializeElsewhereScript: () => void }).initializeElsewhereScript();
+        await vi.advanceTimersByTimeAsync(2_500);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(document.querySelector('.streaming-lookup-container')?.textContent)
+            .toContain('elsewhere_panel_not_available_in:Canada');
+        expect(apiFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('persists an empty override when reset is selected so the current admin default is inherited', async () => {
+        const context = JC.identity.capture()!;
+        JC.pluginConfig.DEFAULT_REGION = 'GB';
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'CA', Regions: [], Services: [] }, context),
+        }, context);
+        vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(
+                (input instanceof Request
+                    ? input.url
+                    : input instanceof URL ? input.href : input).includes('providers.txt')
+                    ? 'Netflix'
+                    : 'US\tUnited States\nGB\tUnited Kingdom\nCA\tCanada',
+            ),
+        } as Response)));
+        const save = vi.fn().mockResolvedValue({});
+        JC.saveUserSettings = save;
+
+        (JC as typeof JC & { initializeElsewhereScript: () => void }).initializeElsewhereScript();
+        await vi.advanceTimersByTimeAsync(2_500);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const select = document.getElementById('region-select') as HTMLSelectElement;
+        select.value = '';
+        document.getElementById('save-settings')!.click();
+        await Promise.resolve();
+
+        expect(save).toHaveBeenCalledWith('elsewhere.json', expect.objectContaining({ Region: '' }));
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.identity.test.ts
@@ -202,6 +202,48 @@ describe('Elsewhere account ownership', () => {
         expect(apiFetch).toHaveBeenCalledTimes(1);
     });
 
+    it('never lets unsupported user or admin codes reach automatic lookup or labels', async () => {
+        document.body.innerHTML = `
+            <div class="detailSectionContent">
+                <a href="https://www.themoviedb.org/movie/123">TMDB</a>
+            </div>`;
+        const context = JC.identity.capture()!;
+        JC.pluginConfig.DEFAULT_REGION = 'ZZ';
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'zz', Regions: ['ZZ'], Services: [] }, context),
+        }, context);
+        JC.t = (key: string, params?: Record<string, unknown>) =>
+            `${key}:${typeof params?.region === 'string' ? params.region : ''}`;
+        vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(
+                (input instanceof Request
+                    ? input.url
+                    : input instanceof URL ? input.href : input).includes('providers.txt')
+                    ? 'Wrong Provider'
+                    : 'US\tUnited States\nXK\tKosovo\nZZ\tUnsupported',
+            ),
+        } as Response)));
+        JC.core.api = {
+            fetch: vi.fn().mockResolvedValue({
+                results: { ZZ: { flatrate: [{ provider_name: 'Wrong Provider' }] } },
+            }),
+        } as unknown as typeof JC.core.api;
+
+        (JC as typeof JC & { initializeElsewhereScript: () => void }).initializeElsewhereScript();
+        await vi.advanceTimersByTimeAsync(2_500);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const panel = document.querySelector('.streaming-lookup-container');
+        expect(panel?.textContent).toContain('elsewhere_panel_not_available_in:United States');
+        expect(panel?.textContent).not.toContain('Wrong Provider');
+        const modal = document.getElementById('streaming-settings-modal')!;
+        expect((modal.querySelector('#region-select') as HTMLSelectElement).value).toBe('');
+        expect(modal.textContent).not.toContain('Unsupported');
+    });
+
     it('persists an empty override when reset is selected so the current admin default is inherited', async () => {
         const context = JC.identity.capture()!;
         JC.pluginConfig.DEFAULT_REGION = 'GB';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.ts
@@ -9,7 +9,7 @@ import { isDetailsPageVisible } from '../core/details-view';
 import { onBodyMutation } from '../core/dom-observer';
 import { createStableMethodFacade } from '../core/feature-loader';
 import {
-    normalizeStreamingRegion,
+    normalizeSupportedStreamingRegion,
     parseStreamingRegionCatalog,
     resolveAdminStreamingRegion,
     resolveCatalogStreamingRegion,
@@ -147,7 +147,7 @@ function initializeElsewhereImpl(): void {
     }
 
     let userRegion = resolveEffectiveStreamingRegion(JC.userConfig, JC.pluginConfig);
-    let userRegionOverride: StreamingRegionCode | '' = normalizeStreamingRegion(JC.userConfig?.elsewhere?.Region) || '';
+    let userRegionOverride: StreamingRegionCode | '' = normalizeSupportedStreamingRegion(JC.userConfig?.elsewhere?.Region) || '';
     let userRegions: string[] = []; // Multiple regions for search
     let userServices: string[] = []; // Empty by default - will show all services from settings region
     let availableRegions: Record<string, string> = {};
@@ -581,7 +581,7 @@ function initializeElsewhereImpl(): void {
             saveButton.disabled = true;
             void JC.saveUserSettings('elsewhere.json', elsewhereSettings).then(() => {
                 if (!isInitializerCurrent()) return;
-                userRegionOverride = normalizeStreamingRegion(nextRegionOverride) || '';
+                userRegionOverride = normalizeSupportedStreamingRegion(nextRegionOverride) || '';
                 userRegion = userRegionOverride || adminRegion;
                 userRegions = selectedRegions;
                 userServices = selectedServices;
@@ -607,11 +607,11 @@ function initializeElsewhereImpl(): void {
     function loadSettings(): void {
         const settings = JC.userConfig.elsewhere || {};
         JC.rememberUserSettingsSnapshot?.('elsewhere.json', settings);
-        userRegionOverride = normalizeStreamingRegion(settings.Region) || '';
+        userRegionOverride = normalizeSupportedStreamingRegion(settings.Region) || '';
         userRegion = resolveEffectiveStreamingRegion(JC.userConfig, JC.pluginConfig);
         userRegions = Array.isArray(settings.Regions)
             ? (settings.Regions as unknown[])
-                .map(normalizeStreamingRegion)
+                .map(normalizeSupportedStreamingRegion)
                 .filter((value): value is StreamingRegionCode => value !== null)
             : [];
         userServices = Array.isArray(settings.Services) ? settings.Services : [];

--- a/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/elsewhere/elsewhere.ts
@@ -8,6 +8,14 @@ import { assetUrl } from '../core/asset-urls';
 import { isDetailsPageVisible } from '../core/details-view';
 import { onBodyMutation } from '../core/dom-observer';
 import { createStableMethodFacade } from '../core/feature-loader';
+import {
+    normalizeStreamingRegion,
+    parseStreamingRegionCatalog,
+    resolveAdminStreamingRegion,
+    resolveCatalogStreamingRegion,
+    resolveEffectiveStreamingRegion,
+    type StreamingRegionCode,
+} from '../core/effective-region';
 import { onNavigate, onViewPage } from '../core/navigation';
 import type { ApiApi, JELegacyHelpers, PluginConfig } from '../types/jc';
 
@@ -33,7 +41,6 @@ const JC = JEBase as typeof JEBase & {
     pluginConfig: PluginConfig & {
         ElsewhereEnabled?: boolean;
         TmdbEnabled?: boolean;
-        DEFAULT_REGION?: string;
         DEFAULT_PROVIDERS?: string;
         IGNORE_PROVIDERS?: string;
         ElsewhereCustomBrandingText?: string;
@@ -128,7 +135,7 @@ function initializeElsewhereImpl(): void {
     }
     // --- Configuration ---
     const TmdbEnabled = !!JC.pluginConfig.TmdbEnabled;
-    const DEFAULT_REGION = JC.pluginConfig.DEFAULT_REGION || 'US';
+    const adminRegion = resolveAdminStreamingRegion(JC.pluginConfig);
     const DEFAULT_PROVIDERS = JC.pluginConfig.DEFAULT_PROVIDERS ? JC.pluginConfig.DEFAULT_PROVIDERS.replace(/'/g, '').replace(/\n/g, ',').split(',').map(s => s.trim()).filter(s => s) : [];
     const IGNORE_PROVIDERS = JC.pluginConfig.IGNORE_PROVIDERS ? JC.pluginConfig.IGNORE_PROVIDERS.replace(/'/g, '').replace(/\n/g, ',').split(',').map(s => s.trim()).filter(s => s) : [];
     const ELSEWHERE_CUSTOM_BRANDING_TEXT = JC.pluginConfig.ElsewhereCustomBrandingText || '';
@@ -139,11 +146,16 @@ function initializeElsewhereImpl(): void {
         return;
     }
 
-    let userRegion = DEFAULT_REGION;
+    let userRegion = resolveEffectiveStreamingRegion(JC.userConfig, JC.pluginConfig);
+    let userRegionOverride: StreamingRegionCode | '' = normalizeStreamingRegion(JC.userConfig?.elsewhere?.Region) || '';
     let userRegions: string[] = []; // Multiple regions for search
     let userServices: string[] = []; // Empty by default - will show all services from settings region
     let availableRegions: Record<string, string> = {};
     let availableProviders: string[] = [];
+
+    function ensureRegionDisplay(code: string): void {
+        if (code && !availableRegions[code]) availableRegions[code] = code;
+    }
 
     // Safe fallback for helpers.js Stage-3 load-order races.
     const extLink = JC.helpers?.createExternalLink || ((u: string, o?: ExternalLinkOptions) => {
@@ -167,14 +179,12 @@ function initializeElsewhereImpl(): void {
             .then(response => response.ok ? response.text() : Promise.reject(new Error(`HTTP ${response.status}`)))
             .then(text => {
                 if (!isInitializerCurrent()) return;
-                const lines = text.trim().split('\n');
-                lines.forEach(line => {
-                    if (line.startsWith('#')) return;
-                    const [code, name] = line.split('\t');
-                    if (code && name) {
-                        availableRegions[code] = name;
-                    }
-                });
+                const catalog = parseStreamingRegionCatalog(text);
+                if (catalog.length === 0) throw new Error('Empty regions catalog');
+                availableRegions = Object.fromEntries(catalog.map((entry) => [entry.code, entry.name]));
+                userRegion = resolveCatalogStreamingRegion(userRegion, catalog, adminRegion);
+                if (userRegionOverride && userRegion !== userRegionOverride) userRegionOverride = '';
+                ensureRegionDisplay(adminRegion);
             })
             .catch(() => {
                 if (!isInitializerCurrent()) return;
@@ -186,6 +196,9 @@ function initializeElsewhereImpl(): void {
                     'ES': 'Spain', 'NL': 'Netherlands', 'SE': 'Sweden', 'NO': 'Norway',
                     'DK': 'Denmark', 'FI': 'Finland'
                 };
+                // A stale/missing mirror must not erase a valid uncommon value.
+                ensureRegionDisplay(adminRegion);
+                ensureRegionDisplay(userRegion);
             });
 
              // Load providers
@@ -484,8 +497,9 @@ function initializeElsewhereImpl(): void {
             <div style="margin-bottom: 16px;">
                 <label style="display: block; margin-bottom: 6px; font-weight: 600; color: #ccc;">${JC.t('elsewhere_settings_country')}</label>
                 <select id="region-select" style="width: 100%; padding: 12px; border: 1px solid #444; border-radius: 6px; background: #2a2a2a; color: #fff; font-size: 14px;">
+                    <option value="" ${userRegionOverride === '' ? 'selected' : ''}>${JC.escapeHtml(`Use server default — ${availableRegions[adminRegion] || adminRegion} (${adminRegion})`)}</option>
                     ${Object.entries(availableRegions).map(([code, name]) =>
-                        `<option value="${JC.escapeHtml(code)}" ${code === userRegion ? 'selected' : ''}>${JC.escapeHtml(name)}</option>`
+                        `<option value="${JC.escapeHtml(code)}" ${code === userRegionOverride ? 'selected' : ''}>${JC.escapeHtml(`${name} (${code})`)}</option>`
                     ).join('')}
                 </select>
             </div>
@@ -542,7 +556,7 @@ function initializeElsewhereImpl(): void {
         document.getElementById('save-settings')!.onclick = (event) => {
             if (rejectStaleEvent(event)) return;
             const saveButton = document.getElementById('save-settings') as HTMLButtonElement;
-            const nextRegion = (document.getElementById('region-select') as HTMLSelectElement).value;
+            const nextRegionOverride = (document.getElementById('region-select') as HTMLSelectElement).value;
 
             // Get selected regions from autocomplete
             const selectedRegions: string[] = [];
@@ -560,18 +574,21 @@ function initializeElsewhereImpl(): void {
             });
             const elsewhereSettings = JC.identity.own({
                 Revision: Number(JC.userConfig.elsewhere?.Revision) || 0,
-                Region: nextRegion,
+                Region: nextRegionOverride,
                 Regions: selectedRegions,
                 Services: selectedServices
             }, identityContext);
             saveButton.disabled = true;
             void JC.saveUserSettings('elsewhere.json', elsewhereSettings).then(() => {
                 if (!isInitializerCurrent()) return;
-                userRegion = nextRegion;
+                userRegionOverride = normalizeStreamingRegion(nextRegionOverride) || '';
+                userRegion = userRegionOverride || adminRegion;
                 userRegions = selectedRegions;
                 userServices = selectedServices;
                 JC.userConfig.elsewhere = elsewhereSettings;
                 hideSettingsModal();
+                document.querySelectorAll('.streaming-lookup-container').forEach((node) => node.remove());
+                scheduleStreamingLookup();
             }).catch(() => undefined).finally(() => {
                 if (isInitializerCurrent()) saveButton.disabled = false;
             });
@@ -588,11 +605,16 @@ function initializeElsewhereImpl(): void {
 
     // Load saved settings
     function loadSettings(): void {
-        const settings = JC.userConfig.elsewhere;
+        const settings = JC.userConfig.elsewhere || {};
         JC.rememberUserSettingsSnapshot?.('elsewhere.json', settings);
-        userRegion = settings.Region || DEFAULT_REGION;
-        userRegions = settings.Regions || [];
-        userServices = settings.Services || [];
+        userRegionOverride = normalizeStreamingRegion(settings.Region) || '';
+        userRegion = resolveEffectiveStreamingRegion(JC.userConfig, JC.pluginConfig);
+        userRegions = Array.isArray(settings.Regions)
+            ? (settings.Regions as unknown[])
+                .map(normalizeStreamingRegion)
+                .filter((value): value is StreamingRegionCode => value !== null)
+            : [];
+        userServices = Array.isArray(settings.Services) ? settings.Services : [];
     }
 
     function createServiceBadge(service: any, tmdbId: string, mediaType: string): HTMLElement {
@@ -697,7 +719,7 @@ function initializeElsewhereImpl(): void {
 
     // Process streaming data for default region (auto-load)
     function processDefaultRegionData(data: any, tmdbId: string, mediaType: string): HTMLElement {
-        const regionData = data.results[DEFAULT_REGION];
+        const regionData = data?.results?.[userRegion];
 
         const container = document.createElement('div');
         container.style.cssText = `
@@ -757,7 +779,7 @@ function initializeElsewhereImpl(): void {
         );
 
         if (hasFilteredServices) {
-            title.textContent = JC.t('elsewhere_panel_available_in', { region: availableRegions[DEFAULT_REGION] || DEFAULT_REGION });
+            title.textContent = JC.t('elsewhere_panel_available_in', { region: availableRegions[userRegion] || userRegion });
         } else if (ELSEWHERE_CUSTOM_BRANDING_TEXT) {
             // Show custom branding when no services are available and custom text is configured
             title.textContent = ELSEWHERE_CUSTOM_BRANDING_TEXT;
@@ -792,7 +814,7 @@ function initializeElsewhereImpl(): void {
             }
         } else {
             // Fallback to default message if no custom text is set
-            title.textContent = JC.t('elsewhere_panel_not_available_in', { region: availableRegions[DEFAULT_REGION] || DEFAULT_REGION });
+            title.textContent = JC.t('elsewhere_panel_not_available_in', { region: availableRegions[userRegion] || userRegion });
         }
 
         title.style.cssText = `
@@ -985,7 +1007,7 @@ function initializeElsewhereImpl(): void {
                 const unavailableRegions: string[] = [];
 
                 regionsToSearch.forEach((region, index) => {
-                    const regionData = data.results[region];
+                    const regionData = data?.results?.[region];
                     const hasServices = regionData && regionData.flatrate && regionData.flatrate.length > 0;
 
                     if (hasServices) {
@@ -1113,7 +1135,7 @@ function initializeElsewhereImpl(): void {
 
     // Process streaming data for a specific region
     function processRegionData(data: any, tmdbId: string, mediaType: string, region: string, showAvailable = false): HTMLElement | null {
-        const regionData = data.results[region];
+        const regionData = data?.results?.[region];
         if (!regionData || !regionData.flatrate) {
             return null;
         }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.identity.test.ts
@@ -89,5 +89,13 @@ describe('release-date identity ownership', () => {
         await vi.waitFor(() => expect(container.textContent).toContain('2031'));
         expect(container.textContent).not.toContain('2001');
         expect(container.querySelector<HTMLElement>('.mediaInfoItem-releaseDate')?.dataset.region).toBe('CA');
+
+        JC.userConfig.elsewhere = JC.identity.own({ Region: 'ZZ' }, context);
+        displayReleaseDate('same-item', container);
+
+        await vi.waitFor(() => expect(container.textContent).toContain('2001'));
+        expect(container.textContent).not.toContain('2031');
+        expect(container.querySelector<HTMLElement>('.mediaInfoItem-releaseDate')?.dataset.region).toBe('US');
+        expect(plugin).toHaveBeenCalledTimes(2);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.identity.test.ts
@@ -68,4 +68,26 @@ describe('release-date identity ownership', () => {
         await vi.waitFor(() => expect(container.textContent).toContain('2030'));
         expect(container.textContent).not.toContain('2000');
     });
+
+    it('uses the effective per-user region and keeps cache entries region-scoped', async () => {
+        const context = JC.identity.capture()!;
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'ca' }, context),
+        }, context);
+        const plugin = vi.fn().mockResolvedValue({
+            results: [
+                { iso_3166_1: 'US', release_dates: [{ type: 3, release_date: '2001-01-01' }] },
+                { iso_3166_1: 'CA', release_dates: [{ type: 3, release_date: '2031-03-04' }] },
+            ],
+        });
+        JC.core.api = { plugin } as unknown as ApiApi;
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+
+        displayReleaseDate('same-item', container);
+
+        await vi.waitFor(() => expect(container.textContent).toContain('2031'));
+        expect(container.textContent).not.toContain('2001');
+        expect(container.querySelector<HTMLElement>('.mediaInfoItem-releaseDate')?.dataset.region).toBe('CA');
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/release-dates.ts
@@ -7,6 +7,7 @@
 import { JC } from '../../globals';
 import { ensureMaterialSymbolsFont, removeCss } from '../../core/ui-kit';
 import { createBoundedCache } from '../../core/bounded-cache';
+import { resolveEffectiveStreamingRegion, type StreamingRegionCode } from '../../core/effective-region';
 import { addCSS, getItemCached } from '../helpers';
 import type { IdentityContext } from '../../types/jc';
 
@@ -139,12 +140,15 @@ function earliestOfBucket(releaseDates: ReleaseDateEntry[] | undefined, bucket: 
  * to one region's entry would silently drop digital/physical dates that
  * TMDB has recorded under a different country.
  */
-async function getMovieReleaseInfo(context: IdentityContext, tmdbId: string): Promise<ReleaseInfo[]> {
+async function getMovieReleaseInfo(
+    context: IdentityContext,
+    tmdbId: string,
+    region: StreamingRegionCode,
+): Promise<ReleaseInfo[]> {
     const data = await tmdbGet<MovieReleaseResponse>(context, `/movie/${tmdbId}/release_dates`);
     const results = data.results;
     if (!Array.isArray(results) || results.length === 0) return [];
 
-    const region = ((JC.pluginConfig?.DEFAULT_REGION as string) || 'US').toUpperCase();
     const preferredOrder = [region, 'US'].filter((iso, i, arr) => iso && arr.indexOf(iso) === i);
 
     const infos: ReleaseInfo[] = [];
@@ -201,12 +205,17 @@ async function getEpisodeReleaseInfo(context: IdentityContext, tmdbId: string, s
  * SeriesProviderIds, falling back to fetching the series item) the same
  * way reviews.js does for TMDB reviews.
  */
-async function resolveReleaseInfo(context: IdentityContext, item: JellyfinReleaseItem | null, userId: string): Promise<ReleaseInfo[]> {
+async function resolveReleaseInfo(
+    context: IdentityContext,
+    item: JellyfinReleaseItem | null,
+    userId: string,
+    region: StreamingRegionCode,
+): Promise<ReleaseInfo[]> {
     const mediaType = item?.Type;
 
     if (mediaType === 'Movie') {
         const tmdbId = item?.ProviderIds?.Tmdb;
-        return tmdbId ? getMovieReleaseInfo(context, String(tmdbId)) : [];
+        return tmdbId ? getMovieReleaseInfo(context, String(tmdbId), region) : [];
     }
 
     if (mediaType === 'Series') {
@@ -257,22 +266,25 @@ async function resolveReleaseInfo(context: IdentityContext, item: JellyfinReleas
 export function displayReleaseDate(itemId: string, container: HTMLElement): void {
     const context = JC.identity.capture();
     if (!context) return;
+    const region = resolveEffectiveStreamingRegion();
+    const cacheKey = `${context.serverId}:${context.userId}:${region}:${itemId}`;
     const existing = container.querySelector<HTMLElement>('.mediaInfoItem-releaseDate');
     if (existing) {
         // Already rendered (or in flight) for this itemId — nothing to do.
-        if (existing.dataset.itemId === itemId) return;
+        if (existing.dataset.itemId === itemId && existing.dataset.region === region) return;
         existing.remove();
     }
 
-    const cached = releaseDateCache.get(itemId);
+    const cached = releaseDateCache.get(cacheKey);
     if (cached && (Date.now() - cached.ts) < (cached.error ? ERROR_CACHE_TTL : RELEASEDATE_CACHE_TTL)) {
-        if (cached.infos.length > 0) renderReleaseDateChip(context, container, itemId, cached.infos);
+        if (cached.infos.length > 0) renderReleaseDateChip(context, container, itemId, region, cached.infos);
         return;
     }
 
     const placeholder = document.createElement('div');
     placeholder.className = 'mediaInfoItem mediaInfoItem-releaseDate';
     placeholder.dataset.itemId = itemId;
+    placeholder.dataset.region = region;
     placeholder.style.display = 'none';
     container.appendChild(placeholder);
 
@@ -283,9 +295,9 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
             const userId = context.userId;
             const item = await getItemCached(itemId, { userId }) as JellyfinReleaseItem | null;
             if (!isActive(context, placeholder)) return;
-            const infos = await resolveReleaseInfo(context, item, userId);
+            const infos = await resolveReleaseInfo(context, item, userId, region);
             if (!isActive(context, placeholder)) return;
-            releaseDateCache.set(itemId, { infos, ts: now });
+            releaseDateCache.set(cacheKey, { infos, ts: now });
             // The user may have navigated away while this was in flight.
             if (!placeholder.isConnected) return;
             if (infos.length > 0) {
@@ -302,12 +314,12 @@ export function displayReleaseDate(itemId: string, container: HTMLElement): void
             // for dedup; it is removed only once retries are exhausted. The
             // chip appearing late is a single insert (R7) into the misc-info
             // row, same as the normal slow-TMDB path.
-            releaseDateCache.set(itemId, { infos: [], ts: now, error: true });
+            releaseDateCache.set(cacheKey, { infos: [], ts: now, error: true });
             if (attempt < FETCH_MAX_ATTEMPTS && placeholder.isConnected) {
                 const timer = window.setTimeout(() => {
                     retryTimers.delete(timer);
                     if (isActive(context, placeholder)) {
-                        releaseDateCache.delete(itemId);
+                        releaseDateCache.delete(cacheKey);
                         void performFetch(attempt + 1);
                     }
                 }, RETRY_BASE_DELAY_MS * attempt);
@@ -371,11 +383,18 @@ function fillReleaseDateChip(chip: HTMLElement, infos: ReleaseInfo[]): void {
 }
 
 /** Creates and appends a fresh release-date chip (cache-hit path, where there's no placeholder to fill). */
-function renderReleaseDateChip(context: IdentityContext, container: HTMLElement, itemId: string, infos: ReleaseInfo[]): void {
+function renderReleaseDateChip(
+    context: IdentityContext,
+    container: HTMLElement,
+    itemId: string,
+    region: StreamingRegionCode,
+    infos: ReleaseInfo[],
+): void {
     if (!JC.identity.isCurrent(context)) return;
     const chip = document.createElement('div');
     chip.className = 'mediaInfoItem mediaInfoItem-releaseDate';
     chip.dataset.itemId = itemId;
+    chip.dataset.region = region;
     fillReleaseDateChip(chip, infos);
     container.appendChild(chip);
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/data.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/data.ts
@@ -1,7 +1,7 @@
 // src/seerr/more-info-modal/data.ts
 // Fetch + pure data helpers for the more-info modal (ratings, details,
 // content rating resolution, currency formatting, error reporting).
-import { JC } from '../../globals';
+import { resolveEffectiveStreamingRegion } from '../../core/effective-region';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 
@@ -84,7 +84,7 @@ try {
  */
 function getContentRating(data: any, mediaType: any) {
 // Resolve region: prefer Elsewhere user setting → plugin fallback → US
-const region = ((JC?.userConfig?.elsewhere as any)?.Region || JC?.pluginConfig?.DEFAULT_REGION || 'US')?.toUpperCase();
+const region = resolveEffectiveStreamingRegion();
 
 if (mediaType === 'movie') {
     // For movies: releases.results[].release_dates[].certification

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/effective-region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/effective-region.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { JC } from '../../globals';
+import '../../core/ui-kit';
+import { internal } from './internal';
+import './data';
+import './badges';
+import './render';
+
+describe('Seerr More Info effective region', () => {
+    beforeEach(() => {
+        const context = JC.identity.capture()!;
+        JC.pluginConfig = { TmdbEnabled: true, DEFAULT_REGION: 'ZZ' };
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'zz' }, context),
+        }, context);
+        JC.t = (key: string) => key;
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('uses US rather than unsupported persisted codes for ratings and providers', () => {
+        const data = {
+            title: 'Region test',
+            releases: {
+                results: [
+                    { iso_3166_1: 'ZZ', release_dates: [{ type: 3, certification: 'WRONG' }] },
+                    { iso_3166_1: 'US', release_dates: [{ type: 3, certification: 'PG' }] },
+                ],
+            },
+            watchProviders: [
+                { iso_3166_1: 'ZZ', flatrate: [{ id: 1, name: 'Wrong', logoPath: '/wrong.png' }] },
+                { iso_3166_1: 'US', flatrate: [{ id: 2, name: 'Fallback', logoPath: '/us.png' }] },
+            ],
+        };
+
+        expect(internal.getContentRating(data, 'movie')).toBe('PG');
+
+        const host = document.createElement('div');
+        host.innerHTML = internal.buildModalContent(data, 'movie');
+        expect(host.querySelector<HTMLImageElement>('.jc-more-info-providers-list img')?.alt)
+            .toBe('Fallback');
+        expect(host.textContent).not.toContain('Wrong');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/render.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/more-info-modal/render.ts
@@ -4,6 +4,7 @@
 import { JC } from '../../globals';
 // PERF(R6): no remote assets — flag/icon images served from the local asset cache.
 import { assetUrl, flagPngUrl } from '../../core/asset-urls';
+import { resolveEffectiveStreamingRegion } from '../../core/effective-region';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 
@@ -205,7 +206,7 @@ if (!JC?.pluginConfig?.TmdbEnabled) {
 }
 
 // Resolve region: prefer Elsewhere user setting → plugin fallback → US
-const region = ((JC?.userConfig?.elsewhere as any)?.Region || JC?.pluginConfig?.DEFAULT_REGION || 'US')?.toUpperCase();
+const region = resolveEffectiveStreamingRegion();
 
 // watchProviders is already the array of region objects
 if (!Array.isArray(data.watchProviders)) return '';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.region.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { JC } from '../../globals';
+import type { ApiApi } from '../../types/jc';
+import { internal } from './internal';
+import './badges';
+
+describe('Seerr provider icon effective region', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+        const context = JC.identity.transition('region-test-server', 'region-test-user', 'region-test')!;
+        JC.pluginConfig = {
+            TmdbEnabled: true,
+            DEFAULT_REGION: 'US',
+            DEFAULT_PROVIDERS: '',
+            IGNORE_PROVIDERS: '',
+        };
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'ca' }, context),
+        }, context);
+    });
+
+    afterEach(() => {
+        JC.identity.transition('', '', 'region-test-cleanup');
+        JC.core.api = undefined;
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    it('reads provider icons from the viewer override rather than the admin default', async () => {
+        const card = document.createElement('div');
+        card.className = 'seerr-card';
+        const container = document.createElement('div');
+        card.appendChild(container);
+        document.body.appendChild(card);
+        JC.identity.own(card, JC.identity.capture());
+        JC.core.api = {
+            plugin: vi.fn().mockResolvedValue({
+                results: {
+                    US: { flatrate: [{ provider_name: 'Wrong', logo_path: '/us.png' }] },
+                    CA: { flatrate: [{ provider_name: 'Right', logo_path: '/ca.png' }] },
+                },
+            }),
+        } as unknown as ApiApi;
+
+        await internal.fetchProviderIcons!(container, 42, 'movie');
+
+        expect(container.querySelector('img')?.title).toBe('Right');
+        expect(container.querySelector('img')?.src).toContain('/ca.png');
+    });
+});

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.region.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.region.test.ts
@@ -47,4 +47,31 @@ describe('Seerr provider icon effective region', () => {
         expect(container.querySelector('img')?.title).toBe('Right');
         expect(container.querySelector('img')?.src).toContain('/ca.png');
     });
+
+    it('falls back to US when both persisted user and admin codes are unsupported', async () => {
+        JC.pluginConfig.DEFAULT_REGION = 'ZZ';
+        const context = JC.identity.capture()!;
+        JC.userConfig = JC.identity.own({
+            elsewhere: JC.identity.own({ Region: 'zz' }, context),
+        }, context);
+        const card = document.createElement('div');
+        card.className = 'seerr-card';
+        const container = document.createElement('div');
+        card.appendChild(container);
+        document.body.appendChild(card);
+        JC.identity.own(card, context);
+        JC.core.api = {
+            plugin: vi.fn().mockResolvedValue({
+                results: {
+                    ZZ: { flatrate: [{ provider_name: 'Wrong', logo_path: '/zz.png' }] },
+                    US: { flatrate: [{ provider_name: 'Fallback', logo_path: '/us.png' }] },
+                },
+            }),
+        } as unknown as ApiApi;
+
+        await internal.fetchProviderIcons!(container, 42, 'movie');
+
+        expect(container.querySelector('img')?.title).toBe('Fallback');
+        expect(container.querySelector('img')?.src).toContain('/us.png');
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/seerr/ui/badges.ts
@@ -2,6 +2,7 @@
 // Card badge helpers: status badge, media-type/collection badges and
 // streaming-provider icons.
 import { JC } from '../../globals';
+import { resolveEffectiveStreamingRegion } from '../../core/effective-region';
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- legacy Seerr payload + DOM shapes; typed incrementally */
 
@@ -80,7 +81,7 @@ async function fetchProviderIcons(container: HTMLElement | null, tmdbId: any, me
         return;
     }
 
-    const DEFAULT_REGION = (JC.pluginConfig.DEFAULT_REGION as string) || 'US';
+    const effectiveRegion = resolveEffectiveStreamingRegion();
     const DEFAULT_PROVIDERS = JC.pluginConfig.DEFAULT_PROVIDERS ? (JC.pluginConfig.DEFAULT_PROVIDERS as string).replace(/'/g, '').replace(/\n/g, ',').split(',').map((s: any) => s.trim()).filter((s: any) => s) : [];
     const IGNORE_PROVIDERS = JC.pluginConfig.IGNORE_PROVIDERS ? (JC.pluginConfig.IGNORE_PROVIDERS as string).replace(/'/g, '').replace(/\n/g, ',').split(',').map((s: any) => s.trim()).filter((s: any) => s) : [];
 
@@ -89,7 +90,7 @@ async function fetchProviderIcons(container: HTMLElement | null, tmdbId: any, me
         // non-OK responses throw and land in the catch below.
         const data: any = await JC.core.api!.plugin(`/tmdb/${mediaType}/${tmdbId}/watch/providers`);
         if (!isCurrent()) return;
-        let providers = data.results?.[DEFAULT_REGION]?.flatrate;
+        let providers = data.results?.[effectiveRegion]?.flatrate;
 
         if (providers && providers.length > 0) {
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/types/jc.ts
@@ -30,6 +30,8 @@ export interface PluginConfig {
     ClearLocalStorageTimestamp?: number;
     /** Serve third-party assets from the local plugin cache (default true); see core/asset-urls.ts. */
     AssetCacheEnabled?: boolean;
+    /** Normalized administrator default for TMDB/Seerr region-indexed data. */
+    DEFAULT_REGION?: string;
     /** Gate the in-app Approve/Decline affordance on pending Seerr requests (default true). */
     RequestApprovalsEnabled?: boolean;
     /** Master switch for the server-local Maintainerr integration. */

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -77,7 +77,7 @@ The server-wide defaults live on the **Elsewhere** tab. Each is also used by fea
 
 | Setting | Default | What it does |
 | --- | --- | --- |
-| **Default Region** | `US` (when blank or invalid) | The primary region for availability checks. The selector is populated from Canopy's locally mirrored Elsewhere [region catalog](https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt) when asset caching is enabled, or from that upstream catalog when it is disabled. Legacy lowercase codes are normalized. If the catalog cannot be refreshed, Canopy preserves a syntactically valid saved code—including an uncommon one—instead of silently replacing it. |
+| **Default Region** | `US` (when blank, malformed, or unsupported) | The primary region for availability checks. The selector is populated from Canopy's locally mirrored Elsewhere [region catalog](https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt) when asset caching is enabled, or from that upstream catalog when it is disabled. Legacy lowercase codes are normalized. If the catalog cannot be refreshed, Canopy preserves a supported saved code—including an uncommon one—instead of silently replacing it; unknown legacy values fall back to `US`. |
 | **Default Providers** | Blank (show all) | Comma-separated list of providers to show by default — e.g. `Netflix,Hulu,Disney Plus`. Leave blank to show every provider. Also used by the Seerr streaming icons. [Full list of providers](https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt). |
 | **Ignore Providers** | Blank | Comma-separated list of providers to hide from results. **Supports regex patterns.** Also used by the Seerr streaming icons. |
 

--- a/docs/discover.md
+++ b/docs/discover.md
@@ -55,7 +55,7 @@ Elsewhere requires a **TMDB API key**. Everything else ships ready to go — **E
 2. Open the **Elsewhere** tab.
 3. Confirm **Enable Elsewhere** is checked (it is on by default).
 4. Enter your **TMDB API Key**.
-5. Select your **Default Region** (for example US, GB, DE).
+5. Select your **Default Region** from the mirrored Elsewhere region catalog.
 6. Optionally configure default and ignored providers (see below).
 7. Click **Save**.
 
@@ -77,7 +77,7 @@ The server-wide defaults live on the **Elsewhere** tab. Each is also used by fea
 
 | Setting | Default | What it does |
 | --- | --- | --- |
-| **Default Region** | `US` (when blank) | The primary region for availability checks. Also used by **TMDB Release Dates** and the **Seerr streaming icons**. Examples: `US`, `GB`, `DE`, `FR`, `ES`, `IT`. [Full list of regions](https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt). |
+| **Default Region** | `US` (when blank or invalid) | The primary region for availability checks. The selector is populated from Canopy's locally mirrored Elsewhere [region catalog](https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/regions.txt) when asset caching is enabled, or from that upstream catalog when it is disabled. Legacy lowercase codes are normalized. If the catalog cannot be refreshed, Canopy preserves a syntactically valid saved code—including an uncommon one—instead of silently replacing it. |
 | **Default Providers** | Blank (show all) | Comma-separated list of providers to show by default — e.g. `Netflix,Hulu,Disney Plus`. Leave blank to show every provider. Also used by the Seerr streaming icons. [Full list of providers](https://cdn.jsdelivr.net/gh/n00bcodr/Jellyfin-Elsewhere/resources/providers.txt). |
 | **Ignore Providers** | Blank | Comma-separated list of providers to hide from results. **Supports regex patterns.** Also used by the Seerr streaming icons. |
 
@@ -113,12 +113,14 @@ Everything above is the server-wide admin default. Any user can override the reg
 
 | Control | What it does |
 | --- | --- |
-| **Region** | A primary region select that overrides the admin **Default Region** for this user. |
+| **Region** | A primary region select that overrides the admin **Default Region** for this user. Choose **Use server default** to clear the override and inherit the admin's current value. |
 | **Add other countries** | An autocomplete for adding extra regions. When set, the panel's **Search** button looks the title up across every selected region at once. |
 | **Providers** | A provider-filter autocomplete that overrides the admin **Default Providers** for this user. Leave it empty to show every provider. |
 | **Search** | Runs the multi-region lookup for the chosen region(s) and shows availability for each. |
 
-Each user's choices are saved server-side to their own `elsewhere.json`, so they persist across devices and never change the admin defaults or anyone else's view. A user who never opens the dialog keeps the admin Default Region and Default Providers.
+Each user's choices are saved server-side to their own `elsewhere.json`, so they persist across devices and never change the admin defaults or anyone else's view. A user who never opens the dialog—or resets **Region** to **Use server default**—inherits the admin Default Region, including later admin changes.
+
+Canopy resolves one effective region for each signed-in user: a valid per-user override wins, otherwise the current admin default is used, and `US` is the final fallback. That effective region is used consistently by the automatic Elsewhere lookup and its labels, TMDB movie release-date selection, Seerr streaming-provider icons and More Info certifications/providers, and discovery watch-provider requests.
 
 ### Streaming posters on Seerr cards
 
@@ -128,7 +130,7 @@ Elsewhere's provider data can also appear on Seerr discovery and result cards, s
 2. Check **Show Streaming Providers on Posters**.
 3. Click **Save**.
 
-The cards then carry the same provider information shown on item pages. This uses the shared TMDB key and the same Default Region / provider settings.
+The cards then carry the same provider information shown on item pages. This uses the shared TMDB key and the user's effective region, plus their provider settings.
 
 ### Privacy, limitations & troubleshooting
 

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -413,7 +413,8 @@ There's also an admin-only chip for release dates:
 !!! note "Show Release/Air Date needs TMDB"
 
     The chip only takes effect once a **TMDB API Key** is set, and it uses the
-    **Default Region** you configure for Elsewhere to choose which country's
+    user's **effective region** (their Elsewhere Region override, or the current
+    admin **Default Region** when they choose **Use server default**) to choose which country's
     release dates to prefer (falling back to US, then any region TMDB has for that
     release type). Both are covered in [Discover & Request](discover.md).
 

--- a/e2e/reviews-gating.spec.ts
+++ b/e2e/reviews-gating.spec.ts
@@ -137,7 +137,7 @@ test.describe('reviews gating', () => {
             elsewhere.dispatchEvent(new Event('input', { bubbles: true }));
 
             function probe(id: string) {
-                const el = document.getElementById(id) as HTMLInputElement;
+                const el = document.getElementById(id) as HTMLInputElement | HTMLSelectElement;
                 const container = el.closest('.inputContainer') as HTMLElement | null;
                 return {
                     disabled: el.disabled,

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 183,
+    "maxOutputCount": 185,
     "maxEsmEntryCount": 38,
-    "maxEsmOutputCount": 88,
+    "maxEsmOutputCount": 89,
     "maxIndividualEsmRawBytes": 262144,
     "maxBootRequests": 17,
     "maxBootRawBytes": 524288,
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7445214,
+    "maxTotalRawBytes": 7458290,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7534008
+    "maxPublishedRawBytes": 7547985
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,12 +25,12 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2944, totalLines: 3329 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2967, totalLines: 3352 });
     assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45123, totalLines: 54910 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 2944,
-        maximumCoveredLines: 2944,
+        minimumCoveredLines: 2967,
+        maximumCoveredLines: 2967,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 6,

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2974, totalLines: 3359 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45143, totalLines: 54938 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45147, totalLines: 54938 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2974,
         maximumCoveredLines: 2974,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 2,
+        cleanRuns: 3,
         minimumCoveredLines: 45140,
-        maximumCoveredLines: 45143,
+        maximumCoveredLines: 45147,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2974, totalLines: 3359 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45147, totalLines: 54938 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45148, totalLines: 54938 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2974,
         maximumCoveredLines: 2974,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
+        cleanRuns: 4,
         minimumCoveredLines: 45140,
-        maximumCoveredLines: 45147,
+        maximumCoveredLines: 45148,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 8);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -25,20 +25,20 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         baselines.policy.description,
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
-    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2967, totalLines: 3352 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45123, totalLines: 54910 });
+    assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2974, totalLines: 3359 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45143, totalLines: 54939 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 2967,
-        maximumCoveredLines: 2967,
+        minimumCoveredLines: 2974,
+        maximumCoveredLines: 2974,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 6,
-        minimumCoveredLines: 45115,
-        maximumCoveredLines: 45123,
+        cleanRuns: 2,
+        minimumCoveredLines: 45141,
+        maximumCoveredLines: 45143,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 8);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2974, totalLines: 3359 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45143, totalLines: 54939 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45143, totalLines: 54938 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2974,
@@ -34,11 +34,11 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 45141,
+        minimumCoveredLines: 45140,
         maximumCoveredLines: 45143,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 2);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 45147,
+        "coveredLines": 45148,
         "totalLines": 54938
       },
       "observations": {
-        "cleanRuns": 3,
+        "cleanRuns": 4,
         "minimumCoveredLines": 45140,
-        "maximumCoveredLines": 45147
+        "maximumCoveredLines": 45148
       },
       "tolerance": {
-        "missingCoveredLines": 7,
-        "rationale": "Issue #709 routes the server Seerr parental certification and certification-cache region through the shared 139-code membership authority, with orchestration regressions proving an unsupported persisted ZZ value uses the divergent US certification/cache partition while supported uncommon XK remains distinct. Two clean local .NET 10.0.9 full-suite runs and the clean hosted exact-head run on this exact 54,938-line source and 4,314-test scope passed every test and measured 45,140/54,938 (82.165%), 45,143/54,938 (82.171%), and 45,147/54,938 (82.178%). The reviewed observed high-water is therefore 45,147/54,938 and the exact observed floor is 45,140/54,938; the seven-line instrumentation spread is 0.012742 percentage points, within the 0.15-point policy maximum. Hosted evidence: GitHub Actions run 31880813419, Unit job 95003008339. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 8,
+        "rationale": "Issue #709 routes the server Seerr parental certification and certification-cache region through the shared 139-code membership authority, with orchestration regressions proving an unsupported persisted ZZ value uses the divergent US certification/cache partition while supported uncommon XK remains distinct. Two clean local .NET 10.0.9 full-suite runs and two clean hosted runs on this exact 54,938-line source and 4,314-test scope passed every test and measured 45,140/54,938 (82.165%), 45,143/54,938 (82.171%), 45,147/54,938 (82.178%), and 45,148/54,938 (82.180%). The reviewed observed high-water is therefore 45,148/54,938 and the exact observed floor is 45,140/54,938; the eight-line instrumentation spread is 0.014562 percentage points, within the 0.15-point policy maximum. Hosted evidence: GitHub Actions runs 31880813419 (Unit job 95003008339) and 31884925057 (Unit job 95012731245). coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -28,16 +28,16 @@
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
         "coveredLines": 45143,
-        "totalLines": 54939
+        "totalLines": 54938
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 45141,
+        "minimumCoveredLines": 45140,
         "maximumCoveredLines": 45143
       },
       "tolerance": {
-        "missingCoveredLines": 2,
-        "rationale": "Issue #709 adds the shared effective-region resolver and the synchronous 139-code membership contract used by administrator settings, per-user settings, Elsewhere, TMDB release dates, discovery and Seerr, plus focused cross-consumer regressions. Two clean local .NET 10.0.9 full-suite runs on this exact 54,939-line source and 4,312-test scope passed every test and measured 45,141/54,939 (82.166%) and 45,143/54,939 (82.169%). The reviewed observed high-water is therefore 45,143/54,939 and the exact observed floor is 45,141/54,939; the two-line instrumentation spread is 0.003640 percentage points, within the 0.15-point policy maximum. Earlier suite-load runs with unrelated timing-bound tests failing are excluded from the clean-run envelope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 3,
+        "rationale": "Issue #709 routes the server Seerr parental certification and certification-cache region through the shared 139-code membership authority, with orchestration regressions proving an unsupported persisted ZZ value uses the divergent US certification/cache partition while supported uncommon XK remains distinct. Two clean local .NET 10.0.9 full-suite runs on this exact 54,938-line source and 4,314-test scope passed every test and measured 45,140/54,938 (82.165%) and 45,143/54,938 (82.171%). The reviewed observed high-water is therefore 45,143/54,938 and the exact observed floor is 45,140/54,938; the three-line instrumentation spread is 0.005461 percentage points, within the 0.15-point policy maximum. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 45143,
+        "coveredLines": 45147,
         "totalLines": 54938
       },
       "observations": {
-        "cleanRuns": 2,
+        "cleanRuns": 3,
         "minimumCoveredLines": 45140,
-        "maximumCoveredLines": 45143
+        "maximumCoveredLines": 45147
       },
       "tolerance": {
-        "missingCoveredLines": 3,
-        "rationale": "Issue #709 routes the server Seerr parental certification and certification-cache region through the shared 139-code membership authority, with orchestration regressions proving an unsupported persisted ZZ value uses the divergent US certification/cache partition while supported uncommon XK remains distinct. Two clean local .NET 10.0.9 full-suite runs on this exact 54,938-line source and 4,314-test scope passed every test and measured 45,140/54,938 (82.165%) and 45,143/54,938 (82.171%). The reviewed observed high-water is therefore 45,143/54,938 and the exact observed floor is 45,140/54,938; the three-line instrumentation spread is 0.005461 percentage points, within the 0.15-point policy maximum. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 7,
+        "rationale": "Issue #709 routes the server Seerr parental certification and certification-cache region through the shared 139-code membership authority, with orchestration regressions proving an unsupported persisted ZZ value uses the divergent US certification/cache partition while supported uncommon XK remains distinct. Two clean local .NET 10.0.9 full-suite runs and the clean hosted exact-head run on this exact 54,938-line source and 4,314-test scope passed every test and measured 45,140/54,938 (82.165%), 45,143/54,938 (82.171%), and 45,147/54,938 (82.178%). The reviewed observed high-water is therefore 45,147/54,938 and the exact observed floor is 45,140/54,938; the seven-line instrumentation spread is 0.012742 percentage points, within the 0.15-point policy maximum. Hosted evidence: GitHub Actions run 31880813419, Unit job 95003008339. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,17 +10,17 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2944,
-        "totalLines": 3329
+        "coveredLines": 2967,
+        "totalLines": 3352
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 2944,
-        "maximumCoveredLines": 2944
+        "minimumCoveredLines": 2967,
+        "maximumCoveredLines": 2967
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "Issue #670 adds the shared ambiguity-safe file-source detector used by poster badges and item details, including canonical source normalization, symmetric generic-versus-specific evidence merging, legacy BluRay suffix compatibility, and multi-version consensus handling. Two clean full client runs on this exact 3,329-line core scope and 2,399-test tree both passed every test and measured 2,944/3,329 (88.435%), advancing the prior 2,943-line high-water by one fully covered line and improving the reviewed ratio from 88.431% with no instrumentation spread. The reviewed observed high-water and exact observed floor are therefore both 2,944/3,329 with zero tolerance. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "Issue #709 adds the shared typed effective-region resolver and catalog parser used by Elsewhere, TMDB release dates, Seerr provider icons and More Info, and discovery provider requests. Two clean full client runs on this exact 3,352-line core scope and 2,415-test tree both passed every test and measured 2,967/3,352 (88.514%), adding 23 fully covered instrumented lines and improving the reviewed ratio from 2,944/3,329 (88.435%) with no instrumentation spread. The reviewed observed high-water and exact observed floor are therefore both 2,967/3,352 with zero tolerance. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
       }
     },
     "server": {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -10,34 +10,34 @@
       "scope": "Jellyfin.Plugin.JellyfinCanopy/src/core/**",
       "report": "coverage/coverage-summary.json",
       "measured": {
-        "coveredLines": 2967,
-        "totalLines": 3352
+        "coveredLines": 2974,
+        "totalLines": 3359
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 2967,
-        "maximumCoveredLines": 2967
+        "minimumCoveredLines": 2974,
+        "maximumCoveredLines": 2974
       },
       "tolerance": {
         "missingCoveredLines": 0,
-        "rationale": "Issue #709 adds the shared typed effective-region resolver and catalog parser used by Elsewhere, TMDB release dates, Seerr provider icons and More Info, and discovery provider requests. Two clean full client runs on this exact 3,352-line core scope and 2,415-test tree both passed every test and measured 2,967/3,352 (88.514%), adding 23 fully covered instrumented lines and improving the reviewed ratio from 2,944/3,329 (88.435%) with no instrumentation spread. The reviewed observed high-water and exact observed floor are therefore both 2,967/3,352 with zero tolerance. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
+        "rationale": "Issue #709 adds the shared typed effective-region resolver and catalog parser used by Elsewhere, TMDB release dates, Seerr provider icons and More Info, and discovery provider requests, then closes the review boundary with a synchronous 139-code supported-region membership contract so unknown legacy values cannot reach any consumer. Clean full client runs on this exact 3,359-line core scope measured 2,974/3,359 (88.538%) without instrumentation spread; the final post-rebase 2,432-test tree also passed every test at that exact measurement. The change adds seven fully covered instrumented lines and improves the reviewed ratio from 2,967/3,352 (88.514%). The reviewed observed high-water and exact observed floor are therefore both 2,974/3,359 with zero tolerance. coverage-baseline.test.js retains the exact below-floor, above-baseline, scope-change, observed-high-water, and broad-tolerance negative boundaries."
       }
     },
     "server": {
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 45123,
-        "totalLines": 54910
+        "coveredLines": 45143,
+        "totalLines": 54939
       },
       "observations": {
-        "cleanRuns": 6,
-        "minimumCoveredLines": 45115,
-        "maximumCoveredLines": 45123
+        "cleanRuns": 2,
+        "minimumCoveredLines": 45141,
+        "maximumCoveredLines": 45143
       },
       "tolerance": {
-        "missingCoveredLines": 8,
-        "rationale": "Issue #670 adds the independently persisted ShowFileSource setting to the canonical admin and per-user configuration contracts and covers the fail-closed unknown-target and unsupported-evidence branches in the admin target settings controller. Three clean local .NET 10.0.10 full-suite runs on this exact 54,910-line source and 4,302-test scope passed every test and each measured 45,115/54,910 covered lines (82.162%). Hosted Unit runs at exact reviewed heads bdf916990739dc39f273601544d7546e50614e68 and f0bd15ebdb818629302bb49b033167b2c53cf4db passed all 4,302 tests and measured 45,121/54,910 (82.173%) and 45,122/54,910 (82.174%): GitHub Actions runs 31081606003/job/92551460291 and 31098714654/job/92606837612. The clean hosted Unit run at exact #710 head 1c2efa34f913f6a58c76820e5b16b5e263118764 also passed all 4,302 tests and measured 45,123/54,910 (82.176%): GitHub Actions run 31882082338/job/95005978501. The reviewed high-water is therefore 45,123/54,910, while the directly observed identical-scope floor remains 45,115/54,910; the eight-line spread is 0.014569 percentage points, within the 0.15-point policy maximum. One separate non-clean 4,301/4,302 local run is excluded from the six-run coverage envelope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 2,
+        "rationale": "Issue #709 adds the shared effective-region resolver and the synchronous 139-code membership contract used by administrator settings, per-user settings, Elsewhere, TMDB release dates, discovery and Seerr, plus focused cross-consumer regressions. Two clean local .NET 10.0.9 full-suite runs on this exact 54,939-line source and 4,312-test scope passed every test and measured 45,141/54,939 (82.166%) and 45,143/54,939 (82.169%). The reviewed observed high-water is therefore 45,143/54,939 and the exact observed floor is 45,141/54,939; the two-line instrumentation spread is 0.003640 percentage points, within the 0.15-point policy maximum. Earlier suite-load runs with unrelated timing-bound tests failing are excluded from the clean-run envelope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #709.

## Summary

- replace the free-text administrator region with the locally mirrored supported-region catalog
- resolve one normalized effective region consistently across Elsewhere, release dates, discovery, Seerr presentation, and parental certification/cache paths
- preserve supported uncommon values during catalog outages while deterministically falling unknown values back to US
- add per-user inherit/reset behavior, identity-scoped caches, server/client catalog parity, documentation, and regression coverage

## Validation

- focused client tests: 26 passed
- focused server/normalizer tests: 56 passed during implementation
- full client coverage: 2,432 passed; exact coverage ratchet passed
- full server coverage: 4,314 passed; exact coverage ratchet passed
- script tests: 655 passed
- source and legacy typechecks passed
- performance, syntax, strict docs, changed-file lint, deterministic bundle, Release build, and diff checks passed
- independent terminal review approved the current-main branch