### PR TITLE
test: use runner credentials for home removal policy

### DIFF
--- a/e2e/remove-home-policy.spec.ts
+++ b/e2e/remove-home-policy.spec.ts
@@ -6,6 +6,7 @@ import {
     showRoute,
     waitForHash,
     assertNoRuntimeErrors,
+    USERS,
 } from './fixtures/auth';
 import { api, apiRaw, authenticate, PLUGIN_ID } from './fixtures/api';
 import {
@@ -153,8 +154,8 @@ test.describe('Remove-from-home policy and resume row ownership', () => {
         baseURL,
         consoleErrors,
     }) => {
-        const admin = await authenticate(baseURL!, 'jc_arradmin', 'Test669Pw!x');
-        const user = await authenticate(baseURL!, 'jc_arruser', 'Test669Pw!x');
+        const admin = await authenticate(baseURL!, USERS.admin.username, USERS.admin.password);
+        const user = await authenticate(baseURL!, USERS.user.username, USERS.user.password);
         const originalConfig = await api<Record<string, unknown>>(
             baseURL!, CONFIG_PATH, admin.token
         );


### PR DESCRIPTION
The remove-from-home browser test failed before its policy assertions when the disposable runner generated nondefault accounts. Its API sessions used fixed credentials while the browser session used the runner configuration.

Use the shared `USERS` fixture for both API sessions so seeding, API requests, and browser login refer to the same accounts. Existing policy, identity, cleanup, and playback-state assertions are unchanged; default exploratory credentials still come from the shared fixture.

Validation: Node 22.20.0/npm 10.9.3; all 658 script tests passed; the complete affected browser test passed with retries disabled against a disposable, digest-pinned Jellyfin 12 server capped at two CPUs and using randomized accounts. Independent Codex review approved the diff. The local runtime also contained a separate client search correction; this PR's required CI validates its isolated head.
