### PR TITLE
perf: bound allocation during Series relationship repair

### DIFF
--- a/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheDependencyInvalidationTests.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy.Tests/Services/TagCacheDependencyInvalidationTests.cs
@@ -3187,6 +3187,91 @@ public sealed class TagCacheDependencyInvalidationTests
         Assert.Equal("new-series-tmdb", entry.SeriesTmdbId);
     }
 
+    private delegate bool ApplyCapacityBatch(IReadOnlyList<TagCacheChange> batch, out bool removed);
+
+    [Theory]
+    [InlineData(40, 100, 5_800_000)]
+    [InlineData(4, 1000, 5_600_000)]
+    public void CoalescedSeriesAllocationGuard(int seriesCount, int childrenPerSeries, long allocationBudget)
+    {
+        var allocated = RunCoalescedSeriesCapacityFixture(seriesCount, childrenPerSeries);
+        Assert.True(allocated < allocationBudget,
+            $"Coalesced Series worker allocated {allocated:N0} bytes (budget: {allocationBudget:N0})");
+    }
+
+    private static long RunCoalescedSeriesCapacityFixture(int seriesCount, int childrenPerSeries)
+    {
+        var probeCount = 0;
+        var series = Enumerable.Range(0, seriesCount).Select(_ => new StubSeries
+        {
+            Id = Guid.NewGuid(),
+            DateLastSaved = SavedAt,
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["Tmdb"] = "stable" },
+        }).ToArray();
+        var seriesById = series.ToDictionary(item => item.Id);
+        var oldSeriesIds = series.Select(_ => Guid.NewGuid()).ToArray();
+        var children = series.Select(owner => Enumerable.Range(0, childrenPerSeries)
+            .Select(_ => new CountingEpisode
+            {
+                Id = Guid.NewGuid(), SeriesId = owner.Id, CommunityRating = 5, CriticRating = 50,
+                DateLastSaved = SavedAt, OnProbe = () => probeCount++,
+            }).ToArray()).ToArray();
+        var childrenBySeries = series.Select((owner, index) => (owner.Id, Children: children[index]))
+            .ToDictionary(pair => pair.Id, pair => pair.Children);
+        var observedDiscoveryOrder = new List<Guid>();
+        var library = new CountingLibraryManager
+        {
+            GetItemByIdHook = id => seriesById.TryGetValue(id, out var found)
+                ? found : throw new InvalidOperationException("no scalar descendant or absent old-owner lookup expected"),
+            GetItemListHook = query =>
+            {
+                if (query.AncestorIds?.Length == 1 && childrenBySeries.TryGetValue(query.AncestorIds[0], out var descendants))
+                {
+                    observedDiscoveryOrder.Add(query.AncestorIds[0]);
+                    return descendants;
+                }
+                if (childrenBySeries.TryGetValue(query.ParentId, out var firstChildren)) return firstChildren;
+                throw new InvalidOperationException("unexpected coalesced relationship query");
+            },
+        };
+        using var service = NewService(library);
+        for (var i = 0; i < seriesCount; i++)
+        {
+            service.SeedEntryForTest(Key(series[i].Id), new TagCacheEntry { Type = "Series", TmdbId = "stable" });
+            foreach (var episode in children[i]) service.SeedEntryForTest(Key(episode.Id), new TagCacheEntry
+            {
+                Type = "Episode", SeriesId = Key(oldSeriesIds[i]), SeriesTmdbId = "stable",
+                CommunityRating = 5, CriticRating = 50, StreamSourceId = Key(episode.Id), SourceRevision = SavedAt.Ticks,
+            });
+        }
+        var batch = series.Select(owner => new TagCacheChange(owner.Id, BaseItemKind.Series,
+            Guid.Empty, Guid.Empty, Guid.Empty, Guid.Empty, false)).ToArray();
+        var method = typeof(TagCacheService).GetMethod("ApplyPendingBatch",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var apply = (ApplyCapacityBatch)method.CreateDelegate(typeof(ApplyCapacityBatch), service);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var changed = apply(batch, out var removed);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(changed);
+        Assert.False(removed);
+        Assert.Equal(series.Select(owner => owner.Id), observedDiscoveryOrder);
+        Assert.Equal(seriesCount * 2, library.GetItemByIdCallCount);
+        Assert.Equal(seriesCount * 2, library.GetItemListCallCount);
+        Assert.Equal(seriesCount, probeCount);
+        Assert.Equal(0, service.PendingChangeCountForTest);
+        for (var i = 0; i < seriesCount; i++) foreach (var episode in children[i])
+        {
+            var entry = service.GetEntryForTest(Key(episode.Id));
+            Assert.NotNull(entry);
+            Assert.Equal(Key(series[i].Id), entry.SeriesId);
+            Assert.Equal("stable", entry.SeriesTmdbId);
+            Assert.Equal(SavedAt.Ticks, entry.SourceRevision);
+            Assert.Equal(5, entry.CommunityRating);
+            Assert.Equal(50, entry.CriticRating);
+        }
+        return allocated;
+    }
+
     private sealed class ControlledEpisode : MediaBrowser.Controller.Entities.TV.Episode
     {
         public bool ThrowOnProbe { get; init; }

--- a/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
+++ b/Jellyfin.Plugin.JellyfinCanopy/Services/TagCacheService.cs
@@ -1555,7 +1555,7 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
         private IReadOnlyList<TagCacheChange> ExpandDependencies(
             IReadOnlyList<TagCacheChange> batch,
             ISet<Guid> expandedSeries,
-            IDictionary<Guid, TagCacheEntry> preparedEntries,
+            Dictionary<Guid, TagCacheEntry> preparedEntries,
             IReadOnlyDictionary<string, TagCacheEntry> cacheSnapshot,
             IReadOnlyDictionary<Guid, Guid[]> collectionParentsSnapshot,
             IReadOnlySet<Guid> unindexedCollectionsSnapshot)
@@ -1873,6 +1873,10 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     var formattedSeriesId = FormatId(change.Id);
                     var snapshotIds = descendantSnapshot.Select(static item => item.Id).ToHashSet();
                     var oldSeriesRepairIds = new HashSet<Guid>();
+                    var discoveredDescendantIds = new HashSet<Guid>();
+                    var targetReservationCount = 0;
+                    var entryReservationCount = 0;
+                    const int MaximumRelationshipReservation = 4_096;
                     foreach (var descendant in descendantSnapshot)
                     {
                         if (descendant is not MediaBrowser.Controller.Entities.TV.Episode
@@ -1890,8 +1894,38 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                                     && season.SeriesId == change.Id))
                         {
                             oldSeriesRepairIds.Add(oldSeriesId);
+                            // Count distinct, relationship-verified stale rows only. Reuse the
+                            // completeness set below so this hint adds no temporary collection.
+                            // A coalesced multi-item batch keeps ordinary geometric growth:
+                            // per-Series hints cover only part of its eventual target set.
+                            if (batch.Count == 1
+                                && discoveredDescendantIds.Count < MaximumRelationshipReservation
+                                && discoveredDescendantIds.Add(descendant.Id)
+                                && !targets.ContainsKey(descendant.Id))
+                            {
+                                targetReservationCount = Math.Min(targetReservationCount + 1, MaximumRelationshipReservation);
+                                if (cachedDescendant.SourceRevision == descendant.DateLastSaved.Ticks
+                                    && !preparedEntries.ContainsKey(descendant.Id))
+                                {
+                                    entryReservationCount = Math.Min(entryReservationCount + 1, MaximumRelationshipReservation);
+                                }
+                            }
                         }
                     }
+
+                    // Bound speculative reservation independently of snapshot size. Ordinary
+                    // dictionary growth still handles actual work beyond this small ceiling.
+                    if (targetReservationCount != 0 && targets.Count < MaximumRelationshipReservation)
+                    {
+                        targets.EnsureCapacity(targets.Count + Math.Min(
+                            targetReservationCount, MaximumRelationshipReservation - targets.Count));
+                    }
+                    if (entryReservationCount != 0 && preparedEntries.Count < MaximumRelationshipReservation)
+                    {
+                        preparedEntries.EnsureCapacity(preparedEntries.Count + Math.Min(
+                            entryReservationCount, MaximumRelationshipReservation - preparedEntries.Count));
+                    }
+                    discoveredDescendantIds.Clear();
 
                     // A partial new-Series snapshot can omit an item whose cache still points at
                     // an old owner, so it is absent from the new owner's expected set. Once any
@@ -1964,7 +1998,6 @@ namespace Jellyfin.Plugin.JellyfinCanopy.Services
                     }
 
                     var firstEpisodesBySeason = new Dictionary<Guid, BaseItem>();
-                    var discoveredDescendantIds = new HashSet<Guid>();
                     var inconsistentSeriesRelationship = false;
                     foreach (var episode in descendantSnapshot.OfType<MediaBrowser.Controller.Entities.TV.Episode>())
                     {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47134, totalLines: 57061 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47135, totalLines: 57061 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
         maximumCoveredLines: 2976,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 3,
+        cleanRuns: 4,
         minimumCoveredLines: 47131,
-        maximumCoveredLines: 47134,
+        maximumCoveredLines: 47135,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 4);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47123, totalLines: 57044 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47131, totalLines: 57061 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
         maximumCoveredLines: 2976,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 4,
-        minimumCoveredLines: 47111,
-        maximumCoveredLines: 47123,
+        cleanRuns: 2,
+        minimumCoveredLines: 47131,
+        maximumCoveredLines: 47131,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 12);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,19 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47131, totalLines: 57061 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47134, totalLines: 57061 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
         maximumCoveredLines: 2976,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 2,
+        cleanRuns: 3,
         minimumCoveredLines: 47131,
-        maximumCoveredLines: 47131,
+        maximumCoveredLines: 47134,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 0);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 3);
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 47134,
+        "coveredLines": 47135,
         "totalLines": 57061
       },
       "observations": {
-        "cleanRuns": 3,
+        "cleanRuns": 4,
         "minimumCoveredLines": 47131,
-        "maximumCoveredLines": 47134
+        "maximumCoveredLines": 47135
       },
       "tolerance": {
-        "missingCoveredLines": 3,
-        "rationale": "The singleton-Series relationship reservation adds 17 net instrumented lines to TagCacheService; every added line is covered in both retained local reports. Two clean full SDK 10.0.302/runtime 10.0.10 runs each passed all 4,667 tests and measured 47,131/57,061 lines. Canopy PR #752 Build & Test run 34055847826, Unit tests job 101547486584, then passed all 4,667 tests on SDK 10.0.400/runtime 10.0.11 and measured 47,134/57,061; only the stale-high-water gate failed afterward. The CI merge tree is identical to the locally tested branch tree, and all 599 recorded production/test/build-input hashes still match. These three clean test runs establish the directly observed high-water 47,134 and unchanged floor 47,131, requiring exactly three lines of tolerance (about 0.0053 percentage points). No prior-scope or changed-test fixture measurement is included. The two local Cobertura reports have identical class/file/line sets and identical changed-service coverage; their existing provider cancellation/lifecycle hit-state differences have zero net effect. CI retains the exact successful test count and measured coverage in its job log but does not upload its Cobertura report, so the three-line CI gain is not attributed to specific lines. The original 1,650,000-byte worker allocation limit and both coalesced-Series guards remain unchanged. Existing coverage-baseline.test.js boundaries reject 47,130, require review above 47,134, and reject scope drift or an unevidenced broader envelope."
+        "missingCoveredLines": 4,
+        "rationale": "The singleton-Series relationship reservation adds 17 net instrumented lines to TagCacheService; every added line is covered in both retained local reports. Two clean full SDK 10.0.302/runtime 10.0.10 runs each passed all 4,667 tests and measured 47,131/57,061 lines. Canopy PR #752 Build & Test run 34055847826, Unit tests job 101547486584, then passed all 4,667 tests on SDK 10.0.400/runtime 10.0.11 and measured 47,134/57,061; only the stale-high-water gate failed afterward. The CI merge tree is identical to the locally tested branch tree, and all 599 recorded production/test/build-input hashes still match. A subsequent same-source/test run, Build & Test 34056832537 / Unit tests 101550154583, again passed all 4,667 tests and measured 47,135/57,061; only the stale-high-water gate failed. These four clean test runs establish the directly observed high-water 47,135 and unchanged floor 47,131, requiring exactly four lines of tolerance (about 0.0071 percentage points). No prior-scope or changed-test fixture measurement is included. The two local Cobertura reports have identical class/file/line sets and identical changed-service coverage; their existing provider cancellation/lifecycle hit-state differences have zero net effect. CI retains the exact successful test count and measured coverage in its job log but does not upload its Cobertura report, so the CI gains is not attributed to specific lines. The original 1,650,000-byte worker allocation limit and both coalesced-Series guards remain unchanged. Existing coverage-baseline.test.js boundaries reject 47,130, require review above 47,135, and reject scope drift or an unevidenced broader envelope."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 47131,
+        "coveredLines": 47134,
         "totalLines": 57061
       },
       "observations": {
-        "cleanRuns": 2,
+        "cleanRuns": 3,
         "minimumCoveredLines": 47131,
-        "maximumCoveredLines": 47131
+        "maximumCoveredLines": 47134
       },
       "tolerance": {
-        "missingCoveredLines": 0,
-        "rationale": "The singleton-Series relationship reservation adds 17 net instrumented lines to TagCacheService; every added line is covered. The existing discovered-ID set construction moves earlier and remains covered. Two clean full .NET SDK 10.0.302/runtime 10.0.10 runs on identical production source and 4,667 tests both passed every test and measured 47,131/57,061 lines. Only the intentionally stale 57,044-line scope gate failed afterward. Both raw Cobertura reports have identical class/file/line sets. Eight hit-state differences between the runs are confined to existing provider invocation and registry cancellation/lifecycle branches and have zero net effect; the changed TagCacheService coverage is identical. The new scope therefore records its directly observed high-water and floor as 47,131/57,061 with zero tolerance. Prior-scope measurements are not mixed into this envelope. The original strict 1,650,000-byte worker budget remains unchanged; two coalesced-Series guards also preserve ordinary-growth allocation and reject repeated per-Series capacity reservation. Raw scope hashes, reports and comparisons are retained for independent review. coverage-baseline.test.js retains exact below-floor, above-high-water, scope-drift, observation-envelope and broad-tolerance negative boundaries."
+        "missingCoveredLines": 3,
+        "rationale": "The singleton-Series relationship reservation adds 17 net instrumented lines to TagCacheService; every added line is covered in both retained local reports. Two clean full SDK 10.0.302/runtime 10.0.10 runs each passed all 4,667 tests and measured 47,131/57,061 lines. Canopy PR #752 Build & Test run 34055847826, Unit tests job 101547486584, then passed all 4,667 tests on SDK 10.0.400/runtime 10.0.11 and measured 47,134/57,061; only the stale-high-water gate failed afterward. The CI merge tree is identical to the locally tested branch tree, and all 599 recorded production/test/build-input hashes still match. These three clean test runs establish the directly observed high-water 47,134 and unchanged floor 47,131, requiring exactly three lines of tolerance (about 0.0053 percentage points). No prior-scope or changed-test fixture measurement is included. The two local Cobertura reports have identical class/file/line sets and identical changed-service coverage; their existing provider cancellation/lifecycle hit-state differences have zero net effect. CI retains the exact successful test count and measured coverage in its job log but does not upload its Cobertura report, so the three-line CI gain is not attributed to specific lines. The original 1,650,000-byte worker allocation limit and both coalesced-Series guards remain unchanged. Existing coverage-baseline.test.js boundaries reject 47,130, require review above 47,134, and reject scope drift or an unevidenced broader envelope."
       }
     }
   }

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 47123,
-        "totalLines": 57044
+        "coveredLines": 47131,
+        "totalLines": 57061
       },
       "observations": {
-        "cleanRuns": 4,
-        "minimumCoveredLines": 47111,
-        "maximumCoveredLines": 47123
+        "cleanRuns": 2,
+        "minimumCoveredLines": 47131,
+        "maximumCoveredLines": 47131
       },
       "tolerance": {
-        "missingCoveredLines": 12,
-        "rationale": "The explicit private-response retention policy adds six instrumented lines in PrivateResponseAttribute; all six are covered in both runs. All other production edits are controller/action annotations, preserving the existing application and validator logic. Two clean full .NET SDK 10.0.302/runtime 10.0.10 runs on this exact 57,044-line and 4,665-test source passed every test and measured 47,111/57,044 (82.587%) and 47,116/57,044 (82.596%); only the intentionally stale 57,038-line scope gate failed afterward. The two raw Cobertura reports have identical class/file/line sets. Their five-line net spread is confined to existing provider invocation and registry cancellation/lifecycle branches, outside the new policy. The initial local new-scope high-water was 47,116/57,044 and its observed floor was 47,111/57,044, a five-line spread (0.008765 percentage points); the floor includes all six newly covered lines above the previous 47,105-line floor. Prior 57,038-line observations are not mixed into this new envelope or extrapolated into an unobserved high-water. PrivateResponseTests and settings revision tests pin retention, public-cache exceptions, validators, stale-write rejection and cross-user denial; coverage-baseline.test.js retains exact below-floor, stale-high-water, scope-drift, observation-envelope and broad-tolerance negative boundaries. Raw repeated-run evidence is retained for independent review in the private implementation validation record. Hosted Build & Test job 101517452478 (https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/34044658488/job/101517452478) passed the same 4,665 tests on this unchanged server source/test scope and measured 47,122/57,044, failing only the stale-high-water gate. The three-run observed high-water is now 47,122 and the exact observed floor remains 47,111; the eleven-line spread is 0.019284 percentage points. The lower local measurements remain valid observations, not substitute high-waters. A fourth clean full run, post-merge Build & Test job 101534962034 (https://github.com/4eh5xitv6787h645ebv/Jellyfin-Canopy/actions/runs/34051176827/job/101534962034), passed all 4,665 tests on the unchanged server production/test source and measured 47,123/57,044. Only the stale-high-water gate failed. Record that actual observation as the new high-water; retain the directly observed 47,111-line floor. The twelve-line envelope is 0.021036 percentage points. No failed test run contributes an observation, the line scope and minimum remain unchanged, and the exact below-floor/above-high-water negative boundaries remain enforced."
+        "missingCoveredLines": 0,
+        "rationale": "The singleton-Series relationship reservation adds 17 net instrumented lines to TagCacheService; every added line is covered. The existing discovered-ID set construction moves earlier and remains covered. Two clean full .NET SDK 10.0.302/runtime 10.0.10 runs on identical production source and 4,667 tests both passed every test and measured 47,131/57,061 lines. Only the intentionally stale 57,044-line scope gate failed afterward. Both raw Cobertura reports have identical class/file/line sets. Eight hit-state differences between the runs are confined to existing provider invocation and registry cancellation/lifecycle branches and have zero net effect; the changed TagCacheService coverage is identical. The new scope therefore records its directly observed high-water and floor as 47,131/57,061 with zero tolerance. Prior-scope measurements are not mixed into this envelope. The original strict 1,650,000-byte worker budget remains unchanged; two coalesced-Series guards also preserve ordinary-growth allocation and reject repeated per-Series capacity reservation. Raw scope hashes, reports and comparisons are retained for independent review. coverage-baseline.test.js retains exact below-floor, above-high-water, scope-drift, observation-envelope and broad-tolerance negative boundaries."
       }
     }
   }


### PR DESCRIPTION
Repairing stale relationships for a single Series grows the worker dictionaries repeatedly. Count distinct verified stale descendants and reserve bounded capacity before repair, reducing the measured cold 1,000-descendant allocation by about 395 KB while preserving the existing 1,650,000-byte limit.

Reservation applies only to singleton batches. Coalesced batches keep ordinary geometric growth; two real-worker regression cases reject repeated per-Series reservation while checking every repaired relationship, metadata, query count and media probe. Initial hints are capped at 4,096 entries. Temporary final capacity can be larger at some cardinalities, so this is not a claim of uniformly lower peak memory.

Validation: two full server runs passed all 4,667 tests; each measured 47,131/57,061 covered lines. Two hosted runs also passed all 4,667 tests and measured 47,134 and 47,135/57,061 on verified identical production/test inputs; their coverage commands stopped only because those results exceeded the recorded high-water. The reviewed four-run record now uses the observed 47,135 high-water and preserves the 47,131 floor with exactly four lines of measured spread. The coverage gate passes. All 660 script tests passed before the final additional observation; all 14 affected coverage contracts pass with the final values. Release builds have zero warnings/errors. The complete disposable Jellyfin 12 browser suite passed 189/189 with no skips at two CPUs per server; all owned resources were cleaned up.

Developed with OpenAI/Codex assistance. Two independent Codex reviewers approved the exact final source, regressions, raw coverage evidence and baseline update, including fresh review of the hosted observation amendment. Hosted CI, including Windows and all six E2E shards, remains required before merge.
