### PR TITLE
chore(deps): apply development dependency security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1827,9 +1827,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2952,9 +2952,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3521,9 +3521,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Refresh three existing transitive development dependencies to compatible releases containing published security fixes:

- Undici: 7.28.0 → 7.29.1
- brace-expansion: 5.0.8 → 5.0.9
- nanoid: 3.3.16 → 3.3.18

The npm-generated change updates only these three lockfile entries. A clean install succeeds and npm audit reports zero known vulnerabilities.

Validation: full client coverage (2,632 tests; 2,976/3,362 core lines), 660 script tests, exact Node/npm check, both type checks, syntax, deterministic bundle, and Release build with zero warnings/errors. The lint verifier accepts existing advisory findings: five errors and 5,493 warnings; no lint policy changed. Bounded probes exercise actual jsdom HTTP/XHR/WebSocket integration and dependency consumers.

Developed with OpenAI/Codex assistance. Two independent Codex reviewers approved the exact final diff and independently verified package integrity and consumer compatibility. Current-head CI, including Windows and all six E2E shards, remains required before merge.
