### PR TITLE
ci: update Python setup to v7 with validated manifest fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         run: npm run check:performance-rules
 
       - name: Setup exact Python for documentation validation
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: .python-version-docs
           cache: pip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -93,7 +93,7 @@ jobs:
         run: npm ci
 
       - name: Set up exact Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: .python-version-docs
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
         run: npm ci
 
       - name: Setup exact Python for documentation validation
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: .python-version-docs
           cache: pip


### PR DESCRIPTION
Python setup validates the primary versions manifest but can receive an invalid raw fallback. Update the three documentation-toolchain consumers to setup-python v7.0.0, which validates both sources, retries transient failures within bounded attempt counts, and fails setup if neither source supplies a valid manifest.

This is an explicit major action update, pinned to its immutable release commit. All consumers use supported inputs; none uses the removed pip-install input. Python remains exactly 3.13.14, with the same pip cache and separate hash-locked dependency installation. The action remains on the runner’s Node 24 runtime. Workflow permissions, triggers, quality gates, and release controls are unchanged.

Validation: all 660 script tests and the complete deterministic documentation gate, including strict MkDocs, passed before and after integration with current main. Two independent Codex reviews approved the complete three-pin change. Its diff is byte-identical after integration at 06e6602881a04285d7fd4e402fe9d1664e50c268. Required hosted setup/cache and downstream checks must pass before merge. No release was dispatched.
