### PR TITLE
docs: correct language tag customization selectors

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -144,19 +144,32 @@ Genre tags collapse to an icon until you hover over them. To keep the text alway
 
 #### Language tags
 
-Language tags render as a flag carrying a `data-lang` attribute. Resize the flag:
+Each language tag uses a `.language-tag-presentation` wrapper. Its `data-lang-tags` attribute contains a JSON array of canonical language tags, such as `["ja-JP"]`. When the media specifies a supported country region, the wrapper has an uppercase `data-region` value (for example, `JP`) and contains a `.language-flag` image. Otherwise, it shows a neutral language label with an empty `data-region` value.
+
+Resize the flag images:
 
 ```css
-.language-flag {
+.language-tag-presentation .language-flag {
     width: 30px !important;
     height: auto !important;
 }
 ```
 
-Hide a specific language by its `data-lang` code:
+Hide Japanese tags, including generic `ja` and variants such as `ja-JP`, by targeting the wrapper:
 
 ```css
-.language-flag[data-lang="jp"] {
+.language-tag-presentation[data-lang-tags*='"ja"'],
+.language-tag-presentation[data-lang-tags*='"ja-'] {
+    display: none !important;
+}
+```
+
+The quotes and hyphen match a complete language code or its subtag boundary within the JSON array. A flag can group several languages that share a region; hiding its wrapper hides the whole group.
+
+To hide tags by country region instead, use `data-region`. This example hides all groups represented by Japan's flag, regardless of language:
+
+```css
+.language-tag-presentation[data-region="JP"] {
     display: none !important;
 }
 ```


### PR DESCRIPTION
The language-tag customization examples targeted a `data-lang` attribute that the renderer no longer emits, so the documented hide-language rule had no effect.

Document the current presentation wrapper, canonical language-tag array, and region attribute. Provide selectors for Japanese language variants and a separate Japan-region example, explain shared-region grouping, and retain flag-image sizing.

Validation: strict documentation build passed under Python 3.13.14 and Node 22.20.0/npm 10.9.3. Eight fixtures rendered by the actual language-tag implementation verified all three documented selectors (24 assertions). Independent Codex review approved the change.
