### PR TITLE
test: await canon classification after detail navigation

### DIFF
--- a/e2e/anime-filler-warnings.spec.ts
+++ b/e2e/anime-filler-warnings.spec.ts
@@ -134,7 +134,17 @@ test.describe.serial('anime filler warnings', () => {
         await expect(detailBadge).toHaveAttribute('role', 'note');
         await expect(detailBadge).toHaveAttribute('aria-label', /filler/i);
 
+        // An empty marker set can be the outgoing view's cleanup. Wait for
+        // the canon detail request to finish before asserting its result.
+        const canonClassification = page.waitForResponse((response) => {
+            if (!response.url().endsWith('/JellyfinCanopy/anime-filler/classifications')) return false;
+            const body = response.request().postDataJSON() as { itemIds?: string[] };
+            return body.itemIds?.includes(target!.canonId) === true;
+        });
         await showDetails(page, target!.canonId);
+        const canonResponse = await canonClassification;
+        expect(canonResponse.ok()).toBe(true);
+        await canonResponse.finished();
         await expect(page.locator(`#itemDetailPage ${MARKER}`)).toHaveCount(0);
         expect(requests.value).toBeGreaterThanOrEqual(3);
         expect(await page.evaluate(() => localStorage.getItem('layout'))).toBe('experimental');


### PR DESCRIPTION
The anime warning navigation test could assert the final request count while Jellyfin was still loading the canon episode. The outgoing page had already cleared its markers, so the absence assertion passed before classification ran.

Wait for the canon episode's classification response to finish before checking that no detail warning remains. The original request-count threshold, timeout budgets, filler assertions, and mobile/disabled coverage remain intact.

Validation: all three affected browser tests passed with retries disabled against a disposable digest-pinned Jellyfin 12 server capped at two CPUs; all 658 script tests passed under Node 22.20.0/npm 10.9.3; independent Codex review approved the diff. The local runtime also contained a separate client search correction; required CI validates this PR's isolated head.
