### PR TITLE
feat: normalize German FSK ratings

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -222,6 +222,30 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.dataset.jcColoredRating).toBeUndefined();
     });
 
+    it('captures last-moment host state before immediate detached identity teardown', () => {
+        const rating = addRating('DE-12');
+        rating.setAttribute('rating', 'host-rating-12');
+        rating.setAttribute('aria-label', 'Host DE-12 label');
+        rating.setAttribute('title', 'Host DE-12 title');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        // Model React repopulating a retained node and identity teardown in the
+        // same task, before either MutationObserver callback can run.
+        rating.firstChild!.nodeValue = 'DE-16';
+        rating.setAttribute('rating', 'host-rating-16');
+        rating.setAttribute('aria-label', 'Host DE-16 label');
+        rating.setAttribute('title', 'Host DE-16 title');
+        rating.remove();
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+
+        expect(rating.textContent).toBe('DE-16');
+        expect(rating.getAttribute('rating')).toBe('host-rating-16');
+        expect(rating.getAttribute('aria-label')).toBe('Host DE-16 label');
+        expect(rating.getAttribute('title')).toBe('Host DE-16 title');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
     it('preserves host metadata for unsupported FSK-prefixed values', () => {
         const rating = addRating('FSK-21');
         rating.setAttribute('aria-label', 'Host unknown FSK label');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -73,4 +73,46 @@ describe('colored ratings identity lifecycle', () => {
         expect(JC.core.navigation!.getNavCallbackCount()).toBe(navCount);
         expect(document.querySelectorAll('[data-jc-colored-rating="true"]')).toHaveLength(1);
     });
+
+    it('keeps the visible and accessible FSK value canonical, then restores host state', () => {
+        const rating = addRating('DE-12');
+        rating.setAttribute('rating', 'host-rating');
+        rating.setAttribute('aria-label', 'Host DE-12 label');
+        rating.setAttribute('title', 'Host DE-12 title');
+
+        JC.initializeColoredRatings!();
+
+        expect(rating.textContent).toBe('FSK-12');
+        expect(rating.getAttribute('rating')).toBe('FSK-12');
+        expect(rating.getAttribute('aria-label')).toBe('Content rated FSK-12');
+        expect(rating.getAttribute('title')).toBe('Rating: FSK-12');
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('DE-12');
+        expect(rating.getAttribute('rating')).toBe('host-rating');
+        expect(rating.getAttribute('aria-label')).toBe('Host DE-12 label');
+        expect(rating.getAttribute('title')).toBe('Host DE-12 title');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
+    it('updates a retained host node to a new FSK value and restores the latest source text', () => {
+        const rating = addRating('FSK 6');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-6');
+
+        rating.textContent = 'DE-16';
+        JC.resumeRatingsPolling!();
+        vi.advanceTimersByTime(100);
+
+        expect(rating.textContent).toBe('FSK-16');
+        expect(rating.getAttribute('rating')).toBe('FSK-16');
+        expect(rating.getAttribute('aria-label')).toBe('Content rated FSK-16');
+        expect(rating.getAttribute('title')).toBe('Rating: FSK-16');
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('DE-16');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -119,6 +119,26 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.hasAttribute('title')).toBe(false);
     });
 
+    it('retains a late host write equal to the canonical rendered text', async () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        // Move beyond navigation settling, then model a new item's already-
+        // canonical host value on the retained text node. The value comparison
+        // is equal, but the characterData record still transfers ownership.
+        await vi.advanceTimersByTimeAsync(600);
+        rating.firstChild!.nodeValue = 'FSK-12';
+        await vi.advanceTimersByTimeAsync(100);
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('FSK-12');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
     it('updates plugin-owned accessibility metadata from FSK to non-FSK', async () => {
         const rating = addRating('DE-12');
         JC.initializeColoredRatings!();
@@ -244,6 +264,60 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.getAttribute('aria-label')).toBe('Host DE-16 label');
         expect(rating.getAttribute('title')).toBe('Host DE-16 title');
         expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
+    it('drains an equal canonical host write before immediate detached identity teardown', () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        // No microtask/timer yield: teardown must drain the observer record
+        // before disconnect() would otherwise discard it.
+        rating.firstChild!.nodeValue = 'FSK-12';
+        rating.remove();
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+
+        expect(rating.textContent).toBe('FSK-12');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
+    it('preserves host accessibility metadata on predecessor-marker cleanup', () => {
+        const rating = addRating('PG-13');
+        rating.setAttribute('rating', 'stale-plugin-rating');
+        rating.setAttribute('aria-label', 'Host rating label');
+        rating.setAttribute('title', 'Host rating title');
+        rating.dataset.jcColoredRating = 'true';
+
+        resetColoredRatings();
+
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.getAttribute('aria-label')).toBe('Host rating label');
+        expect(rating.getAttribute('title')).toBe('Host rating title');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+        expect(rating.dataset.jcColoredRatingAria).toBeUndefined();
+        expect(rating.dataset.jcColoredRatingTitle).toBeUndefined();
+    });
+
+    it('removes accessibility metadata proven owned by predecessor markers', () => {
+        const rating = addRating('PG-13');
+        rating.setAttribute('rating', 'PG-13');
+        rating.setAttribute('aria-label', 'Content rated PG-13');
+        rating.setAttribute('title', 'Rating: PG-13');
+        rating.dataset.jcColoredRating = 'true';
+        rating.dataset.jcColoredRatingAria = 'true';
+        rating.dataset.jcColoredRatingTitle = 'true';
+
+        resetColoredRatings();
+
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+        expect(rating.dataset.jcColoredRatingAria).toBeUndefined();
+        expect(rating.dataset.jcColoredRatingTitle).toBeUndefined();
     });
 
     it('preserves host metadata for unsupported FSK-prefixed values', () => {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -170,6 +170,58 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.hasAttribute('title')).toBe(false);
     });
 
+    it('restores and re-observes a rating removed then re-attached by the host', async () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        rating.firstChild!.nodeValue = 'DE-16';
+        rating.remove();
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(rating.textContent).toBe('DE-16');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+
+        document.body.appendChild(rating);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(rating.textContent).toBe('FSK-16');
+
+        rating.firstChild!.nodeValue = 'DE-18';
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(rating.textContent).toBe('FSK-18');
+        expect(rating.getAttribute('rating')).toBe('FSK-18');
+        expect(rating.getAttribute('aria-label')).toBe('Content rated FSK-18');
+        expect(rating.getAttribute('title')).toBe('Rating: FSK-18');
+    });
+
+    it('restores a detached rating during identity teardown before re-attachment', async () => {
+        const rating = addRating('DE-12');
+        rating.setAttribute('rating', 'host-rating');
+        rating.setAttribute('aria-label', 'Host DE-12 label');
+        rating.setAttribute('title', 'Host DE-12 title');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        rating.remove();
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+
+        expect(rating.textContent).toBe('DE-12');
+        expect(rating.getAttribute('rating')).toBe('host-rating');
+        expect(rating.getAttribute('aria-label')).toBe('Host DE-12 label');
+        expect(rating.getAttribute('title')).toBe('Host DE-12 title');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+
+        document.body.appendChild(rating);
+        await vi.advanceTimersByTimeAsync(200);
+        expect(rating.textContent).toBe('DE-12');
+        expect(rating.getAttribute('rating')).toBe('host-rating');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
     it('preserves host metadata for unsupported FSK-prefixed values', () => {
         const rating = addRating('FSK-21');
         rating.setAttribute('aria-label', 'Host unknown FSK label');

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -95,14 +95,17 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.dataset.jcColoredRating).toBeUndefined();
     });
 
-    it('updates a retained host node to a new FSK value and restores the latest source text', () => {
+    it('updates a retained text node through the production observer path', async () => {
         const rating = addRating('FSK 6');
         JC.initializeColoredRatings!();
         expect(rating.textContent).toBe('FSK-6');
 
-        rating.textContent = 'DE-16';
-        JC.resumeRatingsPolling!();
-        vi.advanceTimersByTime(100);
+        // Move beyond the fixed navigation-settle window, then model React's
+        // retained text-node update. No compatibility resume hook is invoked.
+        await vi.advanceTimersByTimeAsync(600);
+        expect(rating.firstChild).toBeInstanceOf(Text);
+        rating.firstChild!.nodeValue = 'DE-16';
+        await vi.advanceTimersByTimeAsync(100);
 
         expect(rating.textContent).toBe('FSK-16');
         expect(rating.getAttribute('rating')).toBe('FSK-16');
@@ -114,5 +117,69 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.hasAttribute('rating')).toBe(false);
         expect(rating.hasAttribute('aria-label')).toBe(false);
         expect(rating.hasAttribute('title')).toBe(false);
+    });
+
+    it('updates plugin-owned accessibility metadata from FSK to non-FSK', async () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+
+        rating.firstChild!.nodeValue = 'PG-13';
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(rating.textContent).toBe('PG-13');
+        expect(rating.getAttribute('rating')).toBe('PG-13');
+        expect(rating.getAttribute('aria-label')).toBe('Content rated PG-13');
+        expect(rating.getAttribute('title')).toBe('Rating: PG-13');
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('PG-13');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+    });
+
+    it('restores host accessibility metadata when a retained FSK node becomes non-FSK', async () => {
+        const rating = addRating('DE-12');
+        rating.setAttribute('aria-label', 'Host rating label');
+        rating.setAttribute('title', 'Host rating title');
+        JC.initializeColoredRatings!();
+
+        rating.firstChild!.nodeValue = 'PG-13';
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(rating.getAttribute('aria-label')).toBe('Host rating label');
+        expect(rating.getAttribute('title')).toBe('Host rating title');
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('PG-13');
+        expect(rating.getAttribute('aria-label')).toBe('Host rating label');
+        expect(rating.getAttribute('title')).toBe('Host rating title');
+    });
+
+    it('does not process retained text updates after lifecycle cleanup', async () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        resetColoredRatings();
+
+        rating.firstChild!.nodeValue = 'DE-16';
+        await vi.advanceTimersByTimeAsync(200);
+
+        expect(rating.textContent).toBe('DE-16');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+    });
+
+    it('preserves host metadata for unsupported FSK-prefixed values', () => {
+        const rating = addRating('FSK-21');
+        rating.setAttribute('aria-label', 'Host unknown FSK label');
+        rating.setAttribute('title', 'Host unknown FSK title');
+
+        JC.initializeColoredRatings!();
+
+        expect(rating.textContent).toBe('FSK-21');
+        expect(rating.getAttribute('rating')).toBe('FSK-21');
+        expect(rating.getAttribute('aria-label')).toBe('Host unknown FSK label');
+        expect(rating.getAttribute('title')).toBe('Host unknown FSK title');
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -284,6 +284,46 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.dataset.jcColoredRating).toBeUndefined();
     });
 
+    it('drains equal canonical host metadata before immediate detached identity teardown', () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        expect(rating.getAttribute('rating')).toBe('FSK-12');
+
+        // These same-value writes still transfer ownership to the host. No
+        // microtask/timer yield occurs before the retained node is detached.
+        rating.firstChild!.nodeValue = 'FSK-12';
+        rating.setAttribute('rating', 'FSK-12');
+        rating.setAttribute('aria-label', 'Content rated FSK-12');
+        rating.setAttribute('title', 'Rating: FSK-12');
+        rating.remove();
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+
+        expect(rating.textContent).toBe('FSK-12');
+        expect(rating.getAttribute('rating')).toBe('FSK-12');
+        expect(rating.getAttribute('aria-label')).toBe('Content rated FSK-12');
+        expect(rating.getAttribute('title')).toBe('Rating: FSK-12');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
+    it('retains delayed equal canonical host metadata through reset', async () => {
+        const rating = addRating('DE-16');
+        JC.initializeColoredRatings!();
+        await vi.advanceTimersByTimeAsync(600);
+
+        rating.firstChild!.nodeValue = 'FSK-16';
+        rating.setAttribute('rating', 'FSK-16');
+        rating.setAttribute('aria-label', 'Content rated FSK-16');
+        rating.setAttribute('title', 'Rating: FSK-16');
+        await vi.advanceTimersByTimeAsync(100);
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('FSK-16');
+        expect(rating.getAttribute('rating')).toBe('FSK-16');
+        expect(rating.getAttribute('aria-label')).toBe('Content rated FSK-16');
+        expect(rating.getAttribute('title')).toBe('Rating: FSK-16');
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
     it('preserves host accessibility metadata on predecessor-marker cleanup', () => {
         const rating = addRating('PG-13');
         rating.setAttribute('rating', 'stale-plugin-rating');
@@ -293,7 +333,7 @@ describe('colored ratings identity lifecycle', () => {
 
         resetColoredRatings();
 
-        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.getAttribute('rating')).toBe('stale-plugin-rating');
         expect(rating.getAttribute('aria-label')).toBe('Host rating label');
         expect(rating.getAttribute('title')).toBe('Host rating title');
         expect(rating.dataset.jcColoredRating).toBeUndefined();
@@ -315,6 +355,25 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.hasAttribute('rating')).toBe(false);
         expect(rating.hasAttribute('aria-label')).toBe(false);
         expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+        expect(rating.dataset.jcColoredRatingAria).toBeUndefined();
+        expect(rating.dataset.jcColoredRatingTitle).toBeUndefined();
+    });
+
+    it('preserves host-replaced metadata despite predecessor ownership markers', () => {
+        const rating = addRating('PG-13');
+        rating.setAttribute('rating', 'host-rating');
+        rating.setAttribute('aria-label', 'Host replacement label');
+        rating.setAttribute('title', 'Host replacement title');
+        rating.dataset.jcColoredRating = 'true';
+        rating.dataset.jcColoredRatingAria = 'true';
+        rating.dataset.jcColoredRatingTitle = 'true';
+
+        resetColoredRatings();
+
+        expect(rating.getAttribute('rating')).toBe('host-rating');
+        expect(rating.getAttribute('aria-label')).toBe('Host replacement label');
+        expect(rating.getAttribute('title')).toBe('Host replacement title');
         expect(rating.dataset.jcColoredRating).toBeUndefined();
         expect(rating.dataset.jcColoredRatingAria).toBeUndefined();
         expect(rating.dataset.jcColoredRatingTitle).toBeUndefined();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.identity.test.ts
@@ -139,6 +139,26 @@ describe('colored ratings identity lifecycle', () => {
         expect(rating.dataset.jcColoredRating).toBeUndefined();
     });
 
+    it('retains a delayed equal canonical host text-child replacement through reset', async () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        // React can replace the text child via textContent instead of mutating
+        // the retained Text node. The resulting childList record is ownership
+        // evidence even though the visible value is unchanged.
+        await vi.advanceTimersByTimeAsync(600);
+        rating.textContent = 'FSK-12';
+        await vi.advanceTimersByTimeAsync(250);
+
+        resetColoredRatings();
+        expect(rating.textContent).toBe('FSK-12');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
     it('updates plugin-owned accessibility metadata from FSK to non-FSK', async () => {
         const rating = addRating('DE-12');
         JC.initializeColoredRatings!();
@@ -274,6 +294,24 @@ describe('colored ratings identity lifecycle', () => {
         // No microtask/timer yield: teardown must drain the observer record
         // before disconnect() would otherwise discard it.
         rating.firstChild!.nodeValue = 'FSK-12';
+        rating.remove();
+        switchIdentity('ratings-server-b', 'ratings-user-b');
+
+        expect(rating.textContent).toBe('FSK-12');
+        expect(rating.hasAttribute('rating')).toBe(false);
+        expect(rating.hasAttribute('aria-label')).toBe(false);
+        expect(rating.hasAttribute('title')).toBe(false);
+        expect(rating.dataset.jcColoredRating).toBeUndefined();
+    });
+
+    it('drains an equal canonical host text-child replacement before detached identity teardown', () => {
+        const rating = addRating('DE-12');
+        JC.initializeColoredRatings!();
+        expect(rating.textContent).toBe('FSK-12');
+
+        // No observer delivery or timer yield: teardown must drain the queued
+        // childList record before disconnecting the element-scoped observer.
+        rating.textContent = 'FSK-12';
         rating.remove();
         switchIdentity('ratings-server-b', 'ratings-user-b');
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.test.ts
@@ -3,7 +3,7 @@
 // observer (PERF(R3/R5) fix). Only batches that can actually contain rating elements
 // may schedule the full-document processing pass.
 import { describe, expect, it } from 'vitest';
-import { mutationsTouchRatings } from './colored-ratings';
+import { mutationsTouchRatings, normalizeRating } from './colored-ratings';
 
 function record(partial: Partial<MutationRecord>): MutationRecord {
     return {
@@ -61,5 +61,22 @@ describe('mutationsTouchRatings', () => {
             record({ addedNodes: [text] as unknown as NodeList })
         ];
         expect(mutationsTouchRatings(batch)).toBe(false);
+    });
+});
+
+describe('normalizeRating', () => {
+    it.each([
+        ['DE-0', 'FSK-0'],
+        ['de-6', 'FSK-6'],
+        ['FSK12', 'FSK-12'],
+        ['fsk 16', 'FSK-16'],
+        ['FSK-18', 'FSK-18'],
+    ])('canonicalizes supported German alias %s', (input, expected) => {
+        expect(normalizeRating(input)).toBe(expected);
+        expect(normalizeRating(expected)).toBe(expected);
+    });
+
+    it.each(['DE-15', 'FSK-21', 'DE12', 'US-12', 'TV-14'])('does not rewrite %s', (input) => {
+        expect(normalizeRating(input)).toBe(input);
     });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.test.ts
@@ -73,13 +73,15 @@ describe('mutationsTouchRatings', () => {
 });
 
 describe('normalizeRating', () => {
-    it.each([
-        ['DE-0', 'FSK-0'],
-        ['de-6', 'FSK-6'],
-        ['FSK12', 'FSK-12'],
-        ['fsk 16', 'FSK-16'],
-        ['FSK-18', 'FSK-18'],
-    ])('canonicalizes supported German alias %s', (input, expected) => {
+    const ages = ['0', '6', '12', '16', '18'] as const;
+    const supportedAliases = ages.flatMap((age) => [
+        [`DE-${age}`, `FSK-${age}`],
+        [`FSK${age}`, `FSK-${age}`],
+        [`FSK ${age}`, `FSK-${age}`],
+        [`FSK-${age}`, `FSK-${age}`],
+    ] as const);
+
+    it.each(supportedAliases)('canonicalizes supported German alias %s', (input, expected) => {
         expect(normalizeRating(input)).toBe(expected);
         expect(normalizeRating(expected)).toBe(expected);
     });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.test.ts
@@ -32,6 +32,14 @@ describe('mutationsTouchRatings', () => {
         expect(mutationsTouchRatings(batch)).toBe(true);
     });
 
+    it('matches a removed rating subtree so element observers can be pruned', () => {
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = '<span class="mediaInfoOfficialRating">PG-13</span>';
+
+        const batch = [record({ removedNodes: [wrapper] as unknown as NodeList })];
+        expect(mutationsTouchRatings(batch)).toBe(true);
+    });
+
     it('matches a childList change whose target is a rating element (text swap)', () => {
         const rating = document.createElement('div');
         rating.className = 'mediaInfoOfficialRating';

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -46,7 +46,7 @@ interface RatingElementState {
     ownsAriaLabel: boolean;
     ownsTitle: boolean;
 }
-let elementStates = new WeakMap<HTMLElement, RatingElementState>();
+let elementStates = new Map<HTMLElement, RatingElementState>();
 let generation = 0;
 
 function isActive(context: IdentityContext, expectedGeneration: number): boolean {
@@ -98,12 +98,51 @@ function pruneRatingTextObservers(liveElements: Set<HTMLElement>): void {
         if (liveElements.has(element) && element.isConnected) return;
         observer.disconnect();
         ratingTextObservers.delete(element);
+        const state = elementStates.get(element);
+        if (state) {
+            captureHostChanges(element, state);
+            restoreRatingElement(element, state);
+            elementStates.delete(element);
+        }
     });
 }
 
 function writeOptionalAttribute(element: HTMLElement, name: string, value: string | null): void {
     if (value === null) element.removeAttribute(name);
     else element.setAttribute(name, value);
+}
+
+function restoreRatingElement(element: HTMLElement, state: RatingElementState): void {
+    element.textContent = state.sourceText;
+    writeOptionalAttribute(element, CONFIG.attributeName, state.sourceRating);
+    writeOptionalAttribute(element, 'aria-label', state.sourceAriaLabel);
+    writeOptionalAttribute(element, 'title', state.sourceTitle);
+    delete element.dataset.jcColoredRating;
+}
+
+function captureHostChanges(element: HTMLElement, state: RatingElementState): boolean {
+    const currentText = element.textContent;
+    const currentRating = element.getAttribute(CONFIG.attributeName);
+    const currentAriaLabel = element.getAttribute('aria-label');
+    const currentTitle = element.getAttribute('title');
+    if (currentText === state.renderedText && currentRating === state.renderedRating
+        && currentAriaLabel === state.renderedAriaLabel && currentTitle === state.renderedTitle) {
+        return false;
+    }
+    // A retained host node can be populated with a different item on
+    // navigation. Values that no longer match our last render are the latest
+    // host-owned state, including updates made immediately before detachment.
+    if (currentText !== state.renderedText) state.sourceText = currentText;
+    if (currentRating !== state.renderedRating) state.sourceRating = currentRating;
+    if (currentAriaLabel !== state.renderedAriaLabel) {
+        state.sourceAriaLabel = currentAriaLabel;
+        state.ownsAriaLabel = false;
+    }
+    if (currentTitle !== state.renderedTitle) {
+        state.sourceTitle = currentTitle;
+        state.ownsTitle = false;
+    }
+    return true;
 }
 
 
@@ -117,27 +156,7 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
             if (!isActive(context, expectedGeneration)) return;
             let state = elementStates.get(element);
             if (state) {
-                const currentText = element.textContent;
-                const currentRating = element.getAttribute(CONFIG.attributeName);
-                const currentAriaLabel = element.getAttribute('aria-label');
-                const currentTitle = element.getAttribute('title');
-                if (currentText === state.renderedText && currentRating === state.renderedRating
-                    && currentAriaLabel === state.renderedAriaLabel && currentTitle === state.renderedTitle) {
-                    return;
-                }
-                // A retained host node can be populated with a different item on
-                // navigation. Treat values that no longer match our last render
-                // as the new host-owned state so teardown restores the right item.
-                if (currentText !== state.renderedText) state.sourceText = currentText;
-                if (currentRating !== state.renderedRating) state.sourceRating = currentRating;
-                if (currentAriaLabel !== state.renderedAriaLabel) {
-                    state.sourceAriaLabel = currentAriaLabel;
-                    state.ownsAriaLabel = false;
-                }
-                if (currentTitle !== state.renderedTitle) {
-                    state.sourceTitle = currentTitle;
-                    state.ownsTitle = false;
-                }
+                if (!captureHostChanges(element, state)) return;
             } else {
                 state = {
                     sourceText: element.textContent,
@@ -343,21 +362,18 @@ function cleanup(): void {
 export function resetColoredRatings(): void {
     generation += 1;
     cleanup();
+    // The state map is deliberately enumerable so teardown can restore a
+    // host-cached element even while it is detached from document.
+    elementStates.forEach((state, element) => restoreRatingElement(element, state));
     document.querySelectorAll<HTMLElement>('[data-jc-colored-rating="true"]').forEach((element) => {
-        const state = elementStates.get(element);
-        if (state) {
-            element.textContent = state.sourceText;
-            writeOptionalAttribute(element, CONFIG.attributeName, state.sourceRating);
-            writeOptionalAttribute(element, 'aria-label', state.sourceAriaLabel);
-            writeOptionalAttribute(element, 'title', state.sourceTitle);
-        } else {
-            element.removeAttribute(CONFIG.attributeName);
-            element.removeAttribute('aria-label');
-            element.removeAttribute('title');
-        }
+        // Defensive cleanup for annotations left by an interrupted/older
+        // activation that has no entry in this module instance's state map.
+        element.removeAttribute(CONFIG.attributeName);
+        element.removeAttribute('aria-label');
+        element.removeAttribute('title');
         delete element.dataset.jcColoredRating;
     });
-    elementStates = new WeakMap();
+    elementStates = new Map();
     ratingTextObservers = new Map();
     document.getElementById(CONFIG.cssId)?.remove();
 }

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -59,7 +59,7 @@ function captureObservedHostWrites(element: HTMLElement, mutations: MutationReco
         // even when its value happens to equal our canonical render. A value
         // comparison alone cannot distinguish that case from an untouched
         // element. Plugin-owned writes are synchronously drained separately.
-        if (mutation.type === 'characterData') {
+        if (mutation.type === 'characterData' || mutation.type === 'childList') {
             state.sourceText = element.textContent;
             captured = true;
         } else if (mutation.type === 'attributes') {
@@ -146,6 +146,7 @@ function observeRatingMutations(
         attributes: true,
         attributeFilter: [CONFIG.attributeName, 'aria-label', 'title'],
         characterData: true,
+        childList: true,
         subtree: true,
     });
     ratingMutationObservers.set(element, observer);

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -33,7 +33,7 @@ let observerHandle: { unsubscribe(): void } | null = null;
 let navUnsubscribe: (() => void) | null = null;
 let navSettleTimer: ReturnType<typeof setTimeout> | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-let ratingTextObservers = new Map<HTMLElement, MutationObserver>();
+let ratingMutationObservers = new Map<HTMLElement, MutationObserver>();
 interface RatingElementState {
     sourceText: string | null;
     sourceRating: string | null;
@@ -49,23 +49,57 @@ interface RatingElementState {
 let elementStates = new Map<HTMLElement, RatingElementState>();
 let generation = 0;
 
-function captureObservedHostText(element: HTMLElement, mutations: MutationRecord[]): boolean {
-    if (!mutations.some((mutation) => mutation.type === 'characterData')) return false;
+function captureObservedHostWrites(element: HTMLElement, mutations: MutationRecord[]): boolean {
     const state = elementStates.get(element);
-    if (state) {
-        // The mutation itself proves that the host wrote this text, even when
-        // its value happens to equal our canonical render. A value comparison
-        // alone cannot distinguish that case from an untouched element.
-        state.sourceText = element.textContent;
+    if (!state) return false;
+
+    let captured = false;
+    for (const mutation of mutations) {
+        // The mutation record itself proves that the host wrote this field,
+        // even when its value happens to equal our canonical render. A value
+        // comparison alone cannot distinguish that case from an untouched
+        // element. Plugin-owned writes are synchronously drained separately.
+        if (mutation.type === 'characterData') {
+            state.sourceText = element.textContent;
+            captured = true;
+        } else if (mutation.type === 'attributes') {
+            if (mutation.attributeName === CONFIG.attributeName) {
+                state.sourceRating = element.getAttribute(CONFIG.attributeName);
+                captured = true;
+            } else if (mutation.attributeName === 'aria-label') {
+                state.sourceAriaLabel = element.getAttribute('aria-label');
+                state.ownsAriaLabel = false;
+                captured = true;
+            } else if (mutation.attributeName === 'title') {
+                state.sourceTitle = element.getAttribute('title');
+                state.ownsTitle = false;
+                captured = true;
+            }
+        }
     }
-    return true;
+    return captured;
 }
 
-function disconnectRatingTextObserver(element: HTMLElement, observer: MutationObserver): void {
+function disconnectRatingObserver(element: HTMLElement, observer: MutationObserver): void {
     // disconnect() discards queued records. Drain them first so a same-task
-    // host write followed by removal/identity teardown still advances sourceText.
-    captureObservedHostText(element, observer.takeRecords());
+    // host write followed by removal/identity teardown still transfers every
+    // field's ownership, including equal-canonical attribute values.
+    captureObservedHostWrites(element, observer.takeRecords());
     observer.disconnect();
+}
+
+function writePluginState(element: HTMLElement, mutate: () => void): void {
+    const observer = ratingMutationObservers.get(element);
+    if (observer) {
+        // A retained host node can be repopulated in the same task immediately
+        // before Canopy runs. Capture those queued writes before overwriting it.
+        captureObservedHostWrites(element, observer.takeRecords());
+    }
+    mutate();
+    // Mutation records are queued synchronously. Removing only the records
+    // created by this bounded plugin write prevents our own canonical render
+    // from being mistaken for later host ownership.
+    observer?.takeRecords();
 }
 
 function isActive(context: IdentityContext, expectedGeneration: number): boolean {
@@ -92,31 +126,36 @@ function injectCSS(): void {
     }
 }
 
-function observeRatingText(
+function observeRatingMutations(
     element: HTMLElement,
     context: IdentityContext,
     expectedGeneration: number
 ): void {
-    if (!window.MutationObserver || ratingTextObservers.has(element)) return;
+    if (!window.MutationObserver || ratingMutationObservers.has(element)) return;
 
     const observer = new MutationObserver((mutations) => {
         if (!isActive(context, expectedGeneration)) return;
-        if (captureObservedHostText(element, mutations)) {
+        if (captureObservedHostWrites(element, mutations)) {
             debouncedProcess(context, expectedGeneration);
         }
     });
     // PERF(R3): character-data observation is deliberately limited to the
     // handful of live rating elements. Observing body/document would also see
     // high-frequency playback clock and OSD updates.
-    observer.observe(element, { characterData: true, subtree: true });
-    ratingTextObservers.set(element, observer);
+    observer.observe(element, {
+        attributes: true,
+        attributeFilter: [CONFIG.attributeName, 'aria-label', 'title'],
+        characterData: true,
+        subtree: true,
+    });
+    ratingMutationObservers.set(element, observer);
 }
 
-function pruneRatingTextObservers(liveElements: Set<HTMLElement>): void {
-    ratingTextObservers.forEach((observer, element) => {
+function pruneRatingMutationObservers(liveElements: Set<HTMLElement>): void {
+    ratingMutationObservers.forEach((observer, element) => {
         if (liveElements.has(element) && element.isConnected) return;
-        disconnectRatingTextObserver(element, observer);
-        ratingTextObservers.delete(element);
+        disconnectRatingObserver(element, observer);
+        ratingMutationObservers.delete(element);
         const state = elementStates.get(element);
         if (state) {
             restoreLatestHostState(element, state);
@@ -206,35 +245,37 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
                 const visibleText = isFsk ? normalizedRating : element.textContent;
                 let ariaLabel = element.getAttribute('aria-label');
                 let title = element.getAttribute('title');
-                if (visibleText !== element.textContent) element.textContent = visibleText;
-                element.setAttribute(CONFIG.attributeName, normalizedRating);
-                if (isFsk || (state.ownsAriaLabel && state.sourceAriaLabel === null) || ariaLabel === null) {
-                    ariaLabel = `Content rated ${normalizedRating}`;
-                    element.setAttribute('aria-label', ariaLabel);
-                    state.ownsAriaLabel = true;
-                } else if (state.ownsAriaLabel) {
-                    ariaLabel = state.sourceAriaLabel;
-                    writeOptionalAttribute(element, 'aria-label', ariaLabel);
-                    state.ownsAriaLabel = false;
-                }
-                if (isFsk || (state.ownsTitle && state.sourceTitle === null) || title === null) {
-                    title = `Rating: ${normalizedRating}`;
-                    element.setAttribute('title', title);
-                    state.ownsTitle = true;
-                } else if (state.ownsTitle) {
-                    title = state.sourceTitle;
-                    writeOptionalAttribute(element, 'title', title);
-                    state.ownsTitle = false;
-                }
-                element.dataset.jcColoredRating = 'true';
+                writePluginState(element, () => {
+                    if (visibleText !== element.textContent) element.textContent = visibleText;
+                    element.setAttribute(CONFIG.attributeName, normalizedRating);
+                    if (isFsk || (state.ownsAriaLabel && state.sourceAriaLabel === null) || ariaLabel === null) {
+                        ariaLabel = `Content rated ${normalizedRating}`;
+                        element.setAttribute('aria-label', ariaLabel);
+                        state.ownsAriaLabel = true;
+                    } else if (state.ownsAriaLabel) {
+                        ariaLabel = state.sourceAriaLabel;
+                        writeOptionalAttribute(element, 'aria-label', ariaLabel);
+                        state.ownsAriaLabel = false;
+                    }
+                    if (isFsk || (state.ownsTitle && state.sourceTitle === null) || title === null) {
+                        title = `Rating: ${normalizedRating}`;
+                        element.setAttribute('title', title);
+                        state.ownsTitle = true;
+                    } else if (state.ownsTitle) {
+                        title = state.sourceTitle;
+                        writeOptionalAttribute(element, 'title', title);
+                        state.ownsTitle = false;
+                    }
+                    element.dataset.jcColoredRating = 'true';
+                });
                 state.renderedText = visibleText;
                 state.renderedRating = normalizedRating;
                 state.renderedAriaLabel = ariaLabel;
                 state.renderedTitle = title;
             }
-            observeRatingText(element, context, expectedGeneration);
+            observeRatingMutations(element, context, expectedGeneration);
         });
-        pruneRatingTextObservers(liveElements);
+        pruneRatingMutationObservers(liveElements);
 
     } catch (error) {
         console.error('🪼 Jellyfin Canopy: Error processing rating elements', error);
@@ -381,8 +422,8 @@ function cleanup(): void {
         clearTimeout(debounceTimer);
         debounceTimer = null;
     }
-    ratingTextObservers.forEach((observer, element) => disconnectRatingTextObserver(element, observer));
-    ratingTextObservers.clear();
+    ratingMutationObservers.forEach((observer, element) => disconnectRatingObserver(element, observer));
+    ratingMutationObservers.clear();
 }
 
 export function resetColoredRatings(): void {
@@ -394,17 +435,31 @@ export function resetColoredRatings(): void {
     document.querySelectorAll<HTMLElement>('[data-jc-colored-rating="true"]').forEach((element) => {
         // Defensive cleanup for annotations left by an interrupted/older
         // activation that has no entry in this module instance's state map.
-        // The main marker proves ownership of `rating`; predecessor-specific
-        // markers are the only proof that accessibility metadata is ours.
-        element.removeAttribute(CONFIG.attributeName);
-        if (element.dataset.jcColoredRatingAria === 'true') element.removeAttribute('aria-label');
-        if (element.dataset.jcColoredRatingTitle === 'true') element.removeAttribute('title');
+        // A legacy marker alone is ambiguous after the host has reused the
+        // element. Remove only a value that still exactly matches the
+        // predecessor's deterministic render; otherwise fail open.
+        const visibleText = element.textContent?.trim() ?? '';
+        const expectedRating = visibleText ? normalizeRating(visibleText) : '';
+        const currentRating = element.getAttribute(CONFIG.attributeName);
+        if (expectedRating && currentRating === expectedRating) {
+            element.removeAttribute(CONFIG.attributeName);
+        }
+        if (element.dataset.jcColoredRatingAria === 'true'
+            && expectedRating
+            && element.getAttribute('aria-label') === `Content rated ${expectedRating}`) {
+            element.removeAttribute('aria-label');
+        }
+        if (element.dataset.jcColoredRatingTitle === 'true'
+            && expectedRating
+            && element.getAttribute('title') === `Rating: ${expectedRating}`) {
+            element.removeAttribute('title');
+        }
         delete element.dataset.jcColoredRating;
         delete element.dataset.jcColoredRatingAria;
         delete element.dataset.jcColoredRatingTitle;
     });
     elementStates = new Map();
-    ratingTextObservers = new Map();
+    ratingMutationObservers = new Map();
     document.getElementById(CONFIG.cssId)?.remove();
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -100,8 +100,7 @@ function pruneRatingTextObservers(liveElements: Set<HTMLElement>): void {
         ratingTextObservers.delete(element);
         const state = elementStates.get(element);
         if (state) {
-            captureHostChanges(element, state);
-            restoreRatingElement(element, state);
+            restoreLatestHostState(element, state);
             elementStates.delete(element);
         }
     });
@@ -143,6 +142,14 @@ function captureHostChanges(element: HTMLElement, state: RatingElementState): bo
         state.ownsTitle = false;
     }
     return true;
+}
+
+function restoreLatestHostState(element: HTMLElement, state: RatingElementState): void {
+    // MutationObserver callbacks are asynchronous. Inspect the DOM at the
+    // ownership boundary so a host update made immediately before removal or
+    // identity/config teardown cannot be overwritten by an older snapshot.
+    captureHostChanges(element, state);
+    restoreRatingElement(element, state);
 }
 
 
@@ -364,7 +371,7 @@ export function resetColoredRatings(): void {
     cleanup();
     // The state map is deliberately enumerable so teardown can restore a
     // host-cached element even while it is detached from document.
-    elementStates.forEach((state, element) => restoreRatingElement(element, state));
+    elementStates.forEach((state, element) => restoreLatestHostState(element, state));
     document.querySelectorAll<HTMLElement>('[data-jc-colored-rating="true"]').forEach((element) => {
         // Defensive cleanup for annotations left by an interrupted/older
         // activation that has no entry in this module instance's state map.

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -32,7 +32,17 @@ let observerHandle: { unsubscribe(): void } | null = null;
 let navUnsubscribe: (() => void) | null = null;
 let navSettleTimer: ReturnType<typeof setTimeout> | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-let processedElements = new WeakSet<Element>();
+interface RatingElementState {
+    sourceText: string | null;
+    sourceRating: string | null;
+    sourceAriaLabel: string | null;
+    sourceTitle: string | null;
+    renderedText: string | null;
+    renderedRating: string;
+    renderedAriaLabel: string | null;
+    renderedTitle: string | null;
+}
+let elementStates = new WeakMap<HTMLElement, RatingElementState>();
 let generation = 0;
 
 function isActive(context: IdentityContext, expectedGeneration: number): boolean {
@@ -67,32 +77,59 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
 
         elements.forEach((element) => {
             if (!isActive(context, expectedGeneration)) return;
-            if (processedElements.has(element)) {
-                const currentRating = element.textContent?.trim();
-                const existingRating = element.getAttribute(CONFIG.attributeName);
-                if (currentRating === existingRating) {
+            let state = elementStates.get(element);
+            if (state) {
+                const currentText = element.textContent;
+                const currentRating = element.getAttribute(CONFIG.attributeName);
+                const currentAriaLabel = element.getAttribute('aria-label');
+                const currentTitle = element.getAttribute('title');
+                if (currentText === state.renderedText && currentRating === state.renderedRating
+                    && currentAriaLabel === state.renderedAriaLabel && currentTitle === state.renderedTitle) {
                     return;
                 }
+                // A retained host node can be populated with a different item on
+                // navigation. Treat values that no longer match our last render
+                // as the new host-owned state so teardown restores the right item.
+                if (currentText !== state.renderedText) state.sourceText = currentText;
+                if (currentRating !== state.renderedRating) state.sourceRating = currentRating;
+                if (currentAriaLabel !== state.renderedAriaLabel) state.sourceAriaLabel = currentAriaLabel;
+                if (currentTitle !== state.renderedTitle) state.sourceTitle = currentTitle;
+            } else {
+                state = {
+                    sourceText: element.textContent,
+                    sourceRating: element.getAttribute(CONFIG.attributeName),
+                    sourceAriaLabel: element.getAttribute('aria-label'),
+                    sourceTitle: element.getAttribute('title'),
+                    renderedText: element.textContent,
+                    renderedRating: '',
+                    renderedAriaLabel: element.getAttribute('aria-label'),
+                    renderedTitle: element.getAttribute('title'),
+                };
+                elementStates.set(element, state);
             }
 
             const ratingText = element.textContent?.trim();
             if (ratingText && ratingText.length > 0) {
                 const normalizedRating = normalizeRating(ratingText);
-
-                if (element.getAttribute(CONFIG.attributeName) !== normalizedRating) {
-                    element.setAttribute(CONFIG.attributeName, normalizedRating);
-                    element.dataset.jcColoredRating = 'true';
-                    processedElements.add(element);
-
-                    if (!element.getAttribute('aria-label')) {
-                        element.setAttribute('aria-label', `Content rated ${normalizedRating}`);
-                        element.dataset.jcColoredRatingAria = 'true';
-                    }
-                    if (!element.getAttribute('title')) {
-                        element.setAttribute('title', `Rating: ${normalizedRating}`);
-                        element.dataset.jcColoredRatingTitle = 'true';
-                    }
+                const isFsk = normalizedRating.startsWith('FSK-');
+                const visibleText = isFsk ? normalizedRating : element.textContent;
+                let ariaLabel = element.getAttribute('aria-label');
+                let title = element.getAttribute('title');
+                if (visibleText !== element.textContent) element.textContent = visibleText;
+                element.setAttribute(CONFIG.attributeName, normalizedRating);
+                if (isFsk || ariaLabel === null) {
+                    ariaLabel = `Content rated ${normalizedRating}`;
+                    element.setAttribute('aria-label', ariaLabel);
                 }
+                if (isFsk || title === null) {
+                    title = `Rating: ${normalizedRating}`;
+                    element.setAttribute('title', title);
+                }
+                element.dataset.jcColoredRating = 'true';
+                state.renderedText = visibleText;
+                state.renderedRating = normalizedRating;
+                state.renderedAriaLabel = ariaLabel;
+                state.renderedTitle = title;
             }
         });
 
@@ -101,7 +138,7 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
     }
 }
 
-function normalizeRating(rating: string): string {
+export function normalizeRating(rating: string): string {
     if (!rating) return '';
 
     const normalized = rating.replace(/\s+/g, ' ').trim().toUpperCase();
@@ -114,6 +151,9 @@ function normalizeRating(rating: string): string {
         'APPROVED': 'APPROVED',
         'PASSED': 'PASSED'
     };
+
+    const fsk = normalized.match(/^(?:DE-|FSK(?:-| )?)(0|6|12|16|18)$/);
+    if (fsk) return `FSK-${fsk[1]}`;
 
     return ratingMappings[normalized] || rating.trim();
 }
@@ -230,20 +270,30 @@ function cleanup(): void {
         clearTimeout(debounceTimer);
         debounceTimer = null;
     }
-    processedElements = new WeakSet();
 }
 
 export function resetColoredRatings(): void {
     generation += 1;
     cleanup();
     document.querySelectorAll<HTMLElement>('[data-jc-colored-rating="true"]').forEach((element) => {
-        element.removeAttribute(CONFIG.attributeName);
-        if (element.dataset.jcColoredRatingAria === 'true') element.removeAttribute('aria-label');
-        if (element.dataset.jcColoredRatingTitle === 'true') element.removeAttribute('title');
+        const state = elementStates.get(element);
+        if (state) {
+            element.textContent = state.sourceText;
+            const restore = (name: string, value: string | null) => {
+                if (value === null) element.removeAttribute(name);
+                else element.setAttribute(name, value);
+            };
+            restore(CONFIG.attributeName, state.sourceRating);
+            restore('aria-label', state.sourceAriaLabel);
+            restore('title', state.sourceTitle);
+        } else {
+            element.removeAttribute(CONFIG.attributeName);
+            element.removeAttribute('aria-label');
+            element.removeAttribute('title');
+        }
         delete element.dataset.jcColoredRating;
-        delete element.dataset.jcColoredRatingAria;
-        delete element.dataset.jcColoredRatingTitle;
     });
+    elementStates = new WeakMap();
     document.getElementById(CONFIG.cssId)?.remove();
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -27,11 +27,13 @@ const CONFIG = {
     navSettleDelay: 500,
     cssId: 'jellyfin-ratings-style'
 };
+const SUPPORTED_FSK_RATINGS = new Set(['FSK-0', 'FSK-6', 'FSK-12', 'FSK-16', 'FSK-18']);
 
 let observerHandle: { unsubscribe(): void } | null = null;
 let navUnsubscribe: (() => void) | null = null;
 let navSettleTimer: ReturnType<typeof setTimeout> | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let ratingTextObservers = new Map<HTMLElement, MutationObserver>();
 interface RatingElementState {
     sourceText: string | null;
     sourceRating: string | null;
@@ -41,6 +43,8 @@ interface RatingElementState {
     renderedRating: string;
     renderedAriaLabel: string | null;
     renderedTitle: string | null;
+    ownsAriaLabel: boolean;
+    ownsTitle: boolean;
 }
 let elementStates = new WeakMap<HTMLElement, RatingElementState>();
 let generation = 0;
@@ -69,11 +73,45 @@ function injectCSS(): void {
     }
 }
 
+function observeRatingText(
+    element: HTMLElement,
+    context: IdentityContext,
+    expectedGeneration: number
+): void {
+    if (!window.MutationObserver || ratingTextObservers.has(element)) return;
+
+    const observer = new MutationObserver((mutations) => {
+        if (!isActive(context, expectedGeneration)) return;
+        if (mutations.some((mutation) => mutation.type === 'characterData')) {
+            debouncedProcess(context, expectedGeneration);
+        }
+    });
+    // PERF(R3): character-data observation is deliberately limited to the
+    // handful of live rating elements. Observing body/document would also see
+    // high-frequency playback clock and OSD updates.
+    observer.observe(element, { characterData: true, subtree: true });
+    ratingTextObservers.set(element, observer);
+}
+
+function pruneRatingTextObservers(liveElements: Set<HTMLElement>): void {
+    ratingTextObservers.forEach((observer, element) => {
+        if (liveElements.has(element) && element.isConnected) return;
+        observer.disconnect();
+        ratingTextObservers.delete(element);
+    });
+}
+
+function writeOptionalAttribute(element: HTMLElement, name: string, value: string | null): void {
+    if (value === null) element.removeAttribute(name);
+    else element.setAttribute(name, value);
+}
+
 
 function processRatingElements(context: IdentityContext, expectedGeneration: number): void {
     if (!isActive(context, expectedGeneration) || !isFeatureEnabled()) return;
     try {
         const elements = document.querySelectorAll<HTMLElement>(CONFIG.targetSelector);
+        const liveElements = new Set(elements);
 
         elements.forEach((element) => {
             if (!isActive(context, expectedGeneration)) return;
@@ -92,8 +130,14 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
                 // as the new host-owned state so teardown restores the right item.
                 if (currentText !== state.renderedText) state.sourceText = currentText;
                 if (currentRating !== state.renderedRating) state.sourceRating = currentRating;
-                if (currentAriaLabel !== state.renderedAriaLabel) state.sourceAriaLabel = currentAriaLabel;
-                if (currentTitle !== state.renderedTitle) state.sourceTitle = currentTitle;
+                if (currentAriaLabel !== state.renderedAriaLabel) {
+                    state.sourceAriaLabel = currentAriaLabel;
+                    state.ownsAriaLabel = false;
+                }
+                if (currentTitle !== state.renderedTitle) {
+                    state.sourceTitle = currentTitle;
+                    state.ownsTitle = false;
+                }
             } else {
                 state = {
                     sourceText: element.textContent,
@@ -104,6 +148,8 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
                     renderedRating: '',
                     renderedAriaLabel: element.getAttribute('aria-label'),
                     renderedTitle: element.getAttribute('title'),
+                    ownsAriaLabel: false,
+                    ownsTitle: false,
                 };
                 elementStates.set(element, state);
             }
@@ -111,19 +157,29 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
             const ratingText = element.textContent?.trim();
             if (ratingText && ratingText.length > 0) {
                 const normalizedRating = normalizeRating(ratingText);
-                const isFsk = normalizedRating.startsWith('FSK-');
+                const isFsk = SUPPORTED_FSK_RATINGS.has(normalizedRating);
                 const visibleText = isFsk ? normalizedRating : element.textContent;
                 let ariaLabel = element.getAttribute('aria-label');
                 let title = element.getAttribute('title');
                 if (visibleText !== element.textContent) element.textContent = visibleText;
                 element.setAttribute(CONFIG.attributeName, normalizedRating);
-                if (isFsk || ariaLabel === null) {
+                if (isFsk || (state.ownsAriaLabel && state.sourceAriaLabel === null) || ariaLabel === null) {
                     ariaLabel = `Content rated ${normalizedRating}`;
                     element.setAttribute('aria-label', ariaLabel);
+                    state.ownsAriaLabel = true;
+                } else if (state.ownsAriaLabel) {
+                    ariaLabel = state.sourceAriaLabel;
+                    writeOptionalAttribute(element, 'aria-label', ariaLabel);
+                    state.ownsAriaLabel = false;
                 }
-                if (isFsk || title === null) {
+                if (isFsk || (state.ownsTitle && state.sourceTitle === null) || title === null) {
                     title = `Rating: ${normalizedRating}`;
                     element.setAttribute('title', title);
+                    state.ownsTitle = true;
+                } else if (state.ownsTitle) {
+                    title = state.sourceTitle;
+                    writeOptionalAttribute(element, 'title', title);
+                    state.ownsTitle = false;
                 }
                 element.dataset.jcColoredRating = 'true';
                 state.renderedText = visibleText;
@@ -131,7 +187,9 @@ function processRatingElements(context: IdentityContext, expectedGeneration: num
                 state.renderedAriaLabel = ariaLabel;
                 state.renderedTitle = title;
             }
+            observeRatingText(element, context, expectedGeneration);
         });
+        pruneRatingTextObservers(liveElements);
 
     } catch (error) {
         console.error('🪼 Jellyfin Canopy: Error processing rating elements', error);
@@ -188,6 +246,14 @@ export function mutationsTouchRatings(mutations: MutationRecord[]): boolean {
             }
         }
 
+        for (const node of mutation.removedNodes) {
+            if (node.nodeType !== Node.ELEMENT_NODE) continue;
+            const el = node as Element;
+            if (el.matches?.(CONFIG.targetSelector) || el.querySelector?.(CONFIG.targetSelector)) {
+                return true;
+            }
+        }
+
         const target = mutation.target as Element;
         if (target.nodeType === Node.ELEMENT_NODE &&
             (target.matches(CONFIG.targetSelector) || target.closest(CONFIG.targetSelector))) {
@@ -203,9 +269,9 @@ function setupMutationObserver(context: IdentityContext, expectedGeneration: num
     try {
         // PERF(R3): rides the shared structural body observer instead of a
         // dedicated characterData:true body observer — that one fired on the
-        // OSD clock's text updates every second during playback. Rating text
-        // only ever (re)renders via childList mutations, and the
-        // per-navigation pass below covers cached-page re-shows.
+        // OSD clock's text updates every second during playback. Retained text
+        // nodes are covered by the element-scoped observers installed above;
+        // this shared subscription discovers new/replaced rating elements.
         observerHandle = onBodyMutation('colored-ratings', (mutations) => {
             if (isActive(context, expectedGeneration) && mutationsTouchRatings(mutations)) {
                 debouncedProcess(context, expectedGeneration);
@@ -270,6 +336,8 @@ function cleanup(): void {
         clearTimeout(debounceTimer);
         debounceTimer = null;
     }
+    ratingTextObservers.forEach((observer) => observer.disconnect());
+    ratingTextObservers.clear();
 }
 
 export function resetColoredRatings(): void {
@@ -279,13 +347,9 @@ export function resetColoredRatings(): void {
         const state = elementStates.get(element);
         if (state) {
             element.textContent = state.sourceText;
-            const restore = (name: string, value: string | null) => {
-                if (value === null) element.removeAttribute(name);
-                else element.setAttribute(name, value);
-            };
-            restore(CONFIG.attributeName, state.sourceRating);
-            restore('aria-label', state.sourceAriaLabel);
-            restore('title', state.sourceTitle);
+            writeOptionalAttribute(element, CONFIG.attributeName, state.sourceRating);
+            writeOptionalAttribute(element, 'aria-label', state.sourceAriaLabel);
+            writeOptionalAttribute(element, 'title', state.sourceTitle);
         } else {
             element.removeAttribute(CONFIG.attributeName);
             element.removeAttribute('aria-label');
@@ -294,6 +358,7 @@ export function resetColoredRatings(): void {
         delete element.dataset.jcColoredRating;
     });
     elementStates = new WeakMap();
+    ratingTextObservers = new Map();
     document.getElementById(CONFIG.cssId)?.remove();
 }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/extras/colored-ratings.ts
@@ -49,6 +49,25 @@ interface RatingElementState {
 let elementStates = new Map<HTMLElement, RatingElementState>();
 let generation = 0;
 
+function captureObservedHostText(element: HTMLElement, mutations: MutationRecord[]): boolean {
+    if (!mutations.some((mutation) => mutation.type === 'characterData')) return false;
+    const state = elementStates.get(element);
+    if (state) {
+        // The mutation itself proves that the host wrote this text, even when
+        // its value happens to equal our canonical render. A value comparison
+        // alone cannot distinguish that case from an untouched element.
+        state.sourceText = element.textContent;
+    }
+    return true;
+}
+
+function disconnectRatingTextObserver(element: HTMLElement, observer: MutationObserver): void {
+    // disconnect() discards queued records. Drain them first so a same-task
+    // host write followed by removal/identity teardown still advances sourceText.
+    captureObservedHostText(element, observer.takeRecords());
+    observer.disconnect();
+}
+
 function isActive(context: IdentityContext, expectedGeneration: number): boolean {
     return generation === expectedGeneration && JC.identity.isCurrent(context);
 }
@@ -82,7 +101,7 @@ function observeRatingText(
 
     const observer = new MutationObserver((mutations) => {
         if (!isActive(context, expectedGeneration)) return;
-        if (mutations.some((mutation) => mutation.type === 'characterData')) {
+        if (captureObservedHostText(element, mutations)) {
             debouncedProcess(context, expectedGeneration);
         }
     });
@@ -96,7 +115,7 @@ function observeRatingText(
 function pruneRatingTextObservers(liveElements: Set<HTMLElement>): void {
     ratingTextObservers.forEach((observer, element) => {
         if (liveElements.has(element) && element.isConnected) return;
-        observer.disconnect();
+        disconnectRatingTextObserver(element, observer);
         ratingTextObservers.delete(element);
         const state = elementStates.get(element);
         if (state) {
@@ -362,7 +381,7 @@ function cleanup(): void {
         clearTimeout(debounceTimer);
         debounceTimer = null;
     }
-    ratingTextObservers.forEach((observer) => observer.disconnect());
+    ratingTextObservers.forEach((observer, element) => disconnectRatingTextObserver(element, observer));
     ratingTextObservers.clear();
 }
 
@@ -375,10 +394,14 @@ export function resetColoredRatings(): void {
     document.querySelectorAll<HTMLElement>('[data-jc-colored-rating="true"]').forEach((element) => {
         // Defensive cleanup for annotations left by an interrupted/older
         // activation that has no entry in this module instance's state map.
+        // The main marker proves ownership of `rating`; predecessor-specific
+        // markers are the only proof that accessibility metadata is ours.
         element.removeAttribute(CONFIG.attributeName);
-        element.removeAttribute('aria-label');
-        element.removeAttribute('title');
+        if (element.dataset.jcColoredRatingAria === 'true') element.removeAttribute('aria-label');
+        if (element.dataset.jcColoredRatingTitle === 'true') element.removeAttribute('title');
         delete element.dataset.jcColoredRating;
+        delete element.dataset.jcColoredRatingAria;
+        delete element.dataset.jcColoredRatingTitle;
     });
     elementStates = new Map();
     ratingTextObservers = new Map();

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/ratings-css.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/ratings-css.test.ts
@@ -111,4 +111,28 @@ describe('ratings.css lint guards', () => {
             expect(backgrounds.has(unknown), `${unknown} was unexpectedly classified`).toBe(false);
         }
     });
+
+    it('uses the official FSK identities with contrast-safe foregrounds', () => {
+        const official = new Map([
+            ['FSK-0', '#FFFFFF'],
+            ['FSK-6', '#FFEB00'],
+            ['FSK-12', '#12B53F'],
+            ['FSK-16', '#1597D4'],
+            ['FSK-18', '#ED0016'],
+        ]);
+        const luminance = (hex: string): number => {
+            const channels = hex.match(/[0-9a-f]{2}/gi)!.map((part) => parseInt(part, 16) / 255)
+                .map((value) => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
+            return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+        };
+        for (const [rating, expectedBackground] of official) {
+            const escaped = rating.replace('-', '\\-');
+            const block = CSS.match(new RegExp(`\\[rating='${escaped}'\\]\\s*\\{([^}]*)\\}`));
+            expect(block, `${rating} rule not found`).toBeTruthy();
+            expect(block![1]).toContain(`background-color: ${expectedBackground} !important`);
+            expect(block![1]).toContain('color: #000000 !important');
+            const contrast = (luminance(expectedBackground) + 0.05) / 0.05;
+            expect(contrast, `${rating} contrast ${contrast.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+        }
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/test/ratings-css.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/test/ratings-css.test.ts
@@ -112,13 +112,15 @@ describe('ratings.css lint guards', () => {
         }
     });
 
-    it('uses the official FSK identities with contrast-safe foregrounds', () => {
+    it('uses the official FSK web-pictogram palette with contrast-safe foregrounds', () => {
+        // Provenance: the lossless 500 px PNGs in the official web-pictogram
+        // archive linked from https://www.fsk.de/fskkennzeichen/.
         const official = new Map([
             ['FSK-0', '#FFFFFF'],
-            ['FSK-6', '#FFEB00'],
-            ['FSK-12', '#12B53F'],
-            ['FSK-16', '#1597D4'],
-            ['FSK-18', '#ED0016'],
+            ['FSK-6', '#FFE800'],
+            ['FSK-12', '#33B540'],
+            ['FSK-16', '#38A7E4'],
+            ['FSK-18', '#ED1C24'],
         ]);
         const luminance = (hex: string): number => {
             const channels = hex.match(/[0-9a-f]{2}/gi)!.map((part) => parseInt(part, 16) / 255)

--- a/css/ratings.css
+++ b/css/ratings.css
@@ -442,7 +442,10 @@
 }
 
 
-/* === GERMANY: Official FSK color identities === */
+/* === GERMANY: Official FSK digital pictogram colors ===
+ * Source: FSK's lossless web-pictogram archive linked from
+ * https://www.fsk.de/fskkennzeichen/ (500 px PNG dominant opaque pixels).
+ */
 .mediaInfoOfficialRating[rating='FSK-0'] {
     background-color: #FFFFFF !important;
     border-color: #BDBDBD !important;
@@ -451,28 +454,28 @@
 }
 
 .mediaInfoOfficialRating[rating='FSK-6'] {
-    background-color: #FFEB00 !important;
+    background-color: #FFE800 !important;
     border-color: #D6C600 !important;
     color: #000000 !important;
     text-shadow: none !important;
 }
 
 .mediaInfoOfficialRating[rating='FSK-12'] {
-    background-color: #12B53F !important;
+    background-color: #33B540 !important;
     border-color: #07912E !important;
     color: #000000 !important;
     text-shadow: none !important;
 }
 
 .mediaInfoOfficialRating[rating='FSK-16'] {
-    background-color: #1597D4 !important;
+    background-color: #38A7E4 !important;
     border-color: #0875AB !important;
     color: #000000 !important;
     text-shadow: none !important;
 }
 
 .mediaInfoOfficialRating[rating='FSK-18'] {
-    background-color: #ED0016 !important;
+    background-color: #ED1C24 !important;
     border-color: #B90011 !important;
     color: #000000 !important;
     text-shadow: none !important;

--- a/css/ratings.css
+++ b/css/ratings.css
@@ -106,8 +106,6 @@
 .mediaInfoOfficialRating[rating='FI-T'],                   /* 🇫🇮 Finland — Tillåten (all ages, Swedish label) */
 .mediaInfoOfficialRating[rating='FR-TP'],                  /* 🇫🇷 France — Tous publics (correct current label) */
 .mediaInfoOfficialRating[rating='FR-U'],                   /* 🇫🇷 France — U (legacy/alternate label) */
-.mediaInfoOfficialRating[rating='DE-0'],                   /* 🇩🇪 Germany — FSK 0 (prefix variant) */
-.mediaInfoOfficialRating[rating='FSK-0'],                  /* 🇩🇪 Germany — FSK 0 */
 .mediaInfoOfficialRating[rating='GR-0'],                   /* 🇬🇷 Greece — Unrestricted */
 .mediaInfoOfficialRating[rating='GR-K'],                   /* 🇬🇷 Greece — Unrestricted (legacy label) */
 .mediaInfoOfficialRating[rating='HK-I'],                   /* 🇭🇰 Hong Kong — Category I (all ages) */
@@ -186,8 +184,6 @@
 .mediaInfoOfficialRating[rating='DK-7'],                   /* 🇩🇰 Denmark — 7 */
 .mediaInfoOfficialRating[rating='FI-7'],                   /* 🇫🇮 Finland — 7 (current label) */
 .mediaInfoOfficialRating[rating='FI-K-7'],                 /* 🇫🇮 Finland — K-7 (legacy label) */
-.mediaInfoOfficialRating[rating='DE-6'],                   /* �� Germany — FSK 6 (prefix variant) */
-.mediaInfoOfficialRating[rating='FSK-6'],                  /* 🇩🇪 Germany — FSK 6 */
 .mediaInfoOfficialRating[rating='GR-13'],                  /* 🇬🇷 Greece — 13 */
 .mediaInfoOfficialRating[rating='GR-K-12'],                /* 🇬🇷 Greece — legacy label */
 .mediaInfoOfficialRating[rating='HK-IIA'],                 /* 🇭🇰 Hong Kong — Category IIA (not suitable for children) */
@@ -271,8 +267,6 @@
 .mediaInfoOfficialRating[rating='FI-K-12'],                /* 🇫🇮 Finland — K-12 (legacy label) */
 .mediaInfoOfficialRating[rating='FR-12'],                  /* 🇫🇷 France */
 .mediaInfoOfficialRating[rating='FR--12'],                 /* 🇫🇷 France */
-.mediaInfoOfficialRating[rating='DE-12'],                  /* 🇩🇪 Germany */
-.mediaInfoOfficialRating[rating='FSK-12'],                 /* 🇩🇪 Germany */
 .mediaInfoOfficialRating[rating='GR-K-15'],                /* 🇬🇷 Greece — legacy 15 label */
 .mediaInfoOfficialRating[rating='HU-12'],                  /* 🇭🇺 Hungary */
 .mediaInfoOfficialRating[rating='IN-UA-13'],               /* 🇮🇳 India — UA 13+ */
@@ -334,8 +328,6 @@
 .mediaInfoOfficialRating[rating='FI-K-16'],                /* 🇫🇮 Finland — K-16 (legacy label) */
 .mediaInfoOfficialRating[rating='FR-16'],                  /* 🇫🇷 France */
 .mediaInfoOfficialRating[rating='FR--16'],                 /* 🇫🇷 France */
-.mediaInfoOfficialRating[rating='DE-16'],                  /* 🇩🇪 Germany */
-.mediaInfoOfficialRating[rating='FSK-16'],                 /* 🇩🇪 Germany */
 .mediaInfoOfficialRating[rating='GR-17'],                  /* 🇬🇷 Greece — 17 */
 .mediaInfoOfficialRating[rating='GR-K-17'],                /* 🇬🇷 Greece — legacy 17 label */
 .mediaInfoOfficialRating[rating='HU-16'],                  /* 🇭🇺 Hungary */
@@ -391,8 +383,6 @@
 .mediaInfoOfficialRating[rating='FI-K-18'],                /* 🇫🇮 Finland — K-18 (legacy label) */
 .mediaInfoOfficialRating[rating='FR-18'],                  /* 🇫🇷 France */
 .mediaInfoOfficialRating[rating='FR--18'],                 /* 🇫🇷 France */
-.mediaInfoOfficialRating[rating='DE-18'],                  /* 🇩🇪 Germany */
-.mediaInfoOfficialRating[rating='FSK-18'],                 /* 🇩🇪 Germany */
 .mediaInfoOfficialRating[rating='GR-18'],                  /* 🇬🇷 Greece — 18 */
 .mediaInfoOfficialRating[rating='HU-18'],                  /* 🇭🇺 Hungary */
 .mediaInfoOfficialRating[rating='IN-A'],                   /* 🇮🇳 India */
@@ -449,6 +439,43 @@
 .mediaInfoOfficialRating[rating='X'] {                     /* 🇺🇸 United States (Legacy) */
     background-color: #880E4F !important; /* Very Dark Pink */
     border-color: #C2185B !important;
+}
+
+
+/* === GERMANY: Official FSK color identities === */
+.mediaInfoOfficialRating[rating='FSK-0'] {
+    background-color: #FFFFFF !important;
+    border-color: #BDBDBD !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+.mediaInfoOfficialRating[rating='FSK-6'] {
+    background-color: #FFEB00 !important;
+    border-color: #D6C600 !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+.mediaInfoOfficialRating[rating='FSK-12'] {
+    background-color: #12B53F !important;
+    border-color: #07912E !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+.mediaInfoOfficialRating[rating='FSK-16'] {
+    background-color: #1597D4 !important;
+    border-color: #0875AB !important;
+    color: #000000 !important;
+    text-shadow: none !important;
+}
+
+.mediaInfoOfficialRating[rating='FSK-18'] {
+    background-color: #ED0016 !important;
+    border-color: #B90011 !important;
+    color: #000000 !important;
+    text-shadow: none !important;
 }
 
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -63,6 +63,8 @@ Gives each activity type on the Dashboard a distinct Material Design icon in its
 
 Adds value-based colored backgrounds to the rating chips on detail pages, with different colors per rating type. It supports TMDB, IMDb, and Rotten Tomatoes scores, so a strong rating reads differently from a weak one at a glance. Jellyfin's text certification badge is also grouped by age tier, including exact bare labels such as `L`, `12+`, `14`, `U/A 13+`, and `NC16` when metadata providers omit a region prefix.
 
+German content-rating aliases such as `DE-12`, `FSK12`, and `FSK 12` are shown consistently as `FSK-12`. FSK 0, 6, 12, 16, and 18 use the official white, yellow, green, blue, and red identities with contrast-safe text.
+
 ![Colored Ratings](images/ratings.png)
 
 ### Theme Selector (Jellyfish)

--- a/e2e/colored-ratings.spec.ts
+++ b/e2e/colored-ratings.spec.ts
@@ -1,0 +1,201 @@
+// German FSK acceptance proof against the real Jellyfin 12 browser surface.
+// The unit suite pins every supported alias; this spec proves that production
+// canonicalization, the shipped stylesheet, accessible names, and computed
+// contrast survive representative host themes and forced-colors mode.
+import type { Page } from 'playwright/test';
+import {
+    test,
+    expect,
+    loginAs,
+    showRoute,
+    waitForHash,
+    assertNoRuntimeErrors,
+    USERS,
+} from './fixtures/auth';
+import { api, authenticate } from './fixtures/api';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const THEMES = ['dark', 'light', 'blueradiance'] as const;
+const FSK_FIXTURES = [
+    { source: 'DE-0', canonical: 'FSK-0', background: 'rgb(255, 255, 255)' },
+    { source: 'FSK6', canonical: 'FSK-6', background: 'rgb(255, 232, 0)' },
+    { source: 'FSK 12', canonical: 'FSK-12', background: 'rgb(51, 181, 64)' },
+    { source: 'FSK-16', canonical: 'FSK-16', background: 'rgb(56, 167, 228)' },
+    { source: 'DE-18', canonical: 'FSK-18', background: 'rgb(237, 28, 36)' },
+] as const;
+
+async function switchTheme(page: Page, selectedTheme: string): Promise<void> {
+    await page.evaluate(async (theme) => {
+        const themeLink = [...document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')]
+            .find((link) => /\/themes\/[^/]+\/theme\.css$/i.test(
+                new URL(link.href, location.href).pathname
+            ));
+        if (!themeLink) throw new Error('Jellyfin theme stylesheet link was not found');
+
+        const target = new URL(themeLink.href, location.href);
+        target.pathname = target.pathname.replace(
+            /\/themes\/[^/]+\/theme\.css$/i,
+            `/themes/${theme}/theme.css`
+        );
+        document.documentElement.dataset.theme = theme;
+        if (themeLink.href !== target.href) {
+            await new Promise<void>((resolve, reject) => {
+                const timeout = window.setTimeout(
+                    () => reject(new Error(`theme stylesheet ${target.pathname} did not load`)),
+                    30_000
+                );
+                themeLink.addEventListener('load', () => {
+                    window.clearTimeout(timeout);
+                    resolve();
+                }, { once: true });
+                themeLink.addEventListener('error', () => {
+                    window.clearTimeout(timeout);
+                    reject(new Error(`theme stylesheet ${target.pathname} failed to load`));
+                }, { once: true });
+                themeLink.href = target.href;
+            });
+        }
+        await new Promise<void>((resolve) => requestAnimationFrame(
+            () => requestAnimationFrame(() => resolve())
+        ));
+    }, selectedTheme);
+}
+
+async function auditComputedRatings(page: Page) {
+    return page.locator('#jc-fsk-browser-proof .mediaInfoOfficialRating').evaluateAll((elements) => {
+        type Rgb = [number, number, number];
+        const rgb = (value: string): Rgb => {
+            const match = value.match(/rgba?\((\d+)[, ]+(\d+)[, ]+(\d+)/i);
+            if (!match) throw new Error(`unparseable computed color: ${value}`);
+            return [Number(match[1]), Number(match[2]), Number(match[3])];
+        };
+        const luminance = (value: Rgb): number => {
+            const channels = value.map((channel) => {
+                const normalized = channel / 255;
+                return normalized <= 0.04045
+                    ? normalized / 12.92
+                    : ((normalized + 0.055) / 1.055) ** 2.4;
+            });
+            return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+        };
+        return elements.map((element) => {
+            const style = getComputedStyle(element);
+            const foreground = rgb(style.color);
+            const background = rgb(style.backgroundColor);
+            const foregroundLuminance = luminance(foreground);
+            const backgroundLuminance = luminance(background);
+            return {
+                text: element.textContent,
+                rating: element.getAttribute('rating'),
+                ariaLabel: element.getAttribute('aria-label'),
+                title: element.getAttribute('title'),
+                foreground: style.color,
+                background: style.backgroundColor,
+                contrast: (Math.max(foregroundLuminance, backgroundLuminance) + 0.05)
+                    / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05),
+                borderWidth: Number.parseFloat(style.borderWidth),
+            };
+        });
+    });
+}
+
+test.describe('colored ratings', () => {
+    test('FSK aliases remain readable and accessible across host themes and forced colors', async ({
+        page,
+        consoleErrors,
+        baseURL,
+    }) => {
+        await loginAs(page, 'admin', consoleErrors);
+        const admin = await authenticate(baseURL!, USERS.admin.username, USERS.admin.password);
+        const items = await api<{ Items: Array<{ Id: string }> }>(
+            baseURL!,
+            `/Items?Recursive=true&IncludeItemTypes=Movie,Series&Limit=1&userId=${admin.userId}`,
+            admin.token
+        );
+        const itemId = items?.Items?.[0]?.Id;
+        expect(itemId, 'a seeded detail item is required').toBeTruthy();
+
+        const originalEnabled = await page.evaluate(() => {
+            const canopy = (window as any).JellyfinCanopy;
+            const original = canopy.pluginConfig.ColoredRatingsEnabled;
+            canopy.pluginConfig.ColoredRatingsEnabled = true;
+            return original;
+        });
+
+        try {
+            await showRoute(page, `/details?id=${itemId}`);
+            await waitForHash(page, '/details');
+            await page.waitForFunction(
+                () => typeof (window as any).JellyfinCanopy.initializeColoredRatings === 'function',
+                undefined,
+                { timeout: 30_000 }
+            );
+            await page.evaluate((fixtures) => {
+                document.getElementById('jc-fsk-browser-proof')?.remove();
+                const owner = document.createElement('section');
+                owner.id = 'jc-fsk-browser-proof';
+                for (const fixture of fixtures) {
+                    const badge = document.createElement('span');
+                    badge.className = 'mediaInfoOfficialRating';
+                    badge.textContent = fixture.source;
+                    owner.appendChild(badge);
+                }
+                document.body.appendChild(owner);
+                (window as any).JellyfinCanopy.initializeColoredRatings();
+            }, FSK_FIXTURES);
+
+            await expect(page.locator('#jellyfin-ratings-style')).toHaveCount(1);
+            for (let index = 0; index < FSK_FIXTURES.length; index += 1) {
+                const fixture = FSK_FIXTURES[index];
+                const badge = page.locator('#jc-fsk-browser-proof .mediaInfoOfficialRating').nth(index);
+                await expect(badge).toHaveText(fixture.canonical);
+                await expect(badge).toHaveAttribute('rating', fixture.canonical);
+                await expect(badge).toHaveAccessibleName(`Content rated ${fixture.canonical}`);
+                await expect(badge).toHaveAttribute('title', `Rating: ${fixture.canonical}`);
+            }
+
+            for (const theme of THEMES) {
+                await page.emulateMedia({ forcedColors: 'none' });
+                await switchTheme(page, theme);
+                const audit = await auditComputedRatings(page);
+                expect(audit).toHaveLength(FSK_FIXTURES.length);
+                expect(await page.locator('html').getAttribute('data-theme')).toBe(theme);
+                for (let index = 0; index < FSK_FIXTURES.length; index += 1) {
+                    expect(audit[index].background, `${theme}/${FSK_FIXTURES[index].canonical} background`)
+                        .toBe(FSK_FIXTURES[index].background);
+                    expect(audit[index].foreground, `${theme}/${FSK_FIXTURES[index].canonical} foreground`)
+                        .toBe('rgb(0, 0, 0)');
+                    expect(audit[index].contrast, `${theme}/${FSK_FIXTURES[index].canonical} contrast`)
+                        .toBeGreaterThanOrEqual(4.5);
+                }
+            }
+
+            await page.emulateMedia({ forcedColors: 'active' });
+            await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(
+                () => requestAnimationFrame(() => resolve())
+            )));
+            const forcedColors = await auditComputedRatings(page);
+            expect(forcedColors).toHaveLength(FSK_FIXTURES.length);
+            for (let index = 0; index < FSK_FIXTURES.length; index += 1) {
+                expect(forcedColors[index].contrast, `forced-colors/${FSK_FIXTURES[index].canonical} contrast`)
+                    .toBeGreaterThanOrEqual(4.5);
+                expect(forcedColors[index].borderWidth, `forced-colors/${FSK_FIXTURES[index].canonical} border`)
+                    .toBeGreaterThanOrEqual(1);
+                expect(forcedColors[index].ariaLabel).toBe(`Content rated ${FSK_FIXTURES[index].canonical}`);
+            }
+        } finally {
+            await page.emulateMedia({ forcedColors: 'none' });
+            await page.evaluate((enabled) => {
+                const canopy = (window as any).JellyfinCanopy;
+                canopy.pluginConfig.ColoredRatingsEnabled = false;
+                canopy.initializeColoredRatings?.();
+                canopy.pluginConfig.ColoredRatingsEnabled = enabled;
+                document.getElementById('jc-fsk-browser-proof')?.remove();
+                if (enabled) canopy.initializeColoredRatings?.();
+            }, originalEnabled);
+        }
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -38,6 +38,7 @@
     "e2e/code-splitting.spec.ts › manifest-owned code splitting › a failed static boot child retries the complete graph in a new path namespace",
     "e2e/code-splitting.spec.ts › manifest-owned code splitting › cold authenticated home excludes disabled and off-route feature entries",
     "e2e/code-splitting.spec.ts › manifest-owned code splitting › concurrent generation triggers share one applicable route-module load",
+    "e2e/colored-ratings.spec.ts › colored ratings › FSK aliases remain readable and accessible across host themes and forced colors",
     "e2e/details-file-source.spec.ts › details file source (#670) › real .disc source is independent, navigation-safe, and removed live when disabled",
     "e2e/details-media-info-responsive.spec.ts › responsive details media info (#466 finding 5) › modern: chips fit and stay clear of native actions from 500px through 710px",
     "e2e/details-view-cache.spec.ts › details view-cache (chips land in the visible page) › a wiped misc-info row is re-populated (observer gate is alive with cached duplicates)",

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 181,
+    "maxOutputCount": 183,
     "maxEsmEntryCount": 38,
-    "maxEsmOutputCount": 87,
+    "maxEsmOutputCount": 88,
     "maxIndividualEsmRawBytes": 262144,
     "maxBootRequests": 17,
     "maxBootRawBytes": 524288,
@@ -14,7 +14,7 @@
     "maxFeatureRequests": 20,
     "maxFeatureRawBytes": 524288,
     "maxFeatureGzipBytes": 196608,
-    "maxFeatureExpandedRequests": 22,
+    "maxFeatureExpandedRequests": 23,
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "limits": {
-    "maxOutputCount": 183,
+    "maxOutputCount": 181,
     "maxEsmEntryCount": 38,
-    "maxEsmOutputCount": 88,
+    "maxEsmOutputCount": 87,
     "maxIndividualEsmRawBytes": 262144,
     "maxBootRequests": 17,
     "maxBootRawBytes": 524288,
@@ -14,7 +14,7 @@
     "maxFeatureRequests": 20,
     "maxFeatureRawBytes": 524288,
     "maxFeatureGzipBytes": 196608,
-    "maxFeatureExpandedRequests": 23,
+    "maxFeatureExpandedRequests": 22,
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7427698,
+    "maxTotalRawBytes": 7445214,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7516492
+    "maxPublishedRawBytes": 7534008
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2944, totalLines: 3329 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45122, totalLines: 54910 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45123, totalLines: 54910 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2944,
         maximumCoveredLines: 2944,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 5,
+        cleanRuns: 6,
         minimumCoveredLines: 45115,
-        maximumCoveredLines: 45122,
+        maximumCoveredLines: 45123,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 7);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 8);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 45122,
+        "coveredLines": 45123,
         "totalLines": 54910
       },
       "observations": {
-        "cleanRuns": 5,
+        "cleanRuns": 6,
         "minimumCoveredLines": 45115,
-        "maximumCoveredLines": 45122
+        "maximumCoveredLines": 45123
       },
       "tolerance": {
-        "missingCoveredLines": 7,
-        "rationale": "Issue #670 adds the independently persisted ShowFileSource setting to the canonical admin and per-user configuration contracts and covers the fail-closed unknown-target and unsupported-evidence branches in the admin target settings controller. Three clean local .NET 10.0.10 full-suite runs on this exact 54,910-line source and 4,302-test scope passed every test and each measured 45,115/54,910 covered lines (82.162%). The first hosted Unit run at exact head bdf916990739dc39f273601544d7546e50614e68 also passed all 4,302 tests and measured 45,121/54,910 (82.173%): https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/31081606003/job/92551460291. The next hosted Unit run at exact amended head f0bd15ebdb818629302bb49b033167b2c53cf4db again passed all 4,302 tests and measured 45,122/54,910 (82.174%): https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/31098714654/job/92606837612. The reviewed high-water is therefore 45,122/54,910, while the directly observed identical-scope floor remains 45,115/54,910; the seven-line spread is 0.012748 percentage points, within the 0.15-point policy maximum. One separate non-clean 4,301/4,302 local run is excluded from the five-run coverage envelope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 8,
+        "rationale": "Issue #670 adds the independently persisted ShowFileSource setting to the canonical admin and per-user configuration contracts and covers the fail-closed unknown-target and unsupported-evidence branches in the admin target settings controller. Three clean local .NET 10.0.10 full-suite runs on this exact 54,910-line source and 4,302-test scope passed every test and each measured 45,115/54,910 covered lines (82.162%). Hosted Unit runs at exact reviewed heads bdf916990739dc39f273601544d7546e50614e68 and f0bd15ebdb818629302bb49b033167b2c53cf4db passed all 4,302 tests and measured 45,121/54,910 (82.173%) and 45,122/54,910 (82.174%): GitHub Actions runs 31081606003/job/92551460291 and 31098714654/job/92606837612. The clean hosted Unit run at exact #710 head 1c2efa34f913f6a58c76820e5b16b5e263118764 also passed all 4,302 tests and measured 45,123/54,910 (82.176%): GitHub Actions run 31882082338/job/95005978501. The reviewed high-water is therefore 45,123/54,910, while the directly observed identical-scope floor remains 45,115/54,910; the eight-line spread is 0.014569 percentage points, within the 0.15-point policy maximum. One separate non-clean 4,301/4,302 local run is excluded from the six-run coverage envelope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Closes #710.

## Summary

- normalize the complete supported FSK age/alias matrix and render the official digital FSK palette
- preserve and restore host-owned text, rating, title, and accessibility metadata across retained-node updates, detach/reattach, navigation, identity changes, and teardown
- observe both text-node and whole-text replacements with bounded lifecycle ownership
- add exact alias, palette, contrast, forced-colors, computed-theme, predecessor-cleanup, and production lifecycle regressions

## Validation

- focused ratings tests: 59 passed
- full client coverage: 2,455 passed; exact ratchet passed
- real Jellyfin 12 Chromium accessibility/theme test passed
- script tests: 655 passed
- source and legacy typechecks, performance, syntax, strict docs, changed-file lint, deterministic bundle, Release build, and diff checks passed
- independent terminal review approved the current-main branch