### PR TITLE
fix: honor per-user home row removal policy

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
@@ -27,6 +27,7 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
     private readonly User _target;
     private readonly StubUserManager _userManager;
     private readonly FakePluginConfigProvider _provider;
+    private readonly RemoveFromHomePolicyService _removePolicy;
 
     public AdminTargetUserSettingsControllerTests()
     {
@@ -42,12 +43,15 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
         _target = new User("Target <User> & Co", "Provider", "PasswordProvider");
         _userManager = new StubUserManager(_actor, _target);
         _provider = new FakePluginConfigProvider(new PluginConfiguration());
+        _removePolicy = new RemoveFromHomePolicyService(
+            _manager,
+            NullLogger<RemoveFromHomePolicyService>.Instance);
     }
 
     public void Dispose()
     {
-        HiddenContentResponseFilter.InvalidateUserSettings(ActorId);
-        HiddenContentResponseFilter.InvalidateUserSettings(TargetId);
+        _removePolicy.Invalidate(ActorId);
+        _removePolicy.Invalidate(TargetId);
         try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
     }
 
@@ -150,8 +154,8 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
             IsAdmin = true
         };
         candidate.ExtensionData["FutureSetting"] = extensionDocument.RootElement.Clone();
-        HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(ActorId, enabled: true);
-        HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(TargetId, enabled: false);
+        _removePolicy.SeedCacheForTest(ActorId, enabled: true);
+        _removePolicy.SeedCacheForTest(TargetId, enabled: false);
 
         var saveController = Controller(ifMatch: 3);
         var committed = AssertResponse<UserSettings>(
@@ -162,8 +166,8 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
         Assert.Equal("time", committed.Data!.WatchProgressMode);
         Assert.False(committed.Data.IsAdmin);
         Assert.Equal("\"4\"", saveController.Response.Headers.ETag.ToString());
-        Assert.True(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(ActorId));
-        Assert.False(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(TargetId));
+        Assert.True(_removePolicy.IsCachedForTest(ActorId));
+        Assert.False(_removePolicy.IsCachedForTest(TargetId));
 
         var targetStored = _manager.GetUserConfigurationStrict<UserSettings>(
             TargetId,
@@ -893,7 +897,8 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
             new SeerrCache(_provider),
             _provider,
             _manager,
-            new CountingLibraryManager());
+            new CountingLibraryManager(),
+            _removePolicy);
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/AdminTargetUserSettingsControllerTests.cs
@@ -46,6 +46,8 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
 
     public void Dispose()
     {
+        HiddenContentResponseFilter.InvalidateUserSettings(ActorId);
+        HiddenContentResponseFilter.InvalidateUserSettings(TargetId);
         try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
     }
 
@@ -148,6 +150,8 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
             IsAdmin = true
         };
         candidate.ExtensionData["FutureSetting"] = extensionDocument.RootElement.Clone();
+        HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(ActorId, enabled: true);
+        HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(TargetId, enabled: false);
 
         var saveController = Controller(ifMatch: 3);
         var committed = AssertResponse<UserSettings>(
@@ -158,6 +162,8 @@ public sealed class AdminTargetUserSettingsControllerTests : IDisposable
         Assert.Equal("time", committed.Data!.WatchProgressMode);
         Assert.False(committed.Data.IsAdmin);
         Assert.Equal("\"4\"", saveController.Response.Headers.ETag.ToString());
+        Assert.True(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(ActorId));
+        Assert.False(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(TargetId));
 
         var targetStored = _manager.GetUserConfigurationStrict<UserSettings>(
             TargetId,

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/BookmarkRevisionControllerTests.cs
@@ -72,7 +72,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 new SeerrCache(provider),
                 provider,
                 _manager,
-                _libraryManager);
+                _libraryManager,
+                new RemoveFromHomePolicyService(
+                    _manager,
+                    NullLogger<RemoveFromHomePolicyService>.Instance));
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/HiddenContentPayloadControllerTests.cs
@@ -13,16 +13,27 @@ using Jellyfin.Plugin.JellyfinCanopy.Tests.Platform;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.AspNetCore.Routing;
 using Xunit;
+using AudioItem = MediaBrowser.Controller.Entities.Audio.Audio;
 
 namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers;
 
 public sealed class HiddenContentPayloadControllerTests : IDisposable
 {
+    private sealed class Book : MediaBrowser.Controller.Entities.BaseItem
+    {
+    }
+
     private readonly string _baseDir;
     private readonly UserConfigurationManager _manager;
     private readonly User _user;
@@ -153,6 +164,139 @@ public sealed class HiddenContentPayloadControllerTests : IDisposable
             System.Text.Json.JsonSerializer.Serialize(scopedHide.Value),
             StringComparison.OrdinalIgnoreCase);
         Assert.False(File.Exists(HiddenPath));
+    }
+
+    [Fact]
+    public async Task SuccessfulScopedPost_IsVisibleToAFreshResponseFilterThroughRealInvalidation()
+    {
+        var itemId = Guid.NewGuid();
+        _provider.Current = new PluginConfiguration
+        {
+            HiddenContentEnabled = false,
+            RemoveContinueWatchingEnabled = false,
+        };
+        _manager.SaveUserConfiguration(
+            UserId,
+            "settings.json",
+            new UserSettings { RemoveContinueWatchingEnabled = true });
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdUserHook = (id, scopedUser) =>
+                id == itemId && scopedUser?.Id == _user.Id
+                    ? new Movie { Id = itemId, Name = "Caller-authorized resume item" }
+                    : null
+        };
+        var policy = new RemoveFromHomePolicyService(
+            _manager,
+            NullLogger<RemoveFromHomePolicyService>.Instance);
+
+        // Prime the real hidden-context cache with an empty pre-mutation view.
+        Assert.False(await FilterResumeItem(itemId, library, policy));
+        Assert.True(HiddenContentResponseFilter.IsCachedForTest(UserId));
+
+        var posted = Controller(
+                NullLogger<HiddenContentController>.Instance,
+                library)
+            .HideFromContinueWatching(itemId.ToString("D"));
+        Assert.IsType<OkObjectResult>(posted);
+        Assert.False(HiddenContentResponseFilter.IsCachedForTest(UserId));
+
+        // A distinct filter instance represents the next native Resume request.
+        Assert.True(await FilterResumeItem(itemId, library, policy));
+    }
+
+    [Fact]
+    public void AccessibleAudioAndBookResumeItems_UseTheRealCallerScopedEndpoint()
+    {
+        MediaBrowser.Controller.Entities.BaseItem[] items =
+        {
+            new AudioItem { Id = Guid.NewGuid(), Name = "Authorized audio resume" },
+            new Book { Id = Guid.NewGuid(), Name = "Authorized book resume" },
+        };
+        var byId = items.ToDictionary(item => item.Id);
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdUserHook = (id, scopedUser) =>
+                scopedUser?.Id == _user.Id && byId.TryGetValue(id, out var item)
+                    ? item
+                    : null
+        };
+        var controller = Controller(
+            NullLogger<HiddenContentController>.Instance,
+            library);
+
+        foreach (var item in items)
+        {
+            Assert.IsType<OkObjectResult>(
+                controller.HideFromContinueWatching(item.Id.ToString("N")));
+        }
+
+        var stored = _manager.GetUserConfigurationStrict<UserHiddenContent>(
+            UserId,
+            "hidden-content.json");
+        Assert.Equal(2, stored.Items.Count);
+        Assert.Collection(
+            stored.Items.Values.OrderBy(item => item.Type),
+            audio =>
+            {
+                Assert.Equal("Audio", audio.Type);
+                Assert.Equal("continuewatching", audio.HideScope);
+            },
+            book =>
+            {
+                Assert.Equal("Book", book.Type);
+                Assert.Equal("continuewatching", book.HideScope);
+            });
+    }
+
+    private async Task<bool> FilterResumeItem(
+        Guid itemId,
+        CountingLibraryManager library,
+        RemoveFromHomePolicyService policy)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim("Jellyfin-UserId", _user.Id.ToString()) },
+                "TestAuth")),
+        };
+        var routeData = new RouteData();
+        routeData.Values["controller"] = "Items";
+        routeData.Values["action"] = "GetResumeItems";
+        var actionContext = new ActionContext(
+            httpContext,
+            routeData,
+            new ActionDescriptor(),
+            new ModelStateDictionary());
+        var filters = new List<IFilterMetadata>();
+        var controller = new object();
+        var executing = new ActionExecutingContext(
+            actionContext,
+            filters,
+            new Dictionary<string, object?>(),
+            controller);
+        var executed = new ActionExecutedContext(actionContext, filters, controller)
+        {
+            Result = new ObjectResult(new QueryResult<BaseItemDto>(
+                0,
+                1,
+                new List<BaseItemDto> { new() { Id = itemId } })),
+        };
+        var filter = new HiddenContentResponseFilter(
+            _manager,
+            NullLogger<HiddenContentResponseFilter>.Instance,
+            _provider,
+            policy,
+            new HiddenContentHierarchyResolver(
+                library,
+                new StubUserManager(_user)));
+
+        await filter.OnActionExecutionAsync(
+            executing,
+            () => Task.FromResult(executed));
+
+        var result = Assert.IsType<ObjectResult>(executed.Result);
+        return Assert.IsType<QueryResult<BaseItemDto>>(result.Value).Items.Count == 0;
     }
 
     [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
@@ -19,6 +19,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         private readonly UserConfigurationManager _manager;
         private readonly User _user;
         private readonly FakePluginConfigProvider _provider;
+        private readonly RemoveFromHomePolicyService _removePolicy;
 
         public UserSettingsRevisionControllerTests()
         {
@@ -27,6 +28,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             _manager = new UserConfigurationManager(new StubAppPaths(_baseDir), NullLogger<UserConfigurationManager>.Instance);
             _user = new User("settings-user", "Provider", "PasswordProvider");
             _provider = new FakePluginConfigProvider(new PluginConfiguration());
+            _removePolicy = new RemoveFromHomePolicyService(
+                _manager,
+                NullLogger<RemoveFromHomePolicyService>.Instance);
         }
 
         private string UserId => _user.Id.ToString("N");
@@ -40,7 +44,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 
         public void Dispose()
         {
-            HiddenContentResponseFilter.InvalidateUserSettings(UserId);
+            _removePolicy.Invalidate(UserId);
             try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
         }
 
@@ -56,7 +60,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 new SeerrCache(configProvider),
                 configProvider,
                 _manager,
-                new CountingLibraryManager());
+                new CountingLibraryManager(),
+                _removePolicy);
             controller.ControllerContext = new ControllerContext
             {
                 HttpContext = new DefaultHttpContext
@@ -164,8 +169,8 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         {
             SeedSettings();
             var otherUserId = Guid.NewGuid().ToString("N");
-            HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(UserId, enabled: false);
-            HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(otherUserId, enabled: true);
+            _removePolicy.SeedCacheForTest(UserId, enabled: false);
+            _removePolicy.SeedCacheForTest(otherUserId, enabled: true);
 
             var result = Controller(0).SaveUserSettingsSettings(
                 UserId,
@@ -177,20 +182,24 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
                 });
 
             Assert.IsType<OkObjectResult>(result);
-            Assert.False(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(UserId));
-            Assert.True(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(otherUserId));
+            Assert.False(_removePolicy.IsCachedForTest(UserId));
+            Assert.True(_removePolicy.IsCachedForTest(otherUserId));
 
             var filter = new HiddenContentResponseFilter(
                 _manager,
                 NullLogger<HiddenContentResponseFilter>.Instance,
                 _provider,
+                _removePolicy,
                 new HiddenContentHierarchyResolver(
                     new CountingLibraryManager(),
                     new StubUserManager(_user)));
-            Assert.True(filter.RemovePolicyEnabledForTest(_user.Id, administratorDefault: false));
+            Assert.True(_removePolicy.ShouldApply(
+                _user.Id,
+                hiddenContentEnabled: false,
+                administratorDefault: false));
 
-            HiddenContentResponseFilter.InvalidateUserSettings(otherUserId);
-            HiddenContentResponseFilter.InvalidateUserSettings(UserId);
+            _removePolicy.Invalidate(otherUserId);
+            _removePolicy.Invalidate(UserId);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserSettingsRevisionControllerTests.cs
@@ -40,6 +40,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
 
         public void Dispose()
         {
+            HiddenContentResponseFilter.InvalidateUserSettings(UserId);
             try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
         }
 
@@ -156,6 +157,40 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             var ack = Assert.IsType<UserSettingsController.UserFileMutationResponse<UserSettings>>(ok.Value);
             Assert.Equal(7, ack.Revision);
             Assert.Equal(7, _manager.GetUserConfigurationStrict<UserSettings>(UserId, "settings.json").Revision);
+        }
+
+        [Fact]
+        public void SuccessfulSettingsPost_InvalidatesOnlyTheTargetUsersEffectiveRemovePolicy()
+        {
+            SeedSettings();
+            var otherUserId = Guid.NewGuid().ToString("N");
+            HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(UserId, enabled: false);
+            HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(otherUserId, enabled: true);
+
+            var result = Controller(0).SaveUserSettingsSettings(
+                UserId,
+                new UserSettings
+                {
+                    Revision = 0,
+                    WatchProgressMode = "percentage",
+                    RemoveContinueWatchingEnabled = true,
+                });
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.False(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(UserId));
+            Assert.True(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(otherUserId));
+
+            var filter = new HiddenContentResponseFilter(
+                _manager,
+                NullLogger<HiddenContentResponseFilter>.Instance,
+                _provider,
+                new HiddenContentHierarchyResolver(
+                    new CountingLibraryManager(),
+                    new StubUserManager(_user)));
+            Assert.True(filter.RemovePolicyEnabledForTest(_user.Id, administratorDefault: false));
+
+            HiddenContentResponseFilter.InvalidateUserSettings(otherUserId);
+            HiddenContentResponseFilter.InvalidateUserSettings(UserId);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserStoreRecoveryControllerTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Controllers/UserStoreRecoveryControllerTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using Jellyfin.Plugin.JellyfinCanopy.Configuration;
 using Jellyfin.Plugin.JellyfinCanopy.Controllers;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
 using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
 using MediaBrowser.Common.Api;
 using Microsoft.AspNetCore.Authorization;
@@ -18,6 +19,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
         private readonly string _baseDir;
         private readonly string _userId = Guid.NewGuid().ToString("N");
         private readonly UserConfigurationManager _manager;
+        private readonly RemoveFromHomePolicyService _removePolicy;
 
         public UserStoreRecoveryControllerTests()
         {
@@ -26,6 +28,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             _manager = new UserConfigurationManager(
                 new StubAppPaths(_baseDir),
                 NullLogger<UserConfigurationManager>.Instance);
+            _removePolicy = new RemoveFromHomePolicyService(
+                _manager,
+                NullLogger<RemoveFromHomePolicyService>.Instance);
         }
 
         public void Dispose()
@@ -37,7 +42,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Controllers
             => Path.Combine(_baseDir, "configurations", "Jellyfin.Plugin.JellyfinCanopy", _userId);
 
         private UserStoreRecoveryController Controller()
-            => new(_manager, NullLogger<UserStoreRecoveryController>.Instance);
+            => new(
+                _manager,
+                NullLogger<UserStoreRecoveryController>.Instance,
+                _removePolicy);
 
         private void QuarantineSettings()
         {

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/ContinueWatchingEventWritersTests.cs
@@ -69,7 +69,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 Assert.True(HiddenContentResponseFilter.IsCachedForTest(userIdN));
 
                 var provider = new FakePluginConfigProvider(new PluginConfiguration { RemoveContinueWatchingEnabled = true });
-                var consumer = new ContinueWatchingPlaybackConsumer(ucm, NullLogger<ContinueWatchingPlaybackConsumer>.Instance, provider);
+                var consumer = new ContinueWatchingPlaybackConsumer(
+                    ucm,
+                    NullLogger<ContinueWatchingPlaybackConsumer>.Instance,
+                    provider,
+                    new RemoveFromHomePolicyService(
+                        ucm,
+                        NullLogger<RemoveFromHomePolicyService>.Instance));
 
                 var args = new PlaybackStartEventArgs
                 {
@@ -114,7 +120,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
 
                 var logger = new CollectingLogger<ContinueWatchingPlaybackConsumer>();
                 var provider = new FakePluginConfigProvider(new PluginConfiguration { RemoveContinueWatchingEnabled = true });
-                var consumer = new ContinueWatchingPlaybackConsumer(ucm, logger, provider);
+                var consumer = new ContinueWatchingPlaybackConsumer(
+                    ucm,
+                    logger,
+                    provider,
+                    new RemoveFromHomePolicyService(
+                        ucm,
+                        NullLogger<RemoveFromHomePolicyService>.Instance));
                 var args = new PlaybackStartEventArgs
                 {
                     Item = new Movie { Id = Guid.NewGuid() },
@@ -131,6 +143,202 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 try { Directory.Delete(tempDir, recursive: true); } catch { }
             }
         }
+
+        [Theory]
+        [InlineData(false, false, true, false)]
+        [InlineData(false, true, false, true)]
+        [InlineData(true, false, false, false)]
+        [InlineData(false, false, null, true)]
+        [InlineData(false, true, null, false)]
+        public async Task Consumer_UsesExactSessionUsersEffectivePolicy(
+            bool hiddenContentEnabled,
+            bool administratorDefault,
+            bool? userOverride,
+            bool entryRemains)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-policy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var manager = new UserConfigurationManager(
+                    new StubAppPaths(tempDir),
+                    NullLogger<UserConfigurationManager>.Instance);
+                var policy = new RemoveFromHomePolicyService(
+                    manager,
+                    NullLogger<RemoveFromHomePolicyService>.Instance);
+                var userId = Guid.NewGuid();
+                var itemId = Guid.NewGuid();
+                SavePlaybackEntry(manager, userId, itemId);
+                if (userOverride.HasValue)
+                {
+                    manager.SaveUserConfiguration(
+                        userId.ToString("N"),
+                        "settings.json",
+                        new UserSettings { RemoveContinueWatchingEnabled = userOverride.Value });
+                }
+
+                var consumer = Consumer(
+                    manager,
+                    policy,
+                    hiddenContentEnabled,
+                    administratorDefault);
+                await consumer.OnEvent(Playback(userId, itemId));
+
+                var stored = manager.GetUserConfigurationStrict<UserHiddenContent>(
+                    userId.ToString("N"),
+                    "hidden-content.json");
+                Assert.Equal(entryRemains, stored.Items.ContainsKey("entry"));
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task Consumer_TwoSessions_DoNotSharePolicyOrMutateTheOtherUsersStore()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-two-user-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var manager = new UserConfigurationManager(
+                    new StubAppPaths(tempDir),
+                    NullLogger<UserConfigurationManager>.Instance);
+                var policy = new RemoveFromHomePolicyService(
+                    manager,
+                    NullLogger<RemoveFromHomePolicyService>.Instance);
+                var enabledUser = Guid.NewGuid();
+                var disabledUser = Guid.NewGuid();
+                var sharedItem = Guid.NewGuid();
+                SavePlaybackEntry(manager, enabledUser, sharedItem);
+                SavePlaybackEntry(manager, disabledUser, sharedItem);
+                manager.SaveUserConfiguration(
+                    enabledUser.ToString("N"),
+                    "settings.json",
+                    new UserSettings { RemoveContinueWatchingEnabled = true });
+                manager.SaveUserConfiguration(
+                    disabledUser.ToString("N"),
+                    "settings.json",
+                    new UserSettings { RemoveContinueWatchingEnabled = false });
+                var consumer = Consumer(
+                    manager,
+                    policy,
+                    hiddenContentEnabled: false,
+                    administratorDefault: false);
+
+                await Task.WhenAll(
+                    consumer.OnEvent(Playback(enabledUser, sharedItem)),
+                    consumer.OnEvent(Playback(disabledUser, sharedItem)));
+
+                Assert.Empty(manager.GetUserConfigurationStrict<UserHiddenContent>(
+                    enabledUser.ToString("N"),
+                    "hidden-content.json").Items);
+                Assert.True(manager.GetUserConfigurationStrict<UserHiddenContent>(
+                    disabledUser.ToString("N"),
+                    "hidden-content.json").Items.ContainsKey("entry"));
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task Consumer_CorruptPolicy_ColdFailsClosed_AndExpiredCacheRetainsLastKnownGood()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jc-cw-policy-fault-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var manager = new UserConfigurationManager(
+                    new StubAppPaths(tempDir),
+                    NullLogger<UserConfigurationManager>.Instance);
+                var policy = new RemoveFromHomePolicyService(
+                    manager,
+                    NullLogger<RemoveFromHomePolicyService>.Instance);
+                var coldUser = Guid.NewGuid();
+                var coldItem = Guid.NewGuid();
+                SavePlaybackEntry(manager, coldUser, coldItem);
+                File.WriteAllText(UserFile(tempDir, coldUser, "settings.json"), "{ corrupt ]");
+
+                var consumer = Consumer(manager, policy, false, false);
+                await consumer.OnEvent(Playback(coldUser, coldItem));
+                Assert.Empty(manager.GetUserConfigurationStrict<UserHiddenContent>(
+                    coldUser.ToString("N"),
+                    "hidden-content.json").Items);
+
+                var retainedUser = Guid.NewGuid();
+                var retainedItem = Guid.NewGuid();
+                SavePlaybackEntry(manager, retainedUser, retainedItem);
+                manager.SaveUserConfiguration(
+                    retainedUser.ToString("N"),
+                    "settings.json",
+                    new UserSettings { RemoveContinueWatchingEnabled = false });
+                Assert.False(policy.ShouldApply(
+                    retainedUser,
+                    hiddenContentEnabled: false,
+                    administratorDefault: true));
+                File.WriteAllText(UserFile(tempDir, retainedUser, "settings.json"), "{ corrupt ]");
+                policy.ExpireCacheForTest(retainedUser.ToString("N"));
+
+                await consumer.OnEvent(Playback(retainedUser, retainedItem));
+                Assert.True(manager.GetUserConfigurationStrict<UserHiddenContent>(
+                    retainedUser.ToString("N"),
+                    "hidden-content.json").Items.ContainsKey("entry"));
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch { }
+            }
+        }
+
+        private static ContinueWatchingPlaybackConsumer Consumer(
+            UserConfigurationManager manager,
+            RemoveFromHomePolicyService policy,
+            bool hiddenContentEnabled,
+            bool administratorDefault)
+            => new(
+                manager,
+                NullLogger<ContinueWatchingPlaybackConsumer>.Instance,
+                new FakePluginConfigProvider(new PluginConfiguration
+                {
+                    HiddenContentEnabled = hiddenContentEnabled,
+                    RemoveContinueWatchingEnabled = administratorDefault,
+                }),
+                policy);
+
+        private static PlaybackStartEventArgs Playback(Guid userId, Guid itemId)
+            => new()
+            {
+                Item = new Movie { Id = itemId },
+                Session = new SessionInfo(null!, NullLogger.Instance) { UserId = userId },
+            };
+
+        private static void SavePlaybackEntry(
+            UserConfigurationManager manager,
+            Guid userId,
+            Guid itemId)
+        {
+            var hidden = new UserHiddenContent();
+            hidden.Items["entry"] = new HiddenContentItem
+            {
+                ItemId = itemId.ToString("N"),
+                HideScope = "continuewatching",
+            };
+            manager.SaveUserConfiguration(userId.ToString("N"), "hidden-content.json", hidden);
+        }
+
+        private static string UserFile(
+            string baseDir,
+            Guid userId,
+            string fileName)
+            => Path.Combine(
+                baseDir,
+                "configurations",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                userId.ToString("N"),
+                fileName);
 
         [Fact]
         public void LibraryHook_BulkRemoval_DrainsOncePerUser()

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentRemovePolicyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentRemovePolicyTests.cs
@@ -24,6 +24,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
     {
         private readonly string _baseDir;
         private readonly UserConfigurationManager _manager;
+        private readonly RemoveFromHomePolicyService _policy;
         private readonly HashSet<string> _userIds = new(StringComparer.Ordinal);
 
         public HiddenContentRemovePolicyTests()
@@ -35,6 +36,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             _manager = new UserConfigurationManager(
                 new StubAppPaths(_baseDir),
                 NullLogger<UserConfigurationManager>.Instance);
+            _policy = new RemoveFromHomePolicyService(
+                _manager,
+                NullLogger<RemoveFromHomePolicyService>.Instance);
         }
 
         public void Dispose()
@@ -42,7 +46,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             foreach (var userId in _userIds)
             {
                 HiddenContentResponseFilter.InvalidateUser(userId);
-                HiddenContentResponseFilter.InvalidateUserSettings(userId);
+                _policy.Invalidate(userId);
             }
             try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
         }
@@ -193,7 +197,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             var coldItem = Guid.NewGuid();
             SaveHiddenItem(coldUser, coldItem);
             File.WriteAllText(PathFor(coldUser, "settings.json"), "{ not valid json ]");
-            HiddenContentResponseFilter.InvalidateUserSettings(coldUser.ToString("N"));
+            _policy.Invalidate(coldUser.ToString("N"));
 
             Assert.True(await RunFilter(
                 coldUser,
@@ -217,7 +221,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 new PluginConfiguration { HiddenContentEnabled = false }));
 
             File.WriteAllText(PathFor(retainedUser, "settings.json"), "{ not valid json ]");
-            HiddenContentResponseFilter.ExpireRemovePolicyCacheForTest(retainedUser.ToString("N"));
+            _policy.ExpireCacheForTest(retainedUser.ToString("N"));
             Assert.False(await RunFilter(
                 retainedUser,
                 retainedItem,
@@ -229,7 +233,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 retainedUser.ToString("N"),
                 "settings.json",
                 new UserSettings { RemoveContinueWatchingEnabled = true });
-            HiddenContentResponseFilter.InvalidateUserSettings(retainedUser.ToString("N"));
+            _policy.Invalidate(retainedUser.ToString("N"));
             Assert.True(await RunFilter(
                 retainedUser,
                 retainedItem,
@@ -289,19 +293,19 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
         [Fact]
         public void EffectivePolicyCache_IsHardBounded()
         {
-            Assert.Equal(2_048, HiddenContentResponseFilter.RemovePolicyCacheMaximumEntriesForTest);
-            Assert.Equal(2_048, HiddenContentResponseFilter.RemovePolicyCacheMaximumWeightForTest);
+            Assert.Equal(2_048, _policy.MaximumEntriesForTest);
+            Assert.Equal(2_048, _policy.MaximumWeightForTest);
         }
 
         [Fact]
         public void EffectivePolicyInvalidation_CanonicalizesDashedUserIds()
         {
             var userId = Guid.NewGuid();
-            HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(userId.ToString("N"), enabled: true);
+            _policy.SeedCacheForTest(userId.ToString("N"), enabled: true);
 
-            HiddenContentResponseFilter.InvalidateUserSettings(userId.ToString("D"));
+            _policy.Invalidate(userId.ToString("D"));
 
-            Assert.False(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(userId.ToString("N")));
+            Assert.False(_policy.IsCachedForTest(userId.ToString("N")));
         }
 
         private void SaveHiddenItem(Guid userId, Guid itemId)
@@ -316,7 +320,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
             };
             _manager.SaveUserConfiguration(userId.ToString("N"), "hidden-content.json", policy);
             HiddenContentResponseFilter.InvalidateUser(userId.ToString("N"));
-            HiddenContentResponseFilter.InvalidateUserSettings(userId.ToString("N"));
+            _policy.Invalidate(userId.ToString("N"));
         }
 
         private string PathFor(Guid userId, string fileName)
@@ -372,6 +376,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 _manager,
                 NullLogger<HiddenContentResponseFilter>.Instance,
                 new FakePluginConfigProvider(configuration),
+                _policy,
                 hierarchy);
 
             await filter.OnActionExecutionAsync(executing, () => Task.FromResult(executed));

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentRemovePolicyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentRemovePolicyTests.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Services;
+using Jellyfin.Plugin.JellyfinCanopy.Tests.TestDoubles;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
+{
+    public sealed class HiddenContentRemovePolicyTests : IDisposable
+    {
+        private readonly string _baseDir;
+        private readonly UserConfigurationManager _manager;
+        private readonly HashSet<string> _userIds = new(StringComparer.Ordinal);
+
+        public HiddenContentRemovePolicyTests()
+        {
+            _baseDir = Path.Combine(
+                Path.GetTempPath(),
+                "jc-remove-policy-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDir);
+            _manager = new UserConfigurationManager(
+                new StubAppPaths(_baseDir),
+                NullLogger<UserConfigurationManager>.Instance);
+        }
+
+        public void Dispose()
+        {
+            foreach (var userId in _userIds)
+            {
+                HiddenContentResponseFilter.InvalidateUser(userId);
+                HiddenContentResponseFilter.InvalidateUserSettings(userId);
+            }
+            try { Directory.Delete(_baseDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        public static IEnumerable<object[]> EffectivePolicyCases()
+        {
+            foreach (var administratorDefault in new[] { false, true })
+            {
+                foreach (var userOverride in new[] { false, true })
+                {
+                    yield return new object[]
+                    {
+                        administratorDefault,
+                        userOverride,
+                        "Items",
+                        "GetResumeItems",
+                    };
+                    yield return new object[]
+                    {
+                        administratorDefault,
+                        userOverride,
+                        "TvShows",
+                        "GetNextUp",
+                    };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(EffectivePolicyCases))]
+        public async Task AuthenticatedUserSetting_OwnsBothRemoveSurfaces(
+            bool administratorDefault,
+            bool userOverride,
+            string controller,
+            string action)
+        {
+            var userId = Guid.NewGuid();
+            var hiddenItem = Guid.NewGuid();
+            SaveHiddenItem(userId, hiddenItem);
+            _manager.SaveUserConfiguration(
+                userId.ToString("N"),
+                "settings.json",
+                new UserSettings { RemoveContinueWatchingEnabled = userOverride });
+
+            var hidden = await RunFilter(
+                userId,
+                hiddenItem,
+                controller,
+                action,
+                new PluginConfiguration
+                {
+                    HiddenContentEnabled = false,
+                    RemoveContinueWatchingEnabled = administratorDefault,
+                });
+
+            Assert.Equal(userOverride, hidden);
+        }
+
+        [Fact]
+        public async Task SimultaneousUsers_DoNotShareEffectivePolicy()
+        {
+            var enabledUser = Guid.NewGuid();
+            var disabledUser = Guid.NewGuid();
+            var enabledItem = Guid.NewGuid();
+            var disabledItem = Guid.NewGuid();
+            SaveHiddenItem(enabledUser, enabledItem);
+            SaveHiddenItem(disabledUser, disabledItem);
+            _manager.SaveUserConfiguration(
+                enabledUser.ToString("N"),
+                "settings.json",
+                new UserSettings { RemoveContinueWatchingEnabled = true });
+            _manager.SaveUserConfiguration(
+                disabledUser.ToString("N"),
+                "settings.json",
+                new UserSettings { RemoveContinueWatchingEnabled = false });
+            var config = new PluginConfiguration
+            {
+                HiddenContentEnabled = false,
+                RemoveContinueWatchingEnabled = true,
+            };
+
+            var results = await Task.WhenAll(
+                RunFilter(enabledUser, enabledItem, "Items", "GetResumeItems", config),
+                RunFilter(disabledUser, disabledItem, "Items", "GetResumeItems", config));
+
+            Assert.True(results[0]);
+            Assert.False(results[1]);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task MissingSettings_UsesAdministratorDefaultWithoutCreatingAFile(bool administratorDefault)
+        {
+            var userId = Guid.NewGuid();
+            var hiddenItem = Guid.NewGuid();
+            SaveHiddenItem(userId, hiddenItem);
+            var settingsPath = PathFor(userId, "settings.json");
+
+            var hidden = await RunFilter(
+                userId,
+                hiddenItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration
+                {
+                    HiddenContentEnabled = false,
+                    RemoveContinueWatchingEnabled = administratorDefault,
+                });
+
+            Assert.Equal(administratorDefault, hidden);
+            Assert.False(File.Exists(settingsPath));
+        }
+
+        [Fact]
+        public async Task MissingSettings_TracksTheLiveAdministratorDefaultWithoutBecomingAnOverride()
+        {
+            var userId = Guid.NewGuid();
+            var hiddenItem = Guid.NewGuid();
+            SaveHiddenItem(userId, hiddenItem);
+
+            Assert.True(await RunFilter(
+                userId,
+                hiddenItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration
+                {
+                    HiddenContentEnabled = false,
+                    RemoveContinueWatchingEnabled = true,
+                }));
+            Assert.False(await RunFilter(
+                userId,
+                hiddenItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration
+                {
+                    HiddenContentEnabled = false,
+                    RemoveContinueWatchingEnabled = false,
+                }));
+        }
+
+        [Fact]
+        public async Task CorruptSettings_ColdStartFailsClosed_ThenRetainsLastKnownGoodAndInvalidatesOnRepair()
+        {
+            var coldUser = Guid.NewGuid();
+            var coldItem = Guid.NewGuid();
+            SaveHiddenItem(coldUser, coldItem);
+            File.WriteAllText(PathFor(coldUser, "settings.json"), "{ not valid json ]");
+            HiddenContentResponseFilter.InvalidateUserSettings(coldUser.ToString("N"));
+
+            Assert.True(await RunFilter(
+                coldUser,
+                coldItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration { HiddenContentEnabled = false }));
+
+            var retainedUser = Guid.NewGuid();
+            var retainedItem = Guid.NewGuid();
+            SaveHiddenItem(retainedUser, retainedItem);
+            _manager.SaveUserConfiguration(
+                retainedUser.ToString("N"),
+                "settings.json",
+                new UserSettings { RemoveContinueWatchingEnabled = false });
+            Assert.False(await RunFilter(
+                retainedUser,
+                retainedItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration { HiddenContentEnabled = false }));
+
+            File.WriteAllText(PathFor(retainedUser, "settings.json"), "{ not valid json ]");
+            HiddenContentResponseFilter.ExpireRemovePolicyCacheForTest(retainedUser.ToString("N"));
+            Assert.False(await RunFilter(
+                retainedUser,
+                retainedItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration { HiddenContentEnabled = false }));
+
+            _manager.SaveUserConfiguration(
+                retainedUser.ToString("N"),
+                "settings.json",
+                new UserSettings { RemoveContinueWatchingEnabled = true });
+            HiddenContentResponseFilter.InvalidateUserSettings(retainedUser.ToString("N"));
+            Assert.True(await RunFilter(
+                retainedUser,
+                retainedItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration { HiddenContentEnabled = false }));
+        }
+
+        [Fact]
+        public async Task AnonymousRequest_BypassesPolicyBeforeAnyUserStoreAccess()
+        {
+            var hiddenItem = Guid.NewGuid();
+            var pluginStore = Path.Combine(
+                _baseDir,
+                "configurations",
+                "Jellyfin.Plugin.JellyfinCanopy");
+
+            var hidden = await RunFilter(
+                null,
+                hiddenItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration
+                {
+                    HiddenContentEnabled = false,
+                    RemoveContinueWatchingEnabled = true,
+                });
+
+            Assert.False(hidden);
+            Assert.True(Directory.Exists(pluginStore));
+            Assert.Empty(Directory.EnumerateDirectories(pluginStore));
+        }
+
+        [Fact]
+        public async Task HiddenContentMasterSwitch_RemainsIndependentOfUserRemoveSetting()
+        {
+            var userId = Guid.NewGuid();
+            var hiddenItem = Guid.NewGuid();
+            SaveHiddenItem(userId, hiddenItem);
+            _manager.SaveUserConfiguration(
+                userId.ToString("N"),
+                "settings.json",
+                new UserSettings { RemoveContinueWatchingEnabled = false });
+
+            Assert.True(await RunFilter(
+                userId,
+                hiddenItem,
+                "Items",
+                "GetResumeItems",
+                new PluginConfiguration
+                {
+                    HiddenContentEnabled = true,
+                    RemoveContinueWatchingEnabled = false,
+                }));
+        }
+
+        [Fact]
+        public void EffectivePolicyCache_IsHardBounded()
+        {
+            Assert.Equal(2_048, HiddenContentResponseFilter.RemovePolicyCacheMaximumEntriesForTest);
+            Assert.Equal(2_048, HiddenContentResponseFilter.RemovePolicyCacheMaximumWeightForTest);
+        }
+
+        [Fact]
+        public void EffectivePolicyInvalidation_CanonicalizesDashedUserIds()
+        {
+            var userId = Guid.NewGuid();
+            HiddenContentResponseFilter.SeedRemovePolicyCacheForTest(userId.ToString("N"), enabled: true);
+
+            HiddenContentResponseFilter.InvalidateUserSettings(userId.ToString("D"));
+
+            Assert.False(HiddenContentResponseFilter.IsRemovePolicyCachedForTest(userId.ToString("N")));
+        }
+
+        private void SaveHiddenItem(Guid userId, Guid itemId)
+        {
+            _userIds.Add(userId.ToString("N"));
+            var policy = new UserHiddenContent();
+            policy.Items[itemId.ToString("N")] = new HiddenContentItem
+            {
+                ItemId = itemId.ToString("N"),
+                Type = "Movie",
+                HideScope = "homesections",
+            };
+            _manager.SaveUserConfiguration(userId.ToString("N"), "hidden-content.json", policy);
+            HiddenContentResponseFilter.InvalidateUser(userId.ToString("N"));
+            HiddenContentResponseFilter.InvalidateUserSettings(userId.ToString("N"));
+        }
+
+        private string PathFor(Guid userId, string fileName)
+            => Path.Combine(
+                _baseDir,
+                "configurations",
+                "Jellyfin.Plugin.JellyfinCanopy",
+                userId.ToString("N"),
+                fileName);
+
+        private async Task<bool> RunFilter(
+            Guid? userId,
+            Guid itemId,
+            string controller,
+            string action,
+            PluginConfiguration configuration)
+        {
+            var httpContext = new DefaultHttpContext();
+            if (userId.HasValue)
+            {
+                httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                    new[] { new Claim("Jellyfin-UserId", userId.Value.ToString()) },
+                    "TestAuth"));
+            }
+
+            var routeData = new RouteData();
+            routeData.Values["controller"] = controller;
+            routeData.Values["action"] = action;
+            var actionContext = new ActionContext(
+                httpContext,
+                routeData,
+                new ActionDescriptor(),
+                new ModelStateDictionary());
+            var filters = new List<IFilterMetadata>();
+            var controllerInstance = new object();
+            var executing = new ActionExecutingContext(
+                actionContext,
+                filters,
+                new Dictionary<string, object?>(),
+                controllerInstance);
+            var upstream = new QueryResult<BaseItemDto>(
+                0,
+                1,
+                new List<BaseItemDto> { new() { Id = itemId } });
+            var executed = new ActionExecutedContext(actionContext, filters, controllerInstance)
+            {
+                Result = new ObjectResult(upstream),
+            };
+            var hierarchy = new HiddenContentHierarchyResolver(
+                new CountingLibraryManager(),
+                new StubUserManager(Array.Empty<User>()));
+            var filter = new HiddenContentResponseFilter(
+                _manager,
+                NullLogger<HiddenContentResponseFilter>.Instance,
+                new FakePluginConfigProvider(configuration),
+                hierarchy);
+
+            await filter.OnActionExecutionAsync(executing, () => Task.FromResult(executed));
+
+            var result = Assert.IsType<ObjectResult>(executed.Result);
+            var page = Assert.IsType<QueryResult<BaseItemDto>>(result.Value);
+            return page.Items.Count == 0;
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentSearchHintHierarchyTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/HiddenContentSearchHintHierarchyTests.cs
@@ -452,6 +452,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 _configManager,
                 NullLogger<HiddenContentResponseFilter>.Instance,
                 new FakePluginConfigProvider(new PluginConfiguration()),
+                new RemoveFromHomePolicyService(
+                    _configManager,
+                    NullLogger<RemoveFromHomePolicyService>.Instance),
                 hierarchy);
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/PostPaginationFilterContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/PostPaginationFilterContractTests.cs
@@ -176,6 +176,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 configManager: null!,
                 NullLogger<HiddenContentResponseFilter>.Instance,
                 new FakePluginConfigProvider(new PluginConfiguration()),
+                new RemoveFromHomePolicyService(
+                    null!,
+                    NullLogger<RemoveFromHomePolicyService>.Instance),
                 hierarchy);
         }
 
@@ -214,6 +217,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 configManager: null!,
                 NullLogger<HiddenContentResponseFilter>.Instance,
                 new FakePluginConfigProvider(config),
+                new RemoveFromHomePolicyService(
+                    null!,
+                    NullLogger<RemoveFromHomePolicyService>.Instance),
                 new HiddenContentHierarchyResolver(library, new StubUserManager(Array.Empty<User>())));
 
             var executed = new ActionExecutedContext(actionContext, filters, controller)

--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/PrivacyPolicyFaultContractTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/PrivacyPolicyFaultContractTests.cs
@@ -56,6 +56,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Tests.Services
                 _mgr,
                 NullLogger<HiddenContentResponseFilter>.Instance,
                 new FakePluginConfigProvider(new PluginConfiguration()),
+                new RemoveFromHomePolicyService(
+                    _mgr,
+                    NullLogger<RemoveFromHomePolicyService>.Instance),
                 hierarchy);
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/config-page.js
@@ -4761,7 +4761,7 @@
             }
 
             // Display
-            feat('Remove from Continue Watching', bool('removeContinueWatchingEnabled'), 'display', 'Enabled');
+            feat('Remove from Continue Watching & Next Up default', bool('removeContinueWatchingEnabled'), 'display', 'Enabled');
             feat('Hide Favorites Tab', bool('hideFavoritesTab'), 'display', 'Enabled');
             var tagCount = ['qualityTagsEnabled','genreTagsEnabled','languageTagsEnabled','ratingTagsEnabled','peopleTagsEnabled'].filter(bool).length;
             feat('Media Tags', tagCount > 0, 'display', tagCount + ' tag type(s) enabled');

--- a/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
+++ b/Jellyfin.Plugin.JellyfinCanopy/Configuration/configPage.html
@@ -257,9 +257,9 @@
                                 <div class="fieldDescription">List the audio language flags available for each title on its detail page.</div>
                             </div>
 
-                            <div class="checkboxContainer"><label><input id="removeContinueWatchingEnabled" data-config-key="RemoveContinueWatchingEnabled" is="emby-checkbox" type="checkbox"/><span>Enable "Remove from Continue Watching"</span></label></div>
+                            <div class="checkboxContainer"><label><input id="removeContinueWatchingEnabled" data-config-key="RemoveContinueWatchingEnabled" is="emby-checkbox" type="checkbox"/><span>Default: enable "Remove from Continue Watching &amp; Next Up"</span></label></div>
                             <div class="jc-setting-description" data-desc-for="removeContinueWatchingEnabled">
-                                <div class="fieldDescription">Adds a "Remove from Continue Watching" option to the right-click / long-press context menu. Hides items non-destructively, so playback position is preserved and entries appear in Hidden Content's management page (look for "Add back to Continue Watching" on each entry). Items also unhide automatically when you resume playback.</div>
+                                <div class="fieldDescription">Sets the starting value for new users. Each user's Canopy setting then controls both the menu actions and enforcement of that user's saved home-row removals when full Hidden Content is off; other users are unaffected, and Hidden Content keeps its independent filtering policy. Continue Watching includes Jellyfin's video, audio, and book resume rows. Removal is non-destructive: playback position is preserved, entries can be added back from Hidden Content, and resuming an item unhides it automatically.</div>
                             </div>
 
                             <div class="checkboxContainer"><label><input id="hideFavoritesTab" data-config-key="HideFavoritesTab" is="emby-checkbox" type="checkbox"/><span>Hide the Home "Favorites" tab</span></label></div>

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -55,6 +55,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     {
         private readonly UserConfigurationManager _userConfigurationManager;
         private readonly ILibraryManager _libraryManager;
+        private readonly RemoveFromHomePolicyService _removeFromHomePolicy;
 
         public UserSettingsController(
             IHttpClientFactory httpClientFactory,
@@ -63,11 +64,13 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             ISeerrCache seerrCache,
             IPluginConfigProvider configProvider,
             UserConfigurationManager userConfigurationManager,
-            ILibraryManager libraryManager)
+            ILibraryManager libraryManager,
+            RemoveFromHomePolicyService removeFromHomePolicy)
             : base(httpClientFactory, logger, userManager, seerrCache, configProvider)
         {
             _userConfigurationManager = userConfigurationManager;
             _libraryManager = libraryManager;
+            _removeFromHomePolicy = removeFromHomePolicy;
         }
 
         [HttpGet("user-settings/{userId}/settings.json")]
@@ -138,7 +141,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var userConfig = read.Value;
             if (read.WasCreated)
             {
-                HiddenContentResponseFilter.InvalidateUserSettings(authorizedUserId);
+                _removeFromHomePolicy.Invalidate(authorizedUserId);
                 if (!LogCrossUserFileMutationIfNeeded(
                         authorizedUserId,
                         "settings.json",
@@ -509,7 +512,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 {
                     if (string.Equals(fileName, "settings.json", StringComparison.Ordinal))
                     {
-                        HiddenContentResponseFilter.InvalidateUserSettings(authorizedUserId);
+                        _removeFromHomePolicy.Invalidate(authorizedUserId);
                     }
 
                     if (!LogCrossUserFileMutationIfNeeded(
@@ -2201,7 +2204,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         StampServerManagedFields(userId, replacement);
                         _userConfigurationManager.SaveUserConfiguration(userId, "settings.json", replacement);
                     }
-                    HiddenContentResponseFilter.InvalidateUserSettings(userId);
+                    _removeFromHomePolicy.Invalidate(userId);
                     userCount++;
                 }
                 catch (Exception ex)

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserSettingsController.cs
@@ -138,6 +138,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
             var userConfig = read.Value;
             if (read.WasCreated)
             {
+                HiddenContentResponseFilter.InvalidateUserSettings(authorizedUserId);
                 if (!LogCrossUserFileMutationIfNeeded(
                         authorizedUserId,
                         "settings.json",
@@ -506,6 +507,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
 
                 if (result.Status == UserFileCommitStatus.Success)
                 {
+                    if (string.Equals(fileName, "settings.json", StringComparison.Ordinal))
+                    {
+                        HiddenContentResponseFilter.InvalidateUserSettings(authorizedUserId);
+                    }
+
                     if (!LogCrossUserFileMutationIfNeeded(
                             authorizedUserId,
                             fileName,
@@ -2195,6 +2201,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                         StampServerManagedFields(userId, replacement);
                         _userConfigurationManager.SaveUserConfiguration(userId, "settings.json", replacement);
                     }
+                    HiddenContentResponseFilter.InvalidateUserSettings(userId);
                     userCount++;
                 }
                 catch (Exception ex)

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserStoreRecoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserStoreRecoveryController.cs
@@ -22,13 +22,16 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
     {
         private readonly UserConfigurationManager _manager;
         private readonly ILogger<UserStoreRecoveryController> _logger;
+        private readonly RemoveFromHomePolicyService _removeFromHomePolicy;
 
         public UserStoreRecoveryController(
             UserConfigurationManager manager,
-            ILogger<UserStoreRecoveryController> logger)
+            ILogger<UserStoreRecoveryController> logger,
+            RemoveFromHomePolicyService removeFromHomePolicy)
         {
             _manager = manager;
             _logger = logger;
+            _removeFromHomePolicy = removeFromHomePolicy;
         }
 
         [HttpGet]
@@ -75,7 +78,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 }
                 else if (string.Equals(fileName, "settings.json", StringComparison.Ordinal))
                 {
-                    HiddenContentResponseFilter.InvalidateUserSettings(canonicalUserId);
+                    _removeFromHomePolicy.Invalidate(canonicalUserId);
                 }
                 else if (string.Equals(fileName, "spoilerblur.json", StringComparison.Ordinal))
                 {

--- a/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserStoreRecoveryController.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Controllers/UserStoreRecoveryController.cs
@@ -73,6 +73,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Controllers
                 {
                     HiddenContentResponseFilter.InvalidateUser(canonicalUserId);
                 }
+                else if (string.Equals(fileName, "settings.json", StringComparison.Ordinal))
+                {
+                    HiddenContentResponseFilter.InvalidateUserSettings(canonicalUserId);
+                }
                 else if (string.Equals(fileName, "spoilerblur.json", StringComparison.Ordinal))
                 {
                     SpoilerUserResolver.InvalidateUser(canonicalUserId);

--- a/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/EventHandlers/ContinueWatchingPlaybackEvents.cs
@@ -114,35 +114,42 @@ namespace Jellyfin.Plugin.JellyfinCanopy.EventHandlers
         private readonly UserConfigurationManager _configManager;
         private readonly ILogger<ContinueWatchingPlaybackConsumer> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly RemoveFromHomePolicyService _removeFromHomePolicy;
 
-        public ContinueWatchingPlaybackConsumer(UserConfigurationManager configManager, ILogger<ContinueWatchingPlaybackConsumer> logger, IPluginConfigProvider configProvider)
+        public ContinueWatchingPlaybackConsumer(
+            UserConfigurationManager configManager,
+            ILogger<ContinueWatchingPlaybackConsumer> logger,
+            IPluginConfigProvider configProvider,
+            RemoveFromHomePolicyService removeFromHomePolicy)
         {
             _configManager = configManager;
             _logger = logger;
             _configProvider = configProvider;
+            _removeFromHomePolicy = removeFromHomePolicy;
         }
 
         public Task OnEvent(PlaybackStartEventArgs eventArgs)
         {
             try
             {
-                // Mirror the response filter's HC + RCW gate (HiddenContentResponseFilter.cs). When admin runs
-                // RCW=on / HC=off, the filter still strips continuewatching-scope entries; without this branch
-                // resume would never auto-clear those entries and the user would see them stay hidden forever.
-                var cfg = _configProvider.ConfigurationOrNull;
-                var hcEnabled = cfg?.HiddenContentEnabled == true;
-                var rcwEnabled = cfg?.RemoveContinueWatchingEnabled == true;
-                if (!hcEnabled && !rcwEnabled)
-                {
-                    return Task.CompletedTask;
-                }
-
                 var item = eventArgs?.Item;
                 var session = eventArgs?.Session;
                 if (item == null || session == null) return Task.CompletedTask;
 
                 var userId = session.UserId;
                 if (userId == Guid.Empty) return Task.CompletedTask;
+
+                // Resolve policy only after the playback session has supplied the
+                // owning user. The response filter and playback auto-unhide share
+                // this exact bounded per-user policy/cache owner.
+                var cfg = _configProvider.ConfigurationOrNull;
+                if (!_removeFromHomePolicy.ShouldApply(
+                    userId,
+                    cfg?.HiddenContentEnabled == true,
+                    cfg?.RemoveContinueWatchingEnabled == true))
+                {
+                    return Task.CompletedTask;
+                }
 
                 var itemIdStr = item.Id.ToString();
                 var seriesIdStr = item is Episode ep && ep.SeriesId != Guid.Empty

--- a/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/PluginServiceRegistrator.cs
@@ -207,6 +207,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy
             serviceCollection.AddSingleton<Services.ILiveSessionRegistry, Services.LiveSessionRegistry>();
             serviceCollection.AddHostedService<Services.LiveNotifierService>();
             serviceCollection.AddSingleton<UserConfigurationManager>();
+            // One bounded effective-policy owner shared by native response
+            // filtering, playback auto-unhide, and every settings invalidator.
+            serviceCollection.AddSingleton<RemoveFromHomePolicyService>();
             // One HTTP-free policy owner for exact, freshly accessible Hidden Content
             // item decisions. Legacy routes and Platform adapters share this instance.
             serviceCollection.AddSingleton<IHiddenContentItemActionOwner, HiddenContentItemActionOwner>();

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
@@ -20,7 +20,9 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     public sealed class HiddenContentResponseFilter : IAsyncActionFilter
     {
         private const string FileName = "hidden-content.json";
+        private const string SettingsFileName = "settings.json";
         private const string CacheKey = "__JE_HC_FILTER_CACHE";
+        private const string RemovePolicyCacheKey = "__JE_REMOVE_HOME_POLICY_CACHE";
 
         // Cross-request in-memory cache keyed by userId (N-format string).
         // Eliminates per-request disk reads for hidden-content.json.
@@ -34,6 +36,17 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             comparer: StringComparer.OrdinalIgnoreCase,
             defaultTtl: () => _hcCacheTtl);
 
+        // Effective Remove-from-home policy is user-owned once settings.json exists.
+        // Keep a short refresh window but retain bounded last-known-good state long
+        // enough for a transient/corrupt read to preserve the user's privacy choice.
+        private static readonly TimeSpan _removePolicyRefreshInterval = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan _removePolicyRetention = TimeSpan.FromDays(7);
+        private static readonly BoundedTtlCache<string, RemovePolicyCacheEntry> _removePolicyCache = new(
+            maximumEntries: 2_048,
+            maximumWeight: 2_048,
+            comparer: StringComparer.OrdinalIgnoreCase,
+            defaultTtl: () => _removePolicyRetention);
+
         /// <summary>
         /// Removes the cached hidden-content context for the given user so the next
         /// request re-reads from disk. Call this immediately after any write to
@@ -43,6 +56,22 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             if (!string.IsNullOrEmpty(userId))
                 _hcCache.TryRemove(userId, out _);
+        }
+
+        /// <summary>
+        /// Removes the cached effective Remove-from-home policy for one user.
+        /// Every successful settings.json mutation calls this after persistence.
+        /// </summary>
+        public static void InvalidateUserSettings(string userId)
+        {
+            if (string.IsNullOrEmpty(userId)) return;
+            var cacheKey = userId;
+            if (Guid.TryParse(userId, out var userIdGuid))
+            {
+                cacheKey = userIdGuid.ToString("N");
+                _warnedRemovePolicyFailure.TryRemove(userIdGuid, out _);
+            }
+            _removePolicyCache.TryRemove(cacheKey, out _);
         }
 
         // Test seam: seed an (empty) cache entry for a user so a test can prove a writer invalidated
@@ -65,6 +94,36 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // Test seam: whether a cache entry currently exists for a user.
         internal static bool IsCachedForTest(string userIdN)
             => !string.IsNullOrEmpty(userIdN) && _hcCache.ContainsKey(userIdN);
+
+        internal static void SeedRemovePolicyCacheForTest(string userIdN, bool enabled)
+        {
+            if (!string.IsNullOrEmpty(userIdN))
+            {
+                _removePolicyCache[userIdN] = new RemovePolicyCacheEntry(
+                    enabled,
+                    InheritsAdministratorDefault: false,
+                    LoadedAt: DateTime.UtcNow);
+            }
+        }
+
+        internal static bool IsRemovePolicyCachedForTest(string userIdN)
+            => !string.IsNullOrEmpty(userIdN) && _removePolicyCache.ContainsKey(userIdN);
+
+        internal static int RemovePolicyCacheMaximumEntriesForTest => _removePolicyCache.MaximumEntries;
+
+        internal static long RemovePolicyCacheMaximumWeightForTest => _removePolicyCache.MaximumWeight;
+
+        internal static void ExpireRemovePolicyCacheForTest(string userIdN)
+        {
+            if (!string.IsNullOrEmpty(userIdN)
+                && _removePolicyCache.TryGetValue(userIdN, out var entry))
+            {
+                _removePolicyCache[userIdN] = entry with { LoadedAt = DateTime.MinValue };
+            }
+        }
+
+        internal bool RemovePolicyEnabledForTest(Guid userId, bool administratorDefault)
+            => LoadRemovePolicy(new DefaultHttpContext(), userId, administratorDefault);
 
         // Test seam: force a user's cache entry to appear stale (TTL elapsed) WITHOUT
         // removing it, so the next read re-reads disk while the entry is still present
@@ -111,6 +170,11 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             Guid userId,
             CancellationToken cancellationToken);
 
+        private readonly record struct RemovePolicyCacheEntry(
+            bool Enabled,
+            bool InheritsAdministratorDefault,
+            DateTime LoadedAt);
+
         // Re-warn at most once per hour so a real Jellyfin upgrade isn't permanently invisible after the first warn.
         private static readonly TimeSpan ShapeMismatchReWarnInterval = TimeSpan.FromHours(1);
         private static readonly BoundedTtlCache<string, DateTime> _warnedShapeMismatchAt = new(
@@ -120,6 +184,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             comparer: StringComparer.Ordinal,
             defaultTtl: () => ShapeMismatchReWarnInterval);
         private static readonly BoundedTtlCache<Guid, byte> _warnedReadFailure = new(
+            maximumEntries: 2_048,
+            maximumWeight: 2_048,
+            defaultTtl: static () => TimeSpan.FromDays(7));
+        private static readonly BoundedTtlCache<Guid, byte> _warnedRemovePolicyFailure = new(
             maximumEntries: 2_048,
             maximumWeight: 2_048,
             defaultTtl: static () => TimeSpan.FromDays(7));
@@ -168,26 +236,34 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                 return;
             }
 
-            var hcEnabled = _configProvider.ConfigurationOrNull?.HiddenContentEnabled == true;
-            var rcwEnabled = _configProvider.ConfigurationOrNull?.RemoveContinueWatchingEnabled == true;
+            // Authentication owns the policy identity. Do not inspect global or
+            // per-user enforcement state until Jellyfin has supplied a request user.
+            var userId = UserHelper.GetCurrentUserId(context.HttpContext.User) ?? Guid.Empty;
+            if (userId == Guid.Empty)
+            {
+                await next().ConfigureAwait(false);
+                return;
+            }
+
+            var pluginConfiguration = _configProvider.ConfigurationOrNull;
+            var hcEnabled = pluginConfiguration?.HiddenContentEnabled == true;
 
             // /Items doubles as library list + search results — searchTerm wins, then fall back to library.
             var surface = (route.Surface == "library" && HasSearchTerm(context))
                 ? "search"
                 : route.Surface;
 
-            // RemoveContinueWatchingEnabled keeps the home-section Remove surfaces (Continue
-            // Watching + Next Up) filtering on even when HC's master switch is off.
+            // The authenticated user's persisted setting owns Remove-from-home
+            // enforcement. The administrator value is only the missing-file default.
+            // Hidden Content remains an independent master switch on every route.
             var isRemoveSurface = string.Equals(surface, "continuewatching", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(surface, "nextup", StringComparison.OrdinalIgnoreCase);
-            if (!hcEnabled && !(rcwEnabled && isRemoveSurface))
-            {
-                await next().ConfigureAwait(false);
-                return;
-            }
-
-            var userId = UserHelper.GetCurrentUserId(context.HttpContext.User) ?? Guid.Empty;
-            if (userId == Guid.Empty)
+            if (!hcEnabled
+                && (!isRemoveSurface
+                    || !LoadRemovePolicy(
+                        context.HttpContext,
+                        userId,
+                        pluginConfiguration?.RemoveContinueWatchingEnabled == true)))
             {
                 await next().ConfigureAwait(false);
                 return;
@@ -222,6 +298,99 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             catch (Exception ex)
             {
                 _logger.LogError($"HC response filter handler failed for surface '{route.Surface}' — entries will pass through unfiltered for this request: {ex.Message}");
+            }
+        }
+
+        private bool LoadRemovePolicy(HttpContext httpContext, Guid userId, bool administratorDefault)
+        {
+            if (httpContext.Items.TryGetValue(RemovePolicyCacheKey, out var requestValue)
+                && requestValue is bool requestPolicy)
+            {
+                return requestPolicy;
+            }
+
+            var userIdN = userId.ToString("N");
+            var now = DateTime.UtcNow;
+            if (_removePolicyCache.TryGetValue(userIdN, out var cached)
+                && (now - cached.LoadedAt) < _removePolicyRefreshInterval)
+            {
+                var effective = cached.InheritsAdministratorDefault
+                    ? administratorDefault
+                    : cached.Enabled;
+                httpContext.Items[RemovePolicyCacheKey] = effective;
+                return effective;
+            }
+
+            // Serialize this read with settings.json RMWs. The resolved cache entry
+            // is published while the file lock is held, so a subsequent successful
+            // writer invalidation cannot race behind a stale post-write insertion.
+            lock (_configManager.GetUserFileLock(userIdN, SettingsFileName))
+            {
+                now = DateTime.UtcNow;
+                if (_removePolicyCache.TryGetValue(userIdN, out cached)
+                    && (now - cached.LoadedAt) < _removePolicyRefreshInterval)
+                {
+                    var effective = cached.InheritsAdministratorDefault
+                        ? administratorDefault
+                        : cached.Enabled;
+                    httpContext.Items[RemovePolicyCacheKey] = effective;
+                    return effective;
+                }
+
+                var read = _configManager.ReadUserConfiguration<UserSettings>(userIdN, SettingsFileName);
+                if (read.HasUsableValue
+                    && read.Value != null
+                    && !PersistedPayloadPolicy.Validate(read.Value).IsValid)
+                {
+                    read = new UserConfigReadResult<UserSettings>(
+                        UserConfigReadStatus.Corrupt,
+                        null,
+                        "invalid-policy-shape");
+                }
+
+                var hasLastKnownGood = _removePolicyCache.TryGetValue(userIdN, out cached);
+                var lastKnownGood = cached.InheritsAdministratorDefault
+                    ? administratorDefault
+                    : cached.Enabled;
+                var inheritsAdministratorDefault = read.Status == UserConfigReadStatus.Missing;
+                var enabled = read.Status switch
+                {
+                    UserConfigReadStatus.Valid when read.Value != null
+                        => read.Value.RemoveContinueWatchingEnabled,
+                    UserConfigReadStatus.Missing => administratorDefault,
+                    _ when hasLastKnownGood => lastKnownGood,
+                    // A settings-store fault cannot silently disclose a row the
+                    // user may have removed. Cold-start faults therefore engage
+                    // only the Remove surfaces, while Hidden Content keeps its own policy.
+                    _ => true,
+                };
+
+                if (read.IsFault)
+                {
+                    if (_warnedRemovePolicyFailure.TryAdd(userId, 0))
+                    {
+                        var posture = hasLastKnownGood
+                            ? "retaining last-known-good Remove-from-home policy"
+                            : "no last-known-good — failing CLOSED on Remove surfaces";
+                        _logger.LogError(
+                            $"HC response filter: {read.Status} settings.json for user {userId} "
+                            + $"({read.FaultDetail}) — {posture} until repaired.");
+                    }
+                }
+                else
+                {
+                    _warnedRemovePolicyFailure.TryRemove(userId, out _);
+                }
+
+                _removePolicyCache.Set(
+                    userIdN,
+                    new RemovePolicyCacheEntry(
+                        enabled,
+                        InheritsAdministratorDefault: inheritsAdministratorDefault,
+                        LoadedAt: now),
+                    _removePolicyRetention);
+                httpContext.Items[RemovePolicyCacheKey] = enabled;
+                return enabled;
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/HiddenContentResponseFilter.cs
@@ -20,9 +20,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
     public sealed class HiddenContentResponseFilter : IAsyncActionFilter
     {
         private const string FileName = "hidden-content.json";
-        private const string SettingsFileName = "settings.json";
         private const string CacheKey = "__JE_HC_FILTER_CACHE";
-        private const string RemovePolicyCacheKey = "__JE_REMOVE_HOME_POLICY_CACHE";
 
         // Cross-request in-memory cache keyed by userId (N-format string).
         // Eliminates per-request disk reads for hidden-content.json.
@@ -36,17 +34,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             comparer: StringComparer.OrdinalIgnoreCase,
             defaultTtl: () => _hcCacheTtl);
 
-        // Effective Remove-from-home policy is user-owned once settings.json exists.
-        // Keep a short refresh window but retain bounded last-known-good state long
-        // enough for a transient/corrupt read to preserve the user's privacy choice.
-        private static readonly TimeSpan _removePolicyRefreshInterval = TimeSpan.FromSeconds(30);
-        private static readonly TimeSpan _removePolicyRetention = TimeSpan.FromDays(7);
-        private static readonly BoundedTtlCache<string, RemovePolicyCacheEntry> _removePolicyCache = new(
-            maximumEntries: 2_048,
-            maximumWeight: 2_048,
-            comparer: StringComparer.OrdinalIgnoreCase,
-            defaultTtl: () => _removePolicyRetention);
-
         /// <summary>
         /// Removes the cached hidden-content context for the given user so the next
         /// request re-reads from disk. Call this immediately after any write to
@@ -56,22 +43,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         {
             if (!string.IsNullOrEmpty(userId))
                 _hcCache.TryRemove(userId, out _);
-        }
-
-        /// <summary>
-        /// Removes the cached effective Remove-from-home policy for one user.
-        /// Every successful settings.json mutation calls this after persistence.
-        /// </summary>
-        public static void InvalidateUserSettings(string userId)
-        {
-            if (string.IsNullOrEmpty(userId)) return;
-            var cacheKey = userId;
-            if (Guid.TryParse(userId, out var userIdGuid))
-            {
-                cacheKey = userIdGuid.ToString("N");
-                _warnedRemovePolicyFailure.TryRemove(userIdGuid, out _);
-            }
-            _removePolicyCache.TryRemove(cacheKey, out _);
         }
 
         // Test seam: seed an (empty) cache entry for a user so a test can prove a writer invalidated
@@ -94,36 +65,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         // Test seam: whether a cache entry currently exists for a user.
         internal static bool IsCachedForTest(string userIdN)
             => !string.IsNullOrEmpty(userIdN) && _hcCache.ContainsKey(userIdN);
-
-        internal static void SeedRemovePolicyCacheForTest(string userIdN, bool enabled)
-        {
-            if (!string.IsNullOrEmpty(userIdN))
-            {
-                _removePolicyCache[userIdN] = new RemovePolicyCacheEntry(
-                    enabled,
-                    InheritsAdministratorDefault: false,
-                    LoadedAt: DateTime.UtcNow);
-            }
-        }
-
-        internal static bool IsRemovePolicyCachedForTest(string userIdN)
-            => !string.IsNullOrEmpty(userIdN) && _removePolicyCache.ContainsKey(userIdN);
-
-        internal static int RemovePolicyCacheMaximumEntriesForTest => _removePolicyCache.MaximumEntries;
-
-        internal static long RemovePolicyCacheMaximumWeightForTest => _removePolicyCache.MaximumWeight;
-
-        internal static void ExpireRemovePolicyCacheForTest(string userIdN)
-        {
-            if (!string.IsNullOrEmpty(userIdN)
-                && _removePolicyCache.TryGetValue(userIdN, out var entry))
-            {
-                _removePolicyCache[userIdN] = entry with { LoadedAt = DateTime.MinValue };
-            }
-        }
-
-        internal bool RemovePolicyEnabledForTest(Guid userId, bool administratorDefault)
-            => LoadRemovePolicy(new DefaultHttpContext(), userId, administratorDefault);
 
         // Test seam: force a user's cache entry to appear stale (TTL elapsed) WITHOUT
         // removing it, so the next read re-reads disk while the entry is still present
@@ -170,11 +111,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             Guid userId,
             CancellationToken cancellationToken);
 
-        private readonly record struct RemovePolicyCacheEntry(
-            bool Enabled,
-            bool InheritsAdministratorDefault,
-            DateTime LoadedAt);
-
         // Re-warn at most once per hour so a real Jellyfin upgrade isn't permanently invisible after the first warn.
         private static readonly TimeSpan ShapeMismatchReWarnInterval = TimeSpan.FromHours(1);
         private static readonly BoundedTtlCache<string, DateTime> _warnedShapeMismatchAt = new(
@@ -184,10 +120,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             comparer: StringComparer.Ordinal,
             defaultTtl: () => ShapeMismatchReWarnInterval);
         private static readonly BoundedTtlCache<Guid, byte> _warnedReadFailure = new(
-            maximumEntries: 2_048,
-            maximumWeight: 2_048,
-            defaultTtl: static () => TimeSpan.FromDays(7));
-        private static readonly BoundedTtlCache<Guid, byte> _warnedRemovePolicyFailure = new(
             maximumEntries: 2_048,
             maximumWeight: 2_048,
             defaultTtl: static () => TimeSpan.FromDays(7));
@@ -214,17 +146,20 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private readonly UserConfigurationManager _configManager;
         private readonly ILogger<HiddenContentResponseFilter> _logger;
         private readonly IPluginConfigProvider _configProvider;
+        private readonly RemoveFromHomePolicyService _removeFromHomePolicy;
         private readonly HiddenContentHierarchyResolver _hierarchyResolver;
 
         public HiddenContentResponseFilter(
             UserConfigurationManager configManager,
             ILogger<HiddenContentResponseFilter> logger,
             IPluginConfigProvider configProvider,
+            RemoveFromHomePolicyService removeFromHomePolicy,
             HiddenContentHierarchyResolver hierarchyResolver)
         {
             _configManager = configManager;
             _logger = logger;
             _configProvider = configProvider;
+            _removeFromHomePolicy = removeFromHomePolicy;
             _hierarchyResolver = hierarchyResolver;
         }
 
@@ -258,12 +193,12 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             // Hidden Content remains an independent master switch on every route.
             var isRemoveSurface = string.Equals(surface, "continuewatching", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(surface, "nextup", StringComparison.OrdinalIgnoreCase);
-            if (!hcEnabled
-                && (!isRemoveSurface
-                    || !LoadRemovePolicy(
-                        context.HttpContext,
-                        userId,
-                        pluginConfiguration?.RemoveContinueWatchingEnabled == true)))
+            if (isRemoveSurface
+                ? !_removeFromHomePolicy.ShouldApply(
+                    userId,
+                    hcEnabled,
+                    pluginConfiguration?.RemoveContinueWatchingEnabled == true)
+                : !hcEnabled)
             {
                 await next().ConfigureAwait(false);
                 return;
@@ -298,99 +233,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
             catch (Exception ex)
             {
                 _logger.LogError($"HC response filter handler failed for surface '{route.Surface}' — entries will pass through unfiltered for this request: {ex.Message}");
-            }
-        }
-
-        private bool LoadRemovePolicy(HttpContext httpContext, Guid userId, bool administratorDefault)
-        {
-            if (httpContext.Items.TryGetValue(RemovePolicyCacheKey, out var requestValue)
-                && requestValue is bool requestPolicy)
-            {
-                return requestPolicy;
-            }
-
-            var userIdN = userId.ToString("N");
-            var now = DateTime.UtcNow;
-            if (_removePolicyCache.TryGetValue(userIdN, out var cached)
-                && (now - cached.LoadedAt) < _removePolicyRefreshInterval)
-            {
-                var effective = cached.InheritsAdministratorDefault
-                    ? administratorDefault
-                    : cached.Enabled;
-                httpContext.Items[RemovePolicyCacheKey] = effective;
-                return effective;
-            }
-
-            // Serialize this read with settings.json RMWs. The resolved cache entry
-            // is published while the file lock is held, so a subsequent successful
-            // writer invalidation cannot race behind a stale post-write insertion.
-            lock (_configManager.GetUserFileLock(userIdN, SettingsFileName))
-            {
-                now = DateTime.UtcNow;
-                if (_removePolicyCache.TryGetValue(userIdN, out cached)
-                    && (now - cached.LoadedAt) < _removePolicyRefreshInterval)
-                {
-                    var effective = cached.InheritsAdministratorDefault
-                        ? administratorDefault
-                        : cached.Enabled;
-                    httpContext.Items[RemovePolicyCacheKey] = effective;
-                    return effective;
-                }
-
-                var read = _configManager.ReadUserConfiguration<UserSettings>(userIdN, SettingsFileName);
-                if (read.HasUsableValue
-                    && read.Value != null
-                    && !PersistedPayloadPolicy.Validate(read.Value).IsValid)
-                {
-                    read = new UserConfigReadResult<UserSettings>(
-                        UserConfigReadStatus.Corrupt,
-                        null,
-                        "invalid-policy-shape");
-                }
-
-                var hasLastKnownGood = _removePolicyCache.TryGetValue(userIdN, out cached);
-                var lastKnownGood = cached.InheritsAdministratorDefault
-                    ? administratorDefault
-                    : cached.Enabled;
-                var inheritsAdministratorDefault = read.Status == UserConfigReadStatus.Missing;
-                var enabled = read.Status switch
-                {
-                    UserConfigReadStatus.Valid when read.Value != null
-                        => read.Value.RemoveContinueWatchingEnabled,
-                    UserConfigReadStatus.Missing => administratorDefault,
-                    _ when hasLastKnownGood => lastKnownGood,
-                    // A settings-store fault cannot silently disclose a row the
-                    // user may have removed. Cold-start faults therefore engage
-                    // only the Remove surfaces, while Hidden Content keeps its own policy.
-                    _ => true,
-                };
-
-                if (read.IsFault)
-                {
-                    if (_warnedRemovePolicyFailure.TryAdd(userId, 0))
-                    {
-                        var posture = hasLastKnownGood
-                            ? "retaining last-known-good Remove-from-home policy"
-                            : "no last-known-good — failing CLOSED on Remove surfaces";
-                        _logger.LogError(
-                            $"HC response filter: {read.Status} settings.json for user {userId} "
-                            + $"({read.FaultDetail}) — {posture} until repaired.");
-                    }
-                }
-                else
-                {
-                    _warnedRemovePolicyFailure.TryRemove(userId, out _);
-                }
-
-                _removePolicyCache.Set(
-                    userIdN,
-                    new RemovePolicyCacheEntry(
-                        enabled,
-                        InheritsAdministratorDefault: inheritsAdministratorDefault,
-                        LoadedAt: now),
-                    _removePolicyRetention);
-                httpContext.Items[RemovePolicyCacheKey] = enabled;
-                return enabled;
             }
         }
 

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/RemoveFromHomePolicyService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/RemoveFromHomePolicyService.cs
@@ -1,0 +1,174 @@
+using System;
+using Jellyfin.Plugin.JellyfinCanopy.Configuration;
+using Jellyfin.Plugin.JellyfinCanopy.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.JellyfinCanopy.Services
+{
+    /// <summary>
+    /// Process-wide owner of the effective Continue Watching removal policy.
+    /// A persisted per-user setting wins; a missing settings file inherits the
+    /// live administrator default. Faults retain bounded last-known-good state
+    /// and fail closed on a cold read.
+    /// </summary>
+    public sealed class RemoveFromHomePolicyService
+    {
+        private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan Retention = TimeSpan.FromDays(7);
+
+        private readonly UserConfigurationManager _configManager;
+        private readonly ILogger<RemoveFromHomePolicyService> _logger;
+        private readonly BoundedTtlCache<string, PolicyCacheEntry> _cache = new(
+            maximumEntries: 2_048,
+            maximumWeight: 2_048,
+            comparer: StringComparer.OrdinalIgnoreCase,
+            defaultTtl: () => Retention);
+        private readonly BoundedTtlCache<Guid, byte> _warnedReadFailure = new(
+            maximumEntries: 2_048,
+            maximumWeight: 2_048,
+            defaultTtl: static () => TimeSpan.FromDays(7));
+
+        private readonly record struct PolicyCacheEntry(
+            bool Enabled,
+            bool InheritsAdministratorDefault,
+            DateTime LoadedAt);
+
+        public RemoveFromHomePolicyService(
+            UserConfigurationManager configManager,
+            ILogger<RemoveFromHomePolicyService> logger)
+        {
+            _configManager = configManager;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Resolves the effective policy for one already-authenticated/session-owned user.
+        /// Full Hidden Content is an independent master switch and avoids any settings read.
+        /// </summary>
+        public bool ShouldApply(
+            Guid userId,
+            bool hiddenContentEnabled,
+            bool administratorDefault)
+        {
+            if (userId == Guid.Empty) return false;
+            if (hiddenContentEnabled) return true;
+            return LoadUserPolicy(userId, administratorDefault);
+        }
+
+        /// <summary>
+        /// Invalidates only the canonical target user's policy after a durable
+        /// settings mutation or recovery reset.
+        /// </summary>
+        public void Invalidate(string userId)
+        {
+            if (string.IsNullOrEmpty(userId)) return;
+            var cacheKey = userId;
+            if (Guid.TryParse(userId, out var userIdGuid))
+            {
+                cacheKey = userIdGuid.ToString("N");
+                _warnedReadFailure.TryRemove(userIdGuid, out _);
+            }
+
+            _cache.TryRemove(cacheKey, out _);
+        }
+
+        private bool LoadUserPolicy(Guid userId, bool administratorDefault)
+        {
+            var userIdN = userId.ToString("N");
+            var now = DateTime.UtcNow;
+            if (_cache.TryGetValue(userIdN, out var cached)
+                && (now - cached.LoadedAt) < RefreshInterval)
+            {
+                return Effective(cached, administratorDefault);
+            }
+
+            // Serialize the read with settings.json writers. Publishing while
+            // this lock is held prevents a successful writer invalidation from
+            // racing behind a stale post-write cache insertion.
+            lock (_configManager.GetUserFileLock(userIdN, "settings.json"))
+            {
+                now = DateTime.UtcNow;
+                if (_cache.TryGetValue(userIdN, out cached)
+                    && (now - cached.LoadedAt) < RefreshInterval)
+                {
+                    return Effective(cached, administratorDefault);
+                }
+
+                var read = _configManager.ReadUserConfiguration<UserSettings>(
+                    userIdN,
+                    "settings.json");
+                if (read.HasUsableValue
+                    && read.Value != null
+                    && !PersistedPayloadPolicy.Validate(read.Value).IsValid)
+                {
+                    read = new UserConfigReadResult<UserSettings>(
+                        UserConfigReadStatus.Corrupt,
+                        null,
+                        "invalid-policy-shape");
+                }
+
+                var hasLastKnownGood = _cache.TryGetValue(userIdN, out cached);
+                var lastKnownGood = Effective(cached, administratorDefault);
+                var inheritsAdministratorDefault = read.Status == UserConfigReadStatus.Missing;
+                var enabled = read.Status switch
+                {
+                    UserConfigReadStatus.Valid when read.Value != null
+                        => read.Value.RemoveContinueWatchingEnabled,
+                    UserConfigReadStatus.Missing => administratorDefault,
+                    _ when hasLastKnownGood => lastKnownGood,
+                    _ => true,
+                };
+
+                if (read.Status is UserConfigReadStatus.Corrupt or UserConfigReadStatus.Unavailable
+                    && _warnedReadFailure.TryAdd(userId, 0))
+                {
+                    _logger.LogWarning(
+                        "Remove-from-home policy read failed for user {UserId}; using {FallbackKind}.",
+                        userIdN,
+                        hasLastKnownGood ? "bounded last-known-good state" : "fail-closed enforcement");
+                }
+                else if (!read.IsFault)
+                {
+                    _warnedReadFailure.TryRemove(userId, out _);
+                }
+
+                var next = new PolicyCacheEntry(
+                    enabled,
+                    inheritsAdministratorDefault,
+                    now);
+                _cache[userIdN] = next;
+                return Effective(next, administratorDefault);
+            }
+        }
+
+        private static bool Effective(PolicyCacheEntry entry, bool administratorDefault)
+            => entry.InheritsAdministratorDefault ? administratorDefault : entry.Enabled;
+
+        internal void SeedCacheForTest(string userIdN, bool enabled)
+        {
+            if (!string.IsNullOrEmpty(userIdN))
+            {
+                _cache[userIdN] = new PolicyCacheEntry(
+                    enabled,
+                    InheritsAdministratorDefault: false,
+                    LoadedAt: DateTime.UtcNow);
+            }
+        }
+
+        internal bool IsCachedForTest(string userIdN)
+            => !string.IsNullOrEmpty(userIdN) && _cache.ContainsKey(userIdN);
+
+        internal int MaximumEntriesForTest => _cache.MaximumEntries;
+
+        internal long MaximumWeightForTest => _cache.MaximumWeight;
+
+        internal void ExpireCacheForTest(string userIdN)
+        {
+            if (!string.IsNullOrEmpty(userIdN)
+                && _cache.TryGetValue(userIdN, out var entry))
+            {
+                _cache[userIdN] = entry with { LoadedAt = DateTime.MinValue };
+            }
+        }
+    }
+}

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.identity.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/features/remove-home.identity.test.ts
@@ -324,4 +324,41 @@ describe('Continue Watching removal identity ownership', () => {
         });
         expect(JC.state.removeContext).toBeNull();
     });
+
+    it('offers Continue Watching actions for video, audio, and book resume rows only', async () => {
+        disposeFeature?.();
+        disposeFeature = null;
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+            CustomPrefs: {
+                homesection1: 'resume',
+                homesection2: 'resumeaudio',
+                homesection3: 'resumebook',
+                homesection4: 'latestmedia',
+            },
+        });
+        disposeFeature = installRemoveHome();
+
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        for (const [index, type] of [
+            [1, 'Video'],
+            [2, 'Audio'],
+            [3, 'Book'],
+            [4, 'Audio'],
+        ] as const) {
+            const section = document.createElement('div');
+            section.className = `verticalSection section${index}`;
+            section.innerHTML = `<div class="card" data-id="item-${index}" data-type="${type}"></div>`;
+            container.appendChild(section);
+        }
+        document.body.appendChild(container);
+        const cards = container.querySelectorAll<HTMLElement>('.card');
+
+        await vi.waitFor(() => {
+            expect(detectCardSurface(cards[0])).toBe('continuewatching');
+            expect(detectCardSurface(cards[1])).toBe('continuewatching');
+            expect(detectCardSurface(cards[2])).toBe('continuewatching');
+        });
+        expect(detectCardSurface(cards[3])).toBeNull();
+    });
 });

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.home-scope.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/hidden-content/filter.home-scope.test.ts
@@ -131,6 +131,53 @@ describe('home Continue-Watching filtering independent of Filter Library (ENH-2)
         expect(card('CW1').dataset.jcHiddenScopeSignature).toBe('home:1:resume');
     });
 
+    it('filters video, audio, and book resume rows without over-hiding an ordinary audio row', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+            CustomPrefs: {
+                homesection1: 'resume',
+                homesection2: 'resumeaudio',
+                homesection3: 'resumebook',
+                homesection4: 'latestmedia',
+            },
+        });
+        setHiddenContent(
+            { filterLibrary: false, filterContinueWatching: true, filterNextUp: false },
+            {
+                VIDEO: { itemId: 'VIDEO', hideScope: 'continuewatching' },
+                AUDIO: { itemId: 'AUDIO', hideScope: 'continuewatching' },
+                BOOK: { itemId: 'BOOK', hideScope: 'continuewatching' },
+                ORDINARY: { itemId: 'ORDINARY', hideScope: 'continuewatching' },
+            },
+        );
+        const container = document.createElement('div');
+        container.className = 'homeSectionsContainer';
+        for (const [index, id, type] of [
+            [1, 'VIDEO', 'Video'],
+            [2, 'AUDIO', 'Audio'],
+            [3, 'BOOK', 'Book'],
+            [4, 'ORDINARY', 'Audio'],
+        ] as const) {
+            const section = document.createElement('div');
+            section.className = `verticalSection section${index}`;
+            section.innerHTML = `<div class="card" data-id="${id}" data-type="${type}"></div>`;
+            container.appendChild(section);
+        }
+        document.body.appendChild(container);
+
+        setupNativeObserver();
+        filterAllNativeCards();
+
+        await vi.waitFor(() => {
+            expect(card('VIDEO').classList.contains('jc-hidden')).toBe(true);
+            expect(card('AUDIO').classList.contains('jc-hidden')).toBe(true);
+            expect(card('BOOK').classList.contains('jc-hidden')).toBe(true);
+        });
+        expect(card('ORDINARY').classList.contains('jc-hidden')).toBe(false);
+        expect(card('AUDIO').dataset.jcHiddenScopeSignature).toBe('home:2:resumeaudio');
+        expect(card('BOOK').dataset.jcHiddenScopeSignature).toBe('home:3:resumebook');
+        expect(card('ORDINARY').dataset.jcHiddenScopeSignature).toBe('home:4:latestmedia');
+    });
+
     it('rechecks a processed card moved from Continue Watching into Next Up', async () => {
         ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({ CustomPrefs: {} });
         setHiddenContent(

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.test.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.test.ts
@@ -66,6 +66,60 @@ describe('Jellyfin 12 home-row scope resolver', () => {
         release();
     });
 
+    it.each([
+        [1, 'resume'],
+        [2, 'resumeaudio'],
+        [3, 'resumebook'],
+    ])('classifies default slot %i (%s) as Continue Watching without heading text', async (index: number, sectionType: string) => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({ CustomPrefs: {} });
+        const { card } = homeSection(index, `localized-${sectionType}`);
+        const release = acquireHomeRowScopes(() => {});
+
+        primeHomeRowScopes();
+        await vi.waitFor(() => expect(resolveHomeRowScope(card)).toMatchObject({
+            kind: 'continuewatching',
+            signature: `home:${index}:${sectionType}`,
+        }));
+        release();
+    });
+
+    it.each(['resume', 'resumeaudio', 'resumebook'])(
+        'classifies custom %s ordering, including Jellyfin TV prepend',
+        async (sectionType) => {
+            ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+                CustomPrefs: { homesection0: sectionType },
+            });
+            const { container } = homeSection(0, 'misleading ordinary heading');
+            const shifted = document.createElement('div');
+            shifted.className = 'verticalSection section1';
+            shifted.innerHTML = '<div class="card" data-type="Audio"></div>';
+            const sentinel = document.createElement('div');
+            sentinel.className = 'verticalSection section10';
+            container.append(shifted, sentinel);
+            const release = acquireHomeRowScopes(() => {});
+
+            primeHomeRowScopes();
+            await vi.waitFor(() => expect(resolveHomeRowScope(shifted.querySelector('.card')!)).toMatchObject({
+                kind: 'continuewatching',
+                signature: `home:1:${sectionType}`,
+            }));
+            expect(resolveHomeRowScope(container.querySelector('.section0 .card')!).kind).toBe('collection');
+            release();
+        },
+    );
+
+    it('keeps an ordinary custom home row outside Continue Watching', async () => {
+        ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
+            CustomPrefs: { homesection4: 'latestmedia' },
+        });
+        const { card } = homeSection(4, 'Continue Watching is deliberately misleading');
+        const release = acquireHomeRowScopes(() => {});
+
+        primeHomeRowScopes();
+        await vi.waitFor(() => expect(resolveHomeRowScope(card).kind).toBe('ordinary'));
+        release();
+    });
+
     it('uses custom ordering and Jellyfin TV prepend without reading the heading', async () => {
         ApiClient.getDisplayPreferences = vi.fn().mockResolvedValue({
             CustomPrefs: {

--- a/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.ts
+++ b/Jellyfin.Plugin.JellyfinCanopy/src/enhanced/home-row-scope.ts
@@ -50,6 +50,7 @@ const KNOWN_SECTIONS = new Set([
     'none', 'smalllibrarytiles', 'librarybuttons', 'activerecordings',
     'resume', 'resumeaudio', 'resumebook', 'latestmedia', 'nextup', 'livetv',
 ]);
+const CONTINUE_WATCHING_SECTIONS = new Set(['resume', 'resumeaudio', 'resumebook']);
 const COLLECTION_TYPES = new Set([
     'collectionfolder', 'userview', 'boxset', 'playlist', 'channel',
 ]);
@@ -389,7 +390,9 @@ function resolveHomeRowScopeWithPass(
         if (sectionType.startsWith('unknown:')) {
             return resolved('unresolved', true, `home:${index}:${sectionType}`, section);
         }
-        if (sectionType === 'resume') return resolved('continuewatching', true, `home:${index}:resume`, section);
+        if (CONTINUE_WATCHING_SECTIONS.has(sectionType)) {
+            return resolved('continuewatching', true, `home:${index}:${sectionType}`, section);
+        }
         if (sectionType === 'nextup') return resolved('nextup', true, `home:${index}:nextup`, section);
         if (sectionType === 'smalllibrarytiles' || sectionType === 'librarybuttons') {
             return resolved('collection', true, `home:${index}:${sectionType}`, section);

--- a/docs/enhanced.md
+++ b/docs/enhanced.md
@@ -567,7 +567,7 @@ Clean up the home screen without losing anything: this adds a lightweight, **non
 
 **What makes it convenient:**
 
-- Works on both **Continue Watching** and **Next Up** items, each removed from its own row.
+- Works on **Continue Watching** (including Jellyfin's video, audio, and book resume rows) and **Next Up** items, each removed from its own row.
 - Also appears in Jellyfin's **long-press / multi-select menu**, so touch devices with no "⋯" button can remove items. Selecting a mix of rows (and other items) only ever removes the Continue Watching / Next Up ones.
 - Removing several at once shows a confirmation listing each item and the row it will be removed from.
 - Hidden state is stored **server-side, per-user**, so it applies across all your devices and survives reloads.
@@ -576,7 +576,9 @@ Clean up the home screen without losing anything: this adds a lightweight, **non
 
 ![Bulk removal confirmation listing each item and its row](images/remove-confirm.png)
 
-**Enable it:** Canopy User Settings (press `?`) → **Settings** → **Add Remove from Continue Watching & Next Up Buttons**.
+**Enable it (per-user):** Canopy User Settings (press `?`) → **Settings** → **Add Remove from Continue Watching & Next Up Buttons**. This authenticated-user value controls both the menu actions and enforcement of that user's saved home-row removals when the full Hidden Content feature is off. One user's choice never changes another user's rows; Hidden Content keeps its own independent filtering policy.
+
+**Admin default:** Dashboard → **Plugins** → **Jellyfin Canopy** → **Display** → **Default: enable "Remove from Continue Watching & Next Up"** sets only the starting value for new users. Existing users keep their own saved choice.
 
 ### Hiding the Favorites tab
 

--- a/e2e/docker/seed.sh
+++ b/e2e/docker/seed.sh
@@ -3,10 +3,10 @@
 #   1. install the freshly built plugin DLL into a clean config volume,
 #   2. generate a handful of tiny valid movies (including one regional-language
 #      Matroska fixture), one dedicated 40-second Auto-Skip movie, and a 2×2-
-#      episode TV series with ffmpeg (testsrc2 clips),
+#      episode TV series, one audio track, and one compact book fixture,
 #   3. boot the compose stack and complete the startup wizard via the API,
-#   4. create the Movies + Shows libraries and the two test users the specs
-#      expect,
+#   4. create the Movies, Shows, Music, and Books libraries and the two test
+#      users the specs expect,
 #   5. enable the plugin features the specs exercise (tags, random button,
 #      hidden content, Spoiler Guard), wait for the scan, seed movie/episode
 #      metadata plus an incomplete TMDB-anchored BoxSet, and mark S01E01 played
@@ -334,10 +334,13 @@ else
     }
 fi
 
-# Movies and Shows live in dedicated subfolders so the recursive Movies-library
-# scan never descends into the TV tree (and vice-versa) — a single /media root
-# shared by both collection types would misidentify episode files as movies.
-mkdir -p "${MEDIA_DIR}/Movies" "${MEDIA_DIR}/Shows"
+# Every collection type lives in a dedicated folder so recursive scans cannot
+# reclassify another fixture family.
+mkdir -p \
+    "${MEDIA_DIR}/Movies" \
+    "${MEDIA_DIR}/Shows" \
+    "${MEDIA_DIR}/Music" \
+    "${MEDIA_DIR}/Books"
 
 make_clip() { # <relative-path> <tone-hz> [duration-seconds] [audio-language]
     local duration="${3:-5}"
@@ -353,6 +356,13 @@ make_clip() { # <relative-path> <tone-hz> [duration-seconds] [audio-language]
         -c:v libx264 -preset ultrafast -pix_fmt yuv420p -c:a aac -shortest \
         -threads "${JF_FFMPEG_THREADS}" \
         -metadata:s:a:0 language="${audio_language}" -y "$1"
+}
+
+make_audio_clip() { # <relative-path> <tone-hz>
+    run_ffmpeg \
+        -f lavfi -i "sine=frequency=$2:duration=5" \
+        -c:a aac -metadata title="Canopy Resume Audio" \
+        -metadata artist="Canopy Fixture" -y "$1"
 }
 
 make_multilingual_clip() { # <relative-path>
@@ -398,6 +408,33 @@ make_clip "${FILE_SOURCE_RELATIVE_PATH}" 825
 log "generating dedicated Auto-Skip movie (${AUTOSKIP_DURATION}s, seed ${SEED_NONCE})"
 mkdir -p "${MEDIA_DIR}/${AUTOSKIP_RELATIVE_DIR}"
 make_clip "${AUTOSKIP_RELATIVE_PATH}" 880 "${AUTOSKIP_DURATION}"
+
+# Real Audio and Book records protect the host-declared resumeaudio/resumebook
+# action boundary. The compact valid PDF contains no external fixture dependency.
+log "generating audio and book resume fixtures"
+make_audio_clip "Music/Canopy Resume Audio.m4a" 920
+printf '%s\n' \
+    '%PDF-1.4' \
+    '1 0 obj' \
+    '<< /Type /Catalog /Pages 2 0 R >>' \
+    'endobj' \
+    '2 0 obj' \
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>' \
+    'endobj' \
+    '3 0 obj' \
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] >>' \
+    'endobj' \
+    'xref' \
+    '0 4' \
+    '0000000000 65535 f ' \
+    '0000000009 00000 n ' \
+    '0000000058 00000 n ' \
+    '0000000115 00000 n ' \
+    'trailer' \
+    '<< /Size 4 /Root 1 0 R >>' \
+    'startxref' \
+    '186' \
+    '%%EOF' > "${MEDIA_DIR}/Books/Canopy Resume Book.pdf"
 
 # ── TV: one series, 2 seasons × 2 episodes, for the Spoiler Guard specs ───────
 # Series/Season NN/… S0xE0y naming so Jellyfin's naming resolver builds the
@@ -564,6 +601,14 @@ log "creating the Shows library"
 api POST "/Library/VirtualFolders?name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=false" \
     '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
 
+log "creating the Music library"
+api POST "/Library/VirtualFolders?name=Music&collectionType=music&paths=%2Fmedia%2FMusic&refreshLibrary=false" \
+    '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
+
+log "creating the Books library"
+api POST "/Library/VirtualFolders?name=Books&collectionType=books&paths=%2Fmedia%2FBooks&refreshLibrary=false" \
+    '{"LibraryOptions":{"EnableRealtimeMonitor":false}}'
+
 log "creating the Collections library without an implicit scan"
 api POST "/Library/VirtualFolders?name=Collections&collectionType=boxsets&paths=%2Fconfig%2Fdata%2Fcollections&refreshLibrary=false" \
     '{"LibraryOptions":{"EnableRealtimeMonitor":false,"SaveLocalMetadata":true}}'
@@ -708,6 +753,8 @@ MULTILINGUAL_AUDIO_MATCH_COUNT=0
 MULTILINGUAL_AUDIO_TRACKS='[]'
 FILE_SOURCE_MATCH_COUNT=0
 FILE_SOURCE_MEDIA_PATH_COUNT=0
+AUDIO_RESUME_ID=''
+BOOK_RESUME_ID=''
 for _ in $(seq 1 60); do
     AUTOSKIP_SCAN_JSON="$(api GET "/Items?IncludeItemTypes=Movie&Recursive=true&userId=${ADMIN_ID}&Fields=Path,MediaSources,MediaStreams")"
     MOVIES="$(printf '%s' "${AUTOSKIP_SCAN_JSON}" | jq -r '.TotalRecordCount // 0')"
@@ -758,6 +805,10 @@ for _ in $(seq 1 60); do
         '[first(.Items[]? | select(.Path == $path)) as $item
           | ($item.MediaSources // [])[]?
           | select(.Path == $path)] | length')"
+    AUDIO_RESUME_ID="$(api GET "/Items?IncludeItemTypes=Audio&Recursive=true&userId=${ADMIN_ID}&Limit=100" \
+        | jq -r 'first(.Items[]? | select(.Name == "Canopy Resume Audio") | .Id) // empty')"
+    BOOK_RESUME_ID="$(api GET "/Items?IncludeItemTypes=Book&Recursive=true&userId=${ADMIN_ID}&Limit=100" \
+        | jq -r 'first(.Items[]? | select(.Name == "Canopy Resume Book") | .Id) // empty')"
     if [ "${MOVIES}" -ge 7 ] 2>/dev/null \
         && [ "${AUTOSKIP_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
         && [ "${AUTOSKIP_SCAN_SOURCE_COUNT}" -ge 1 ] 2>/dev/null \
@@ -767,7 +818,9 @@ for _ in $(seq 1 60); do
         && [ "${MULTILINGUAL_AUDIO_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
         && [ "${MULTILINGUAL_AUDIO_TRACKS}" = '[{"language":"en-us","codec":"aac","channels":6,"isDefault":true},{"language":"pt-br","codec":"eac3","channels":2,"isDefault":false}]' ] \
         && [ "${FILE_SOURCE_MATCH_COUNT}" -eq 1 ] 2>/dev/null \
-        && [ "${FILE_SOURCE_MEDIA_PATH_COUNT}" -eq 1 ] 2>/dev/null; then
+        && [ "${FILE_SOURCE_MEDIA_PATH_COUNT}" -eq 1 ] 2>/dev/null \
+        && [ -n "${AUDIO_RESUME_ID}" ] \
+        && [ -n "${BOOK_RESUME_ID}" ]; then
         break
     fi
     sleep 5
@@ -793,6 +846,11 @@ log "verified multilingual-audio fixture tracks: ${MULTILINGUAL_AUDIO_TRACKS}"
     || fail "file-source fixture '${FILE_SOURCE_NAME}' was not indexed at ${FILE_SOURCE_CONTAINER_PATH}"
 [ "${FILE_SOURCE_MEDIA_PATH_COUNT}" -eq 1 ] \
     || fail "file-source fixture '${FILE_SOURCE_NAME}' did not expose its exact .disc media-source path"
+[ -n "${AUDIO_RESUME_ID}" ] \
+    || fail "library scan never indexed the Canopy Resume Audio fixture"
+[ -n "${BOOK_RESUME_ID}" ] \
+    || fail "library scan never indexed the Canopy Resume Book fixture"
+log "verified audio/book resume fixtures"
 log "verified file-source fixture: ${FILE_SOURCE_CANONICAL_VALUE} at ${FILE_SOURCE_CONTAINER_PATH}"
 
 log "waiting for the explicit library scan to complete before metadata writes"

--- a/e2e/header-tray-overflow.spec.ts
+++ b/e2e/header-tray-overflow.spec.ts
@@ -31,6 +31,11 @@ const LAYOUT_STAMP: Record<Layout, string> = {
 
 const MOBILE = { width: 390, height: 844 } as const;
 const DESKTOP = { width: 1280, height: 800 } as const;
+// The fit-state case intentionally keeps the complete live admin tray (rather
+// than deleting real controls), so give its eleven-button fixture inventory a
+// genuinely positive free-space budget. The regular desktop case below stays
+// at 1280px and continues to exercise overflow there.
+const FIT_DESKTOP = { width: 1440, height: 800 } as const;
 // Wide enough to overflow the widest tested tray: 40 × 48px ≈ 1920px of
 // buttons exceeds the 1280px desktop viewport (and therefore any tray, which is
 // always ≤ the viewport), guaranteeing scrollWidth > clientWidth on every case.
@@ -433,7 +438,7 @@ test.describe('header button tray stays a single scrollable row (#459)', () => {
     // stranded at the tray's left edge, a visible split, not the native contiguous
     // right-packed tray. Prove the geometry on a roomy modern desktop tray.
     test('modern fit-state: the native-tabs order:-1 group stays right-packed and contiguous, not split to the left edge', async ({ page, consoleErrors }) => {
-        await page.setViewportSize(DESKTOP);
+        await page.setViewportSize(FIT_DESKTOP);
         await seedLayout(page, 'modern');
         await loginAs(page, 'admin', consoleErrors);
 

--- a/e2e/remove-home-policy.spec.ts
+++ b/e2e/remove-home-policy.spec.ts
@@ -8,6 +8,11 @@ import {
     assertNoRuntimeErrors,
 } from './fixtures/auth';
 import { api, apiRaw, authenticate, PLUGIN_ID } from './fixtures/api';
+import {
+    completeAcknowledgedMutation,
+    runIndependentRestorations,
+    throwAfterRestoration,
+} from '../scripts/e2e/remove-home-policy-cleanup';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -89,6 +94,7 @@ async function actionFor(
     cardSelector: string,
     itemId: string,
     expectedSurface: 'continuewatching' | null,
+    journalMutation: () => void = () => {},
 ): Promise<void> {
     await page.evaluate(({ selector }) => {
         document.querySelector('#jc-remove-policy-sheet')?.remove();
@@ -130,8 +136,13 @@ async function actionFor(
         ));
     await button.click();
     const response = await responsePromise;
-    expect(response.status(), 'caller-authorized scoped POST').toBe(200);
-    await expect(page.locator(cardSelector)).toHaveCSS('display', 'none');
+    await completeAcknowledgedMutation({
+        verifyAcknowledgement: () => {
+            expect(response.status(), 'caller-authorized scoped POST').toBe(200);
+        },
+        journalMutation,
+        verifyProductState: () => expect(page.locator(cardSelector)).toHaveCSS('display', 'none'),
+    });
 }
 
 test.describe('Remove-from-home policy and resume row ownership', () => {
@@ -143,6 +154,7 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
         consoleErrors,
     }) => {
         const admin = await authenticate(baseURL!, 'jc_arradmin', 'Test669Pw!x');
+        const user = await authenticate(baseURL!, 'jc_arruser', 'Test669Pw!x');
         const originalConfig = await api<Record<string, unknown>>(
             baseURL!, CONFIG_PATH, admin.token
         );
@@ -175,6 +187,9 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
         });
         expect(fixture.audio, 'real audio fixture is caller-visible').toBeTruthy();
         expect(fixture.book, 'real book fixture is caller-visible').toBeTruthy();
+        expect(canonical(user.userId), 'cleanup session owns the browser user').toBe(
+            canonical(fixture.userId)
+        );
 
         const hiddenResponse = await apiRaw(
             baseURL!,
@@ -331,15 +346,15 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
                 '#jc-remove-policy-proof .section2 .card',
                 fixture.audio!.id,
                 'continuewatching',
+                () => { audioHidden = true; },
             );
-            audioHidden = true;
             await actionFor(
                 page,
                 '#jc-remove-policy-proof .section3 .card',
                 fixture.book!.id,
                 'continuewatching',
+                () => { bookHidden = true; },
             );
-            bookHidden = true;
             await expect(
                 page.locator('#jc-remove-policy-proof .section4 .card'),
                 'same item stays visible on an unrelated authoritative row',
@@ -371,75 +386,92 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
             primaryError = error;
         }
 
-        const cleanupFailures = await page.evaluate(async ({
-            ids,
-            data,
-            hidden,
-            originalRemovePolicy,
-        }) => {
-                const failures: string[] = [];
-                const attempt = async (label: string, operation: () => Promise<unknown>) => {
+        const cleanupFailures = await runIndependentRestorations({
+            pageCleanup: async () => {
+                await page.evaluate(() => {
+                    document.querySelector('#jc-remove-policy-proof')?.remove();
+                    document.querySelector('#jc-remove-policy-sheet')?.remove();
+                });
+            },
+            restoreDurableUserState: async () => {
+                const userStateFailures: string[] = [];
+                const attempt = async (label: string, operation: () => Promise<Response>) => {
                     try {
-                        await operation();
+                        const response = await operation();
+                        if (!response.ok) {
+                            throw new Error(`HTTP ${response.status}`);
+                        }
                     } catch (error) {
-                        failures.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+                        userStateFailures.push(
+                            `${label}: ${error instanceof Error ? error.message : String(error)}`
+                        );
                     }
                 };
-                document.querySelector('#jc-remove-policy-proof')?.remove();
-                document.querySelector('#jc-remove-policy-sheet')?.remove();
-                const canopy = (window as any).JellyfinCanopy;
-                const settings = canopy.currentSettings;
-                if (settings && canopy.identity?.isOwned?.(settings)) {
-                    settings.removeContinueWatchingEnabled = originalRemovePolicy;
-                    await attempt(
-                        'restore user Remove policy',
-                        () => canopy.saveUserSettings('settings.json', settings),
-                    );
-                }
-                const apiClient = (window as any).ApiClient;
-                const userId = apiClient.getCurrentUserId();
+                const ids = [fixture.audio!.id, fixture.book!.id];
+                const hidden = [audioHidden, bookHidden];
                 for (let index = 0; index < ids.length; index++) {
                     if (hidden[index]) {
-                        await attempt(`unhide item ${index}`, () => apiClient.ajax({
-                            type: 'DELETE',
-                            url: apiClient.getUrl(
-                                `/JellyfinCanopy/continue-watching/hide/${encodeURIComponent(ids[index])}`
-                            ),
-                            dataType: 'json',
-                        }));
+                        await attempt(`unhide item ${index}`, () => apiRaw(
+                            baseURL!,
+                            `/JellyfinCanopy/continue-watching/hide/${encodeURIComponent(ids[index])}`,
+                            user.token,
+                            { method: 'DELETE' },
+                        ));
                     }
-                    await attempt(`restore user data ${index}`, () => apiClient.ajax({
-                            type: 'POST',
-                            url: apiClient.getUrl(
-                                `/UserItems/${encodeURIComponent(ids[index])}/UserData?userId=${encodeURIComponent(userId)}`
-                            ),
-                            data: JSON.stringify(data[index]),
-                            contentType: 'application/json',
-                        }));
+                    await attempt(`restore user data ${index}`, () => apiRaw(
+                        baseURL!,
+                        `/UserItems/${encodeURIComponent(ids[index])}/UserData?userId=${encodeURIComponent(user.userId)}`,
+                        user.token,
+                        { method: 'POST', body: JSON.stringify(originalUserData[index]) },
+                    ));
                 }
-                return failures;
-            }, {
-                ids: [fixture.audio!.id, fixture.book!.id],
-                data: originalUserData,
-                hidden: [audioHidden, bookHidden],
-                originalRemovePolicy: fixture.originalRemovePolicy,
-            });
-        try {
-            const restore = await apiRaw(baseURL!, CONFIG_PATH, admin.token, {
-                method: 'POST',
-                body: JSON.stringify(originalConfig),
-            });
-            expect(restore.status).toBe(204);
-        } catch (error) {
-            cleanupFailures.push(
-                `restore plugin configuration: ${error instanceof Error ? error.message : String(error)}`
-            );
-        }
 
-        if (primaryError) {
-            throw primaryError;
-        }
-        expect(cleanupFailures, 'exact test-state restoration').toEqual([]);
+                try {
+                    const settingsPath = `/JellyfinCanopy/user-settings/${encodeURIComponent(user.userId)}/settings.json`;
+                    const current = await api<Record<string, any>>(
+                        baseURL!, settingsPath, user.token
+                    );
+                    if (!current) throw new Error('current settings response is empty');
+                    const revision = field<number>(current, 'Revision', 'revision');
+                    const revisionKey = Object.hasOwn(current, 'Revision') ? 'Revision' : 'revision';
+                    const removeKey = Object.hasOwn(current, 'RemoveContinueWatchingEnabled')
+                        ? 'RemoveContinueWatchingEnabled'
+                        : 'removeContinueWatchingEnabled';
+                    const restored = {
+                        ...current,
+                        [revisionKey]: revision,
+                        [removeKey]: fixture.originalRemovePolicy,
+                    };
+                    await attempt('restore user Remove policy', () => apiRaw(
+                        baseURL!,
+                        settingsPath,
+                        user.token,
+                        {
+                            method: 'POST',
+                            headers: { 'If-Match': `"${revision}"` },
+                            body: JSON.stringify(restored),
+                        },
+                    ));
+                } catch (error) {
+                    userStateFailures.push(
+                        `restore user Remove policy: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                }
+
+                if (userStateFailures.length > 0) {
+                    throw new Error(userStateFailures.join('; '));
+                }
+            },
+            restoreAdministratorConfig: async () => {
+                const restore = await apiRaw(baseURL!, CONFIG_PATH, admin.token, {
+                    method: 'POST',
+                    body: JSON.stringify(originalConfig),
+                });
+                expect(restore.status).toBe(204);
+            },
+        });
+
+        throwAfterRestoration(primaryError, cleanupFailures);
 
         assertNoRuntimeErrors(consoleErrors);
     });

--- a/e2e/remove-home-policy.spec.ts
+++ b/e2e/remove-home-policy.spec.ts
@@ -387,21 +387,36 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
         }
 
         const cleanupFailures = await runIndependentRestorations({
-            pageCleanup: async () => {
-                await page.evaluate(() => {
-                    document.querySelector('#jc-remove-policy-proof')?.remove();
-                    document.querySelector('#jc-remove-policy-sheet')?.remove();
-                });
+            pageCleanup: async (signal) => {
+                let closePromise: Promise<void> | null = null;
+                const closeOnAbort = () => {
+                    closePromise = page.isClosed()
+                        ? Promise.resolve()
+                        : page.close({ runBeforeUnload: false });
+                };
+                signal.addEventListener('abort', closeOnAbort, { once: true });
+                try {
+                    signal.throwIfAborted();
+                    await page.evaluate(() => {
+                        document.querySelector('#jc-remove-policy-proof')?.remove();
+                        document.querySelector('#jc-remove-policy-sheet')?.remove();
+                    });
+                } finally {
+                    signal.removeEventListener('abort', closeOnAbort);
+                    if (closePromise) await closePromise;
+                }
             },
-            restoreDurableUserState: async () => {
+            restoreDurableUserState: async (signal) => {
                 const userStateFailures: string[] = [];
                 const attempt = async (label: string, operation: () => Promise<Response>) => {
+                    signal.throwIfAborted();
                     try {
                         const response = await operation();
                         if (!response.ok) {
                             throw new Error(`HTTP ${response.status}`);
                         }
                     } catch (error) {
+                        if (signal.aborted) throw signal.reason ?? error;
                         userStateFailures.push(
                             `${label}: ${error instanceof Error ? error.message : String(error)}`
                         );
@@ -415,21 +430,21 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
                             baseURL!,
                             `/JellyfinCanopy/continue-watching/hide/${encodeURIComponent(ids[index])}`,
                             user.token,
-                            { method: 'DELETE' },
+                            { method: 'DELETE', signal },
                         ));
                     }
                     await attempt(`restore user data ${index}`, () => apiRaw(
                         baseURL!,
                         `/UserItems/${encodeURIComponent(ids[index])}/UserData?userId=${encodeURIComponent(user.userId)}`,
                         user.token,
-                        { method: 'POST', body: JSON.stringify(originalUserData[index]) },
+                        { method: 'POST', body: JSON.stringify(originalUserData[index]), signal },
                     ));
                 }
 
                 try {
                     const settingsPath = `/JellyfinCanopy/user-settings/${encodeURIComponent(user.userId)}/settings.json`;
                     const current = await api<Record<string, any>>(
-                        baseURL!, settingsPath, user.token
+                        baseURL!, settingsPath, user.token, { signal }
                     );
                     if (!current) throw new Error('current settings response is empty');
                     const revision = field<number>(current, 'Revision', 'revision');
@@ -450,9 +465,11 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
                             method: 'POST',
                             headers: { 'If-Match': `"${revision}"` },
                             body: JSON.stringify(restored),
+                            signal,
                         },
                     ));
                 } catch (error) {
+                    if (signal.aborted) throw signal.reason ?? error;
                     userStateFailures.push(
                         `restore user Remove policy: ${error instanceof Error ? error.message : String(error)}`
                     );
@@ -462,10 +479,11 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
                     throw new Error(userStateFailures.join('; '));
                 }
             },
-            restoreAdministratorConfig: async () => {
+            restoreAdministratorConfig: async (signal) => {
                 const restore = await apiRaw(baseURL!, CONFIG_PATH, admin.token, {
                     method: 'POST',
                     body: JSON.stringify(originalConfig),
+                    signal,
                 });
                 expect(restore.status).toBe(204);
             },

--- a/e2e/remove-home-policy.spec.ts
+++ b/e2e/remove-home-policy.spec.ts
@@ -1,0 +1,446 @@
+import type { Page } from 'playwright/test';
+import {
+    test,
+    expect,
+    loginAs,
+    showRoute,
+    waitForHash,
+    assertNoRuntimeErrors,
+} from './fixtures/auth';
+import { api, apiRaw, authenticate, PLUGIN_ID } from './fixtures/api';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const CONFIG_PATH = `/Plugins/${PLUGIN_ID}/Configuration`;
+
+function field<T>(value: Record<string, any>, pascal: string, camel: string): T {
+    return (value[pascal] ?? value[camel]) as T;
+}
+
+function canonical(value: unknown): string {
+    return String(value || '').replaceAll('-', '').toLowerCase();
+}
+
+async function setPluginPolicy(
+    baseURL: string,
+    token: string,
+    original: Record<string, unknown>,
+    hiddenContentEnabled: boolean,
+    administratorRemoveDefault: boolean,
+): Promise<void> {
+    const response = await apiRaw(baseURL, CONFIG_PATH, token, {
+        method: 'POST',
+        body: JSON.stringify({
+            ...original,
+            HiddenContentEnabled: hiddenContentEnabled,
+            RemoveContinueWatchingEnabled: administratorRemoveDefault,
+        }),
+    });
+    expect(response.status, 'plugin policy update').toBe(204);
+}
+
+async function waitForPluginPolicy(
+    page: Page,
+    hiddenContentEnabled: boolean,
+    administratorRemoveDefault: boolean,
+): Promise<void> {
+    await page.waitForFunction(({ hidden, remove }) => {
+        const config = (window as any).JellyfinCanopy?.pluginConfig;
+        return config?.HiddenContentEnabled === hidden
+            && config?.RemoveContinueWatchingEnabled === remove;
+    }, { hidden: hiddenContentEnabled, remove: administratorRemoveDefault });
+}
+
+async function setUserRemovePolicy(page: Page, enabled: boolean): Promise<void> {
+    const acknowledgement = await page.evaluate(async (next) => {
+        const canopy = (window as any).JellyfinCanopy;
+        const settings = canopy.currentSettings;
+        if (!settings || !canopy.identity?.isOwned?.(settings)) {
+            throw new Error('active settings are not identity-owned');
+        }
+        settings.removeContinueWatchingEnabled = next;
+        return canopy.saveUserSettings('settings.json', settings);
+    }, enabled) as { acknowledged?: unknown };
+    expect(acknowledgement.acknowledged, 'client persistence acknowledgement').toBe(true);
+    await page.waitForFunction((next) =>
+        (window as any).JellyfinCanopy.currentSettings
+            ?.removeContinueWatchingEnabled === next,
+    enabled);
+}
+
+async function resumeIds(page: Page, mediaType: 'Audio' | 'Book'): Promise<string[]> {
+    return page.evaluate(async (type) => {
+        const apiClient = (window as any).ApiClient;
+        const userId = apiClient.getCurrentUserId();
+        const result = await apiClient.ajax({
+            type: 'GET',
+            url: apiClient.getUrl(
+                `/UserItems/Resume?userId=${encodeURIComponent(userId)}`
+                + `&limit=100&mediaTypes=${encodeURIComponent(type)}`
+            ),
+            dataType: 'json',
+        });
+        return (result?.Items || []).map((item: any) => String(item?.Id || ''));
+    }, mediaType);
+}
+
+async function actionFor(
+    page: Page,
+    cardSelector: string,
+    itemId: string,
+    expectedSurface: 'continuewatching' | null,
+): Promise<void> {
+    await page.evaluate(({ selector }) => {
+        document.querySelector('#jc-remove-policy-sheet')?.remove();
+        const card = document.querySelector<HTMLElement>(selector);
+        const menu = card?.querySelector<HTMLButtonElement>('button[data-action="menu"]');
+        if (!card || !menu) throw new Error(`missing action source ${selector}`);
+        menu.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+        const container = document.createElement('div');
+        container.id = 'jc-remove-policy-sheet';
+        container.className = 'dialogContainer';
+        container.innerHTML = `
+            <div class="dialog actionSheet opened" style="display:block">
+                <div class="actionSheetScroller">
+                    <button class="listItem actionSheetMenuItem" data-id="play">
+                        <span class="actionSheetItemText">Play</span>
+                    </button>
+                </div>
+            </div>`;
+        document.body.appendChild(container);
+        (window as any).JellyfinCanopy.addRemoveButton();
+    }, { selector: cardSelector });
+
+    const button = page.locator(
+        '#jc-remove-policy-sheet [data-id="remove-continue-watching"]'
+    );
+    if (expectedSurface === null) {
+        await expect(button, 'ordinary row gets no scoped action').toHaveCount(0);
+        return;
+    }
+
+    await expect(button, 'real feature injected the scoped native action').toHaveCount(1);
+    await expect(button).toHaveAttribute('data-jc-item-id', itemId);
+    await expect(button).toHaveAttribute('data-jc-surface', expectedSurface);
+    const responsePromise = page.waitForResponse((response) =>
+        response.request().method() === 'POST'
+        && response.url().includes(
+            `/JellyfinCanopy/continue-watching/hide/${encodeURIComponent(itemId)}`
+        ));
+    await button.click();
+    const response = await responsePromise;
+    expect(response.status(), 'caller-authorized scoped POST').toBe(200);
+    await expect(page.locator(cardSelector)).toHaveCSS('display', 'none');
+}
+
+test.describe('Remove-from-home policy and resume row ownership', () => {
+    test.use({ serviceWorkers: 'block' });
+
+    test('real audio/book actions obey the effective user policy and stay scoped to resume rows', async ({
+        page,
+        baseURL,
+        consoleErrors,
+    }) => {
+        const admin = await authenticate(baseURL!, 'jc_arradmin', 'Test669Pw!x');
+        const originalConfig = await api<Record<string, unknown>>(
+            baseURL!, CONFIG_PATH, admin.token
+        );
+        expect(originalConfig).toBeTruthy();
+
+        await loginAs(page, 'user', consoleErrors);
+        consoleErrors.reset();
+        const fixture = await page.evaluate(async () => {
+            const apiClient = (window as any).ApiClient;
+            const userId = apiClient.getCurrentUserId();
+            const result = await apiClient.getItems(userId, {
+                Recursive: true,
+                IncludeItemTypes: 'Audio,Book',
+                Limit: 100,
+            });
+            const audio = (result?.Items || []).find(
+                (item: any) => item.Type === 'Audio' && item.Name === 'Canopy Resume Audio'
+            );
+            const book = (result?.Items || []).find(
+                (item: any) => item.Type === 'Book' && item.Name === 'Canopy Resume Book'
+            );
+            return {
+                userId,
+                audio: audio && { id: audio.Id, type: audio.Type },
+                book: book && { id: book.Id, type: book.Type },
+                originalRemovePolicy:
+                    (window as any).JellyfinCanopy.currentSettings
+                        ?.removeContinueWatchingEnabled === true,
+            };
+        });
+        expect(fixture.audio, 'real audio fixture is caller-visible').toBeTruthy();
+        expect(fixture.book, 'real book fixture is caller-visible').toBeTruthy();
+
+        const hiddenResponse = await apiRaw(
+            baseURL!,
+            `/JellyfinCanopy/admin/hidden-content/${fixture.userId}`,
+            admin.token,
+        );
+        expect(hiddenResponse.status).toBe(200);
+        const hiddenEnvelope = await hiddenResponse.json() as Record<string, any>;
+        const originalHidden = field<Record<string, any>>(
+            hiddenEnvelope,
+            'HiddenContent',
+            'hiddenContent',
+        );
+        const originalEntries = field<Record<string, any>>(
+            originalHidden,
+            'Items',
+            'items',
+        ) || {};
+        const originalIds = new Set([
+            ...Object.keys(originalEntries),
+            ...Object.values(originalEntries).map(
+                (item: any) => item?.ItemId ?? item?.itemId
+            ),
+        ].map(canonical));
+        expect(originalIds.has(canonical(fixture.audio!.id))).toBe(false);
+        expect(originalIds.has(canonical(fixture.book!.id))).toBe(false);
+
+        const originalUserData = await page.evaluate(async (ids) => {
+            const apiClient = (window as any).ApiClient;
+            const userId = apiClient.getCurrentUserId();
+            return Promise.all(ids.map((id) => apiClient.ajax({
+                type: 'GET',
+                url: apiClient.getUrl(
+                    `/UserItems/${encodeURIComponent(id)}/UserData?userId=${encodeURIComponent(userId)}`
+                ),
+                dataType: 'json',
+            })));
+        }, [fixture.audio!.id, fixture.book!.id]);
+
+        let audioHidden = false;
+        let bookHidden = false;
+        let primaryError: unknown = null;
+        try {
+            await page.evaluate(async (ids) => {
+                const apiClient = (window as any).ApiClient;
+                const userId = apiClient.getCurrentUserId();
+                for (const id of ids) {
+                    const current = await apiClient.ajax({
+                        type: 'GET',
+                        url: apiClient.getUrl(
+                            `/UserItems/${encodeURIComponent(id)}/UserData?userId=${encodeURIComponent(userId)}`
+                        ),
+                        dataType: 'json',
+                    });
+                    await apiClient.ajax({
+                        type: 'POST',
+                        url: apiClient.getUrl(
+                            `/UserItems/${encodeURIComponent(id)}/UserData?userId=${encodeURIComponent(userId)}`
+                        ),
+                        data: JSON.stringify({
+                            ...current,
+                            PlaybackPositionTicks: 10_000_000,
+                            Played: false,
+                        }),
+                        contentType: 'application/json',
+                    });
+                }
+            }, [fixture.audio!.id, fixture.book!.id]);
+
+            // User false overrides administrator true on both native media families.
+            await setPluginPolicy(baseURL!, admin.token, originalConfig!, false, true);
+            await waitForPluginPolicy(page, false, true);
+            await setUserRemovePolicy(page, false);
+            await expect.poll(async () => ({
+                audio: (await resumeIds(page, 'Audio')).map(canonical),
+                book: (await resumeIds(page, 'Book')).map(canonical),
+            }), { message: 'disabled user override preserves real audio/book Resume rows' })
+                .toMatchObject({
+                    audio: expect.arrayContaining([canonical(fixture.audio!.id)]),
+                    book: expect.arrayContaining([canonical(fixture.book!.id)]),
+                });
+
+            // User true overrides administrator false, then the real loader owns
+            // section2/section3 action injection from DisplayPreferences.
+            await setPluginPolicy(baseURL!, admin.token, originalConfig!, false, false);
+            await waitForPluginPolicy(page, false, false);
+            await setUserRemovePolicy(page, true);
+            await showRoute(page, '/mypreferencesmenu.html');
+            await waitForHash(page, '#/mypreferencesmenu');
+            await showRoute(page, '/home');
+            await waitForHash(page, '#/home');
+            await page.waitForFunction(() =>
+                typeof (window as any).JellyfinCanopy?.addRemoveButton === 'function'
+                && typeof (window as any).JellyfinCanopy?.detectCardSurface === 'function'
+            );
+
+            const rowProof = await page.evaluate(async ({ audioId, bookId }) => {
+                const apiClient = (window as any).ApiClient;
+                const userId = apiClient.getCurrentUserId();
+                const prefs = await apiClient.getDisplayPreferences('usersettings', userId, 'emby');
+                const custom = prefs?.CustomPrefs || {};
+                const expected = {
+                    section2: String(custom.homesection2 || 'resumeaudio').toLowerCase(),
+                    section3: String(custom.homesection3 || 'resumebook').toLowerCase(),
+                    section4: String(custom.homesection4 || 'livetv').toLowerCase(),
+                };
+                const owner = document.createElement('div');
+                owner.id = 'jc-remove-policy-proof';
+                owner.className = 'homeSectionsContainer';
+                owner.innerHTML = `
+                    <div class="verticalSection section2">
+                        <div class="card" data-id="${audioId}" data-type="Audio">
+                            <button data-action="menu">Audio menu</button>
+                        </div>
+                    </div>
+                    <div class="verticalSection section3">
+                        <div class="card" data-id="${bookId}" data-type="Book">
+                            <button data-action="menu">Book menu</button>
+                        </div>
+                    </div>
+                    <div class="verticalSection section4">
+                        <div class="card" data-id="${audioId}" data-type="Audio">
+                            <button data-action="menu">Ordinary menu</button>
+                        </div>
+                    </div>`;
+                document.body.appendChild(owner);
+                const canopy = (window as any).JellyfinCanopy;
+                const surfaces = () => [2, 3, 4].map((index) => canopy.detectCardSurface(
+                    owner.querySelector(`.section${index} .card`)
+                ));
+                const deadline = Date.now() + 10_000;
+                let values = surfaces();
+                while ((values[0] === null || values[1] === null) && Date.now() < deadline) {
+                    await new Promise((resolve) => setTimeout(resolve, 50));
+                    values = surfaces();
+                }
+                return { expected, values };
+            }, { audioId: fixture.audio!.id, bookId: fixture.book!.id });
+            expect(rowProof.expected).toEqual({
+                section2: 'resumeaudio',
+                section3: 'resumebook',
+                section4: 'livetv',
+            });
+            expect(rowProof.values).toEqual(['continuewatching', 'continuewatching', null]);
+
+            await actionFor(
+                page,
+                '#jc-remove-policy-proof .section4 .card',
+                fixture.audio!.id,
+                null,
+            );
+            await actionFor(
+                page,
+                '#jc-remove-policy-proof .section2 .card',
+                fixture.audio!.id,
+                'continuewatching',
+            );
+            audioHidden = true;
+            await actionFor(
+                page,
+                '#jc-remove-policy-proof .section3 .card',
+                fixture.book!.id,
+                'continuewatching',
+            );
+            bookHidden = true;
+            await expect(
+                page.locator('#jc-remove-policy-proof .section4 .card'),
+                'same item stays visible on an unrelated authoritative row',
+            ).not.toHaveCSS('display', 'none');
+
+            await expect.poll(async () => ({
+                audio: (await resumeIds(page, 'Audio')).map(canonical),
+                book: (await resumeIds(page, 'Book')).map(canonical),
+            }), { message: 'fresh native Resume responses apply both scoped actions' })
+                .toEqual({ audio: [], book: [] });
+
+            const playbackTicks = await page.evaluate(async (ids) => {
+                const apiClient = (window as any).ApiClient;
+                const userId = apiClient.getCurrentUserId();
+                return Promise.all(ids.map(async (id) => {
+                    const data = await apiClient.ajax({
+                        type: 'GET',
+                        url: apiClient.getUrl(
+                            `/UserItems/${encodeURIComponent(id)}/UserData?userId=${encodeURIComponent(userId)}`
+                        ),
+                        dataType: 'json',
+                    });
+                    return Number(data?.PlaybackPositionTicks || 0);
+                }));
+            }, [fixture.audio!.id, fixture.book!.id]);
+            expect(playbackTicks).toEqual([10_000_000, 10_000_000]);
+            assertNoRuntimeErrors(consoleErrors);
+        } catch (error) {
+            primaryError = error;
+        }
+
+        const cleanupFailures = await page.evaluate(async ({
+            ids,
+            data,
+            hidden,
+            originalRemovePolicy,
+        }) => {
+                const failures: string[] = [];
+                const attempt = async (label: string, operation: () => Promise<unknown>) => {
+                    try {
+                        await operation();
+                    } catch (error) {
+                        failures.push(`${label}: ${error instanceof Error ? error.message : String(error)}`);
+                    }
+                };
+                document.querySelector('#jc-remove-policy-proof')?.remove();
+                document.querySelector('#jc-remove-policy-sheet')?.remove();
+                const canopy = (window as any).JellyfinCanopy;
+                const settings = canopy.currentSettings;
+                if (settings && canopy.identity?.isOwned?.(settings)) {
+                    settings.removeContinueWatchingEnabled = originalRemovePolicy;
+                    await attempt(
+                        'restore user Remove policy',
+                        () => canopy.saveUserSettings('settings.json', settings),
+                    );
+                }
+                const apiClient = (window as any).ApiClient;
+                const userId = apiClient.getCurrentUserId();
+                for (let index = 0; index < ids.length; index++) {
+                    if (hidden[index]) {
+                        await attempt(`unhide item ${index}`, () => apiClient.ajax({
+                            type: 'DELETE',
+                            url: apiClient.getUrl(
+                                `/JellyfinCanopy/continue-watching/hide/${encodeURIComponent(ids[index])}`
+                            ),
+                            dataType: 'json',
+                        }));
+                    }
+                    await attempt(`restore user data ${index}`, () => apiClient.ajax({
+                            type: 'POST',
+                            url: apiClient.getUrl(
+                                `/UserItems/${encodeURIComponent(ids[index])}/UserData?userId=${encodeURIComponent(userId)}`
+                            ),
+                            data: JSON.stringify(data[index]),
+                            contentType: 'application/json',
+                        }));
+                }
+                return failures;
+            }, {
+                ids: [fixture.audio!.id, fixture.book!.id],
+                data: originalUserData,
+                hidden: [audioHidden, bookHidden],
+                originalRemovePolicy: fixture.originalRemovePolicy,
+            });
+        try {
+            const restore = await apiRaw(baseURL!, CONFIG_PATH, admin.token, {
+                method: 'POST',
+                body: JSON.stringify(originalConfig),
+            });
+            expect(restore.status).toBe(204);
+        } catch (error) {
+            cleanupFailures.push(
+                `restore plugin configuration: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+
+        if (primaryError) {
+            throw primaryError;
+        }
+        expect(cleanupFailures, 'exact test-state restoration').toEqual([]);
+
+        assertNoRuntimeErrors(consoleErrors);
+    });
+});

--- a/e2e/required-test-inventory.json
+++ b/e2e/required-test-inventory.json
@@ -101,6 +101,7 @@
     "e2e/platform-native-pilot.spec.ts › Platform v1 native pilot — live Jellyfin 12 › a live parental-policy revocation invalidates an already-prepared Seerr capability",
     "e2e/player-shortcuts-direct.spec.ts › direct player shortcuts › track, aspect, and playback-info actions stay on direct browser surfaces",
     "e2e/qbittorrent-telemetry.spec.ts › qBittorrent telemetry › real loader account, no-match polling, navigation, and live disable lifecycle",
+    "e2e/remove-home-policy.spec.ts › Remove-from-home policy and resume row ownership › real audio/book actions obey the effective user policy and stay scoped to resume rows",
     "e2e/request-approvals.spec.ts › in-app request approvals › admin: affordance renders and the approve/decline endpoint round-trips",
     "e2e/request-approvals.spec.ts › in-app request approvals › non-admin: no approve/decline UI and the endpoint returns 403",
     "e2e/requests-long-title-responsive.spec.ts › responsive Requests and Issues cards (#466 finding 6) › modern: long request and issue titles ellipsize without card overflow",

--- a/scripts/bundle-budgets.json
+++ b/scripts/bundle-budgets.json
@@ -18,8 +18,8 @@
     "maxFeatureExpandedRawBytes": 786432,
     "maxFeatureExpandedGzipBytes": 262144,
     "maxSourceMapRawBytes": 6000000,
-    "maxTotalRawBytes": 7622454,
+    "maxTotalRawBytes": 7622738,
     "maxClientManifestRawBytes": 262144,
-    "maxPublishedRawBytes": 7713869
+    "maxPublishedRawBytes": 7714153
   }
 }

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 45903, totalLines: 55841 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 46003, totalLines: 55951 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
         maximumCoveredLines: 2976,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
-        minimumCoveredLines: 45895,
-        maximumCoveredLines: 45903,
+        cleanRuns: 2,
+        minimumCoveredLines: 46000,
+        maximumCoveredLines: 46003,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 8);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 46177, totalLines: 55954 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 46183, totalLines: 55954 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
         maximumCoveredLines: 2976,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 2,
+        cleanRuns: 3,
         minimumCoveredLines: 46174,
-        maximumCoveredLines: 46177,
+        maximumCoveredLines: 46183,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 9);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,7 +26,7 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 46003, totalLines: 55951 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 46177, totalLines: 55954 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
@@ -34,8 +34,8 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
     });
     assert.deepEqual(baselines.profiles.server.observations, {
         cleanRuns: 2,
-        minimumCoveredLines: 46000,
-        maximumCoveredLines: 46003,
+        minimumCoveredLines: 46174,
+        maximumCoveredLines: 46177,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
     assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 45903,
-        "totalLines": 55841
+        "coveredLines": 46003,
+        "totalLines": 55951
       },
       "observations": {
-        "cleanRuns": 3,
-        "minimumCoveredLines": 45895,
-        "maximumCoveredLines": 45903
+        "cleanRuns": 2,
+        "minimumCoveredLines": 46000,
+        "maximumCoveredLines": 46003
       },
       "tolerance": {
-        "missingCoveredLines": 8,
-        "rationale": "Issue #718 adds bounded per-user canonical language and region filtering, authoritative Original-language inheritance, caller-scoped inventory, and cache invalidation to the merged issue #715 read-only qBittorrent telemetry mainline. Two clean canonical local .NET SDK 10.0.109/runtime 10.0.9 full-suite runs on exact integrated head 27e002c9e02be125216a3bfe06130053f30e52ba passed all 4,394 tests on the identical 55,841-line assembly scope and measured 45,898/55,841 (82.194087%) and 45,895/55,841 (82.188714%). The hosted GitHub Actions Unit job 95053705601 then passed all 4,394 tests on PR synthetic merge 7bba8666ccd0c25fe2bd4cb2ca9262fefc206bbf of exact published head cb32bdc862b08a3e13ad9c6876f645f655cba8d8 into its unchanged base e4674b89965a865821d1fc89a567f99409f4cbda; that merge tree is byte-identical to the reviewed head tree. It measured 45,903/55,841 (82.203041%) before failing solely because that clean gain exceeded the prior reviewed high-water. The reviewed observed high-water is therefore 45,903/55,841 and the exact observed floor remains 45,895/55,841; the eight-line instrumentation spread is 0.014326 percentage points, within the 0.15-point policy maximum. Two earlier canonical attempts that passed only 4,393/4,394 tests were excluded; their distinct timing-sensitive failures each passed an immediate focused rerun and no evidence from either non-clean attempt entered this envelope. The prior issue #715 and pre-integration issue #718 observations remain evidence for their earlier scopes and are not mixed into this combined scope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 3,
+        "rationale": "Issues #732 and #733 add bounded per-user effective Continue Watching removal policy, exact-user cache invalidation, and authoritative classification of the resume, resumeaudio, and resumebook Home row identities on top of merged issue #718. Two clean local .NET SDK 10.0.109/runtime 10.0.9 full-suite coverage runs on exact rebased implementation head 70b4bc4a975ccfeff241d7e841347697a29d158d passed all 4,412 tests on the identical 55,951-line assembly scope and measured 46,000/55,951 (82.214795%) and 46,003/55,951 (82.220157%). The reviewed observed high-water is therefore 46,003/55,951 and the exact observed floor is 46,000/55,951; the three-line instrumentation spread is 0.005362 percentage points, within the 0.15-point policy maximum. Two earlier canonical attempts that passed only 4,411/4,412 tests were excluded; the identical full suite passed immediate clean minimal-logger reruns, and no evidence from either non-clean attempt entered this envelope. The prior issue #718 observations remain evidence for their earlier scope and are not mixed into this expanded scope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 46003,
-        "totalLines": 55951
+        "coveredLines": 46177,
+        "totalLines": 55954
       },
       "observations": {
         "cleanRuns": 2,
-        "minimumCoveredLines": 46000,
-        "maximumCoveredLines": 46003
+        "minimumCoveredLines": 46174,
+        "maximumCoveredLines": 46177
       },
       "tolerance": {
         "missingCoveredLines": 3,
-        "rationale": "Issues #732 and #733 add bounded per-user effective Continue Watching removal policy, exact-user cache invalidation, and authoritative classification of the resume, resumeaudio, and resumebook Home row identities on top of merged issue #718. Two clean local .NET SDK 10.0.109/runtime 10.0.9 full-suite coverage runs on exact rebased implementation head 70b4bc4a975ccfeff241d7e841347697a29d158d passed all 4,412 tests on the identical 55,951-line assembly scope and measured 46,000/55,951 (82.214795%) and 46,003/55,951 (82.220157%). The reviewed observed high-water is therefore 46,003/55,951 and the exact observed floor is 46,000/55,951; the three-line instrumentation spread is 0.005362 percentage points, within the 0.15-point policy maximum. Two earlier canonical attempts that passed only 4,411/4,412 tests were excluded; the identical full suite passed immediate clean minimal-logger reruns, and no evidence from either non-clean attempt entered this envelope. The prior issue #718 observations remain evidence for their earlier scope and are not mixed into this expanded scope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "rationale": "Issues #732 and #733 now use one bounded exact-user effective Continue Watching removal policy owner across response filtering and playback auto-unhide, with scoped write invalidation, fail-closed cold reads, retained last-known-good state, and authoritative resume, resumeaudio, and resumebook Home-row identity. Two clean local .NET SDK 10.0.109/runtime 10.0.9 full-suite coverage runs on the identical reviewed R2 source tree passed all 4,421 tests and measured 46,174/55,954 (82.521357%) and 46,177/55,954 (82.526718%). The reviewed observed high-water is therefore 46,177/55,954 and the exact observed floor is 46,174/55,954; the three-line instrumentation spread is 0.005362 percentage points, within the 0.15-point policy maximum. Earlier attempts with one or more unrelated pre-existing allocation-budget failures were excluded; the unchanged allocation ratchet then passed both clean measurements, and no evidence from a non-clean attempt entered this envelope. The prior issues #718 and initial #732/#733 observations remain evidence for their earlier scopes and are not mixed into this R2 scope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 46177,
+        "coveredLines": 46183,
         "totalLines": 55954
       },
       "observations": {
-        "cleanRuns": 2,
+        "cleanRuns": 3,
         "minimumCoveredLines": 46174,
-        "maximumCoveredLines": 46177
+        "maximumCoveredLines": 46183
       },
       "tolerance": {
-        "missingCoveredLines": 3,
-        "rationale": "Issues #732 and #733 now use one bounded exact-user effective Continue Watching removal policy owner across response filtering and playback auto-unhide, with scoped write invalidation, fail-closed cold reads, retained last-known-good state, and authoritative resume, resumeaudio, and resumebook Home-row identity. Two clean local .NET SDK 10.0.109/runtime 10.0.9 full-suite coverage runs on the identical reviewed R2 source tree passed all 4,421 tests and measured 46,174/55,954 (82.521357%) and 46,177/55,954 (82.526718%). The reviewed observed high-water is therefore 46,177/55,954 and the exact observed floor is 46,174/55,954; the three-line instrumentation spread is 0.005362 percentage points, within the 0.15-point policy maximum. Earlier attempts with one or more unrelated pre-existing allocation-budget failures were excluded; the unchanged allocation ratchet then passed both clean measurements, and no evidence from a non-clean attempt entered this envelope. The prior issues #718 and initial #732/#733 observations remain evidence for their earlier scopes and are not mixed into this R2 scope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
+        "missingCoveredLines": 9,
+        "rationale": "Issues #732 and #733 now use one bounded exact-user effective Continue Watching removal policy owner across response filtering and playback auto-unhide, with scoped write invalidation, fail-closed cold reads, retained last-known-good state, and authoritative resume, resumeaudio, and resumebook Home-row identity. Two clean local .NET SDK 10.0.109/runtime 10.0.9 full-suite coverage runs on the identical reviewed R2 source tree passed all 4,421 tests and measured 46,174/55,954 (82.521357%) and 46,177/55,954 (82.526718%). Hosted GitHub Actions Unit job 95069621727 then passed all 4,421 tests on PR synthetic merge 86b2adc6de9812fc86529696ffc8dbcf451ef49b of exact reviewed head 7f17666ced16c9a92c5dc57af918b99d0e248feb into its unchanged base 5e71908021c67cabd7dea88db0ff84a65de1c3d5; that merge tree is byte-identical to the reviewed head tree. It measured 46,183/55,954 (82.537441%) before failing solely because that clean gain exceeded the prior reviewed high-water. The reviewed observed high-water is therefore 46,183/55,954 and the exact observed floor remains 46,174/55,954; the nine-line instrumentation spread is 0.016085 percentage points, within the 0.15-point policy maximum. Earlier attempts with one or more unrelated pre-existing allocation-budget failures were excluded; the unchanged allocation ratchet then passed both clean measurements, and no evidence from a non-clean attempt entered this envelope. The prior issues #718 and initial #732/#733 observations remain evidence for their earlier scopes and are not mixed into this R2 scope. coverage-baseline.test.js retains the exact scope-drift, regression, stale-baseline, observed-high-water, spread, single-run, and broad-tolerance negative boundaries."
       }
     }
   }

--- a/scripts/e2e/library-scan-seed.test.js
+++ b/scripts/e2e/library-scan-seed.test.js
@@ -108,6 +108,8 @@ test('seed starts one explicit scan only after all seed-owned libraries exist', 
     const composeUp = seed.indexOf('"${COMPOSE[@]}" up -d');
     const movies = seed.indexOf('name=Movies&collectionType=movies&paths=%2Fmedia%2FMovies&refreshLibrary=false');
     const shows = seed.indexOf('name=Shows&collectionType=tvshows&paths=%2Fmedia%2FShows&refreshLibrary=false');
+    const music = seed.indexOf('name=Music&collectionType=music&paths=%2Fmedia%2FMusic&refreshLibrary=false');
+    const books = seed.indexOf('name=Books&collectionType=books&paths=%2Fmedia%2FBooks&refreshLibrary=false');
     const collections = seed.indexOf('name=Collections&collectionType=boxsets&paths=%2Fconfig%2Fdata%2Fcollections&refreshLibrary=false');
     const trigger = seed.indexOf('LIBRARY_SCAN_TRIGGERED_AT="$(date -u');
     const refresh = seed.indexOf('api POST "/Library/Refresh"');
@@ -116,7 +118,9 @@ test('seed starts one explicit scan only after all seed-owned libraries exist', 
     assert.ok(composeUp > precreatedCollections);
     assert.ok(movies >= 0);
     assert.ok(shows > movies);
-    assert.ok(collections > shows);
+    assert.ok(music > shows);
+    assert.ok(books > music);
+    assert.ok(collections > books);
     assert.ok(trigger > collections);
     assert.ok(refresh > trigger);
     assert.equal((seed.match(/refreshLibrary=true/g) || []).length, 0);

--- a/scripts/e2e/remove-home-policy-cleanup.d.ts
+++ b/scripts/e2e/remove-home-policy-cleanup.d.ts
@@ -1,0 +1,17 @@
+export function completeAcknowledgedMutation(options: {
+    verifyAcknowledgement: () => void;
+    journalMutation: () => void;
+    verifyProductState: () => Promise<void>;
+}): Promise<void>;
+
+export function runIndependentRestorations(options: {
+    pageCleanup: () => Promise<void>;
+    restoreDurableUserState: () => Promise<void>;
+    restoreAdministratorConfig: () => Promise<void>;
+    timeoutMs?: number;
+}): Promise<string[]>;
+
+export function throwAfterRestoration(
+    primaryError: unknown,
+    restorationFailures: string[],
+): void;

--- a/scripts/e2e/remove-home-policy-cleanup.d.ts
+++ b/scripts/e2e/remove-home-policy-cleanup.d.ts
@@ -5,9 +5,9 @@ export function completeAcknowledgedMutation(options: {
 }): Promise<void>;
 
 export function runIndependentRestorations(options: {
-    pageCleanup: () => Promise<void>;
-    restoreDurableUserState: () => Promise<void>;
-    restoreAdministratorConfig: () => Promise<void>;
+    pageCleanup: (signal: AbortSignal) => Promise<void>;
+    restoreDurableUserState: (signal: AbortSignal) => Promise<void>;
+    restoreAdministratorConfig: (signal: AbortSignal) => Promise<void>;
     timeoutMs?: number;
 }): Promise<string[]>;
 

--- a/scripts/e2e/remove-home-policy-cleanup.js
+++ b/scripts/e2e/remove-home-policy-cleanup.js
@@ -1,0 +1,87 @@
+'use strict';
+
+function toError(value) {
+    return value instanceof Error ? value : new Error(String(value));
+}
+
+async function completeAcknowledgedMutation({
+    verifyAcknowledgement,
+    journalMutation,
+    verifyProductState,
+}) {
+    verifyAcknowledgement();
+    journalMutation();
+    await verifyProductState();
+}
+
+async function boundedRestoration(label, operation, timeoutMs) {
+    let timer;
+    try {
+        await Promise.race([
+            Promise.resolve().then(operation),
+            new Promise((_, reject) => {
+                timer = setTimeout(
+                    () => reject(new Error(`${label} exceeded ${timeoutMs}ms`)),
+                    timeoutMs,
+                );
+            }),
+        ]);
+        return null;
+    } catch (error) {
+        return `${label}: ${toError(error).message}`;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+async function runIndependentRestorations({
+    pageCleanup,
+    restoreDurableUserState,
+    restoreAdministratorConfig,
+    timeoutMs = 30_000,
+}) {
+    const failures = [];
+    const pageFailure = await boundedRestoration('restore page-owned state', pageCleanup, timeoutMs);
+    if (pageFailure) failures.push(pageFailure);
+
+    const userStateFailure = await boundedRestoration(
+        'restore durable user state',
+        restoreDurableUserState,
+        timeoutMs,
+    );
+    if (userStateFailure) failures.push(userStateFailure);
+
+    const administratorFailure = await boundedRestoration(
+        'restore administrator configuration',
+        restoreAdministratorConfig,
+        timeoutMs,
+    );
+    if (administratorFailure) failures.push(administratorFailure);
+    return failures;
+}
+
+function throwAfterRestoration(primaryError, restorationFailures) {
+    if (primaryError == null && restorationFailures.length === 0) return;
+    if (primaryError != null && restorationFailures.length === 0) throw primaryError;
+
+    const errors = restorationFailures.map((failure) => new Error(failure));
+    if (primaryError != null) {
+        const primary = toError(primaryError);
+        throw new AggregateError(
+            [primary, ...errors],
+            `Primary test failure; restoration also failed: ${restorationFailures.join('; ')}`,
+            { cause: primary },
+        );
+    }
+
+    throw new AggregateError(
+        errors,
+        `Test-state restoration failed: ${restorationFailures.join('; ')}`,
+    );
+}
+
+module.exports = {
+    completeAcknowledgedMutation,
+    runIndependentRestorations,
+    throwAfterRestoration,
+};

--- a/scripts/e2e/remove-home-policy-cleanup.js
+++ b/scripts/e2e/remove-home-policy-cleanup.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { AbortController: NodeAbortController } = globalThis;
+
 function toError(value) {
     return value instanceof Error ? value : new Error(String(value));
 }
@@ -15,19 +17,22 @@ async function completeAcknowledgedMutation({
 }
 
 async function boundedRestoration(label, operation, timeoutMs) {
-    let timer;
+    const controller = new NodeAbortController();
+    const timeoutError = new Error(`${label} exceeded ${timeoutMs}ms`);
+    let timedOut = false;
+    const timer = setTimeout(() => {
+        timedOut = true;
+        controller.abort(timeoutError);
+    }, timeoutMs);
     try {
-        await Promise.race([
-            Promise.resolve().then(operation),
-            new Promise((_, reject) => {
-                timer = setTimeout(
-                    () => reject(new Error(`${label} exceeded ${timeoutMs}ms`)),
-                    timeoutMs,
-                );
-            }),
-        ]);
+        // A timeout transfers ownership to AbortController, but does not let
+        // this domain go. The operation must observe the signal and settle
+        // before the next state owner is allowed to run.
+        await operation(controller.signal);
+        if (timedOut) return `${label}: ${timeoutError.message}`;
         return null;
     } catch (error) {
+        if (timedOut) return `${label}: ${timeoutError.message}`;
         return `${label}: ${toError(error).message}`;
     } finally {
         clearTimeout(timer);

--- a/scripts/e2e/remove-home-policy-cleanup.test.js
+++ b/scripts/e2e/remove-home-policy-cleanup.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+    completeAcknowledgedMutation,
+    runIndependentRestorations,
+    throwAfterRestoration,
+} = require('./remove-home-policy-cleanup');
+
+test('acknowledged scoped mutation is journaled before a product failure and every cleanup domain runs', async () => {
+    const calls = [];
+    const primary = new Error('post-commit product assertion failed');
+    const pageCleanupFailure = new Error('page cleanup rejected');
+    let scopedMutationCommitted = false;
+
+    await assert.rejects(
+        completeAcknowledgedMutation({
+            verifyAcknowledgement: () => calls.push('POST acknowledged'),
+            journalMutation: () => {
+                scopedMutationCommitted = true;
+                calls.push('journal scoped POST');
+            },
+            verifyProductState: async () => {
+                calls.push('product assertion');
+                throw primary;
+            },
+        }),
+        (error) => error === primary,
+    );
+
+    const failures = await runIndependentRestorations({
+        pageCleanup: async () => {
+            throw pageCleanupFailure;
+        },
+        restoreDurableUserState: async () => {
+            if (scopedMutationCommitted) calls.push('DELETE acknowledged scoped item');
+        },
+        restoreAdministratorConfig: async () => {
+            calls.push('restore administrator configuration');
+        },
+        timeoutMs: 100,
+    });
+
+    assert.deepEqual(calls, [
+        'POST acknowledged',
+        'journal scoped POST',
+        'product assertion',
+        'DELETE acknowledged scoped item',
+        'restore administrator configuration',
+    ]);
+    assert.deepEqual(failures, ['restore page-owned state: page cleanup rejected']);
+    let combined;
+    try {
+        throwAfterRestoration(primary, failures);
+        assert.fail('combined primary/restoration failure was not thrown');
+    } catch (error) {
+        combined = error;
+    }
+    assert.ok(combined instanceof AggregateError);
+    assert.equal(combined.cause, primary);
+    assert.equal(combined.errors[0], primary);
+    assert.match(combined.message, /page cleanup rejected/);
+});
+
+test('timed-out page cleanup cannot bypass the independently bounded administrator restore', async () => {
+    const calls = [];
+    const failures = await runIndependentRestorations({
+        pageCleanup: async () => {
+            calls.push('page cleanup started');
+            await new Promise(() => {});
+        },
+        restoreDurableUserState: async () => {
+            calls.push('restore durable user state');
+        },
+        restoreAdministratorConfig: async () => {
+            calls.push('restore administrator configuration');
+        },
+        timeoutMs: 5,
+    });
+
+    assert.deepEqual(calls, [
+        'page cleanup started',
+        'restore durable user state',
+        'restore administrator configuration',
+    ]);
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /restore page-owned state exceeded 5ms/);
+});

--- a/scripts/e2e/remove-home-policy-cleanup.test.js
+++ b/scripts/e2e/remove-home-policy-cleanup.test.js
@@ -63,15 +63,25 @@ test('acknowledged scoped mutation is journaled before a product failure and eve
     assert.match(combined.message, /page cleanup rejected/);
 });
 
-test('timed-out page cleanup cannot bypass the independently bounded administrator restore', async () => {
+test('timed-out restoration aborts and settles without any touch after return', async () => {
     const calls = [];
     const failures = await runIndependentRestorations({
         pageCleanup: async () => {
-            calls.push('page cleanup started');
-            await new Promise(() => {});
+            calls.push('page cleanup');
         },
-        restoreDurableUserState: async () => {
-            calls.push('restore durable user state');
+        restoreDurableUserState: async (signal) => {
+            calls.push('user cleanup started');
+            await new Promise((resolve, reject) => {
+                const lateTouch = setTimeout(() => {
+                    calls.push('late user touch');
+                    resolve();
+                }, 30);
+                signal.addEventListener('abort', () => {
+                    clearTimeout(lateTouch);
+                    calls.push('user cleanup aborted');
+                    reject(signal.reason);
+                }, { once: true });
+            });
         },
         restoreAdministratorConfig: async () => {
             calls.push('restore administrator configuration');
@@ -80,10 +90,53 @@ test('timed-out page cleanup cannot bypass the independently bounded administrat
     });
 
     assert.deepEqual(calls, [
-        'page cleanup started',
-        'restore durable user state',
+        'page cleanup',
+        'user cleanup started',
+        'user cleanup aborted',
         'restore administrator configuration',
     ]);
     assert.equal(failures.length, 1);
-    assert.match(failures[0], /restore page-owned state exceeded 5ms/);
+    assert.match(failures[0], /restore durable user state exceeded 5ms/);
+    calls.push('helper returned');
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    assert.deepEqual(calls, [
+        'page cleanup',
+        'user cleanup started',
+        'user cleanup aborted',
+        'restore administrator configuration',
+        'helper returned',
+    ]);
+});
+
+test('rejected acknowledgement never journals or schedules a scoped DELETE', async () => {
+    const calls = [];
+    const rejection = new Error('POST was not acknowledged');
+    let journaled = false;
+
+    await assert.rejects(completeAcknowledgedMutation({
+        verifyAcknowledgement: () => {
+            calls.push('acknowledgement rejected');
+            throw rejection;
+        },
+        journalMutation: () => {
+            journaled = true;
+            calls.push('journal scoped POST');
+        },
+        verifyProductState: async () => calls.push('product assertion'),
+    }), (error) => error === rejection);
+
+    await runIndependentRestorations({
+        pageCleanup: async () => calls.push('page cleanup'),
+        restoreDurableUserState: async () => {
+            if (journaled) calls.push('DELETE scoped item');
+        },
+        restoreAdministratorConfig: async () => calls.push('restore administrator configuration'),
+        timeoutMs: 100,
+    });
+
+    assert.deepEqual(calls, [
+        'acknowledgement rejected',
+        'page cleanup',
+        'restore administrator configuration',
+    ]);
 });


### PR DESCRIPTION
Closes #732.
Closes #733.

## Summary

- make server-side Continue Watching and Next Up filtering honor each authenticated user's effective Remove setting instead of treating the administrator default as a runtime ceiling
- keep the full Hidden Content path independent while adding bounded, identity-keyed effective-policy caching and exact invalidation on settings creation, update, reset, and recovery
- classify Jellyfin's `resume`, `resumeaudio`, and `resumebook` DisplayPreferences values consistently as Continue Watching without relying on translated headings or playback-position guesses
- document the administrator-default/per-user-override behavior and the audio/book resume-row scope

## Validation

- focused server tests: 121/121
- focused client tests: 46/46
- full server coverage: 4,421/4,421 twice; 46,174 and 46,177 of 55,954 lines
- full client coverage: 272 files / 2,622 tests twice; 2,976/3,362 lines
- deterministic bundle: two identical builds, 187 files
- Chromium and WebKit: targeted Jellyfin 12 acceptance passed 1/1 in each engine
- typechecks, syntax, lint policy, performance, translations, scripts, strict docs/support, Release build, coverage policy, and diff checks passed

The browser acceptance uses real persisted user settings and validates opposite administrator/user policy combinations, native Resume filtering, real caller-authorized audio and book action POSTs and filtering, an unrelated Live TV negative control, unchanged playback position, runtime cleanliness, restoration, and exact fixture teardown.
