### PR TITLE
test: record observed server coverage without lowering its floor

### DIFF
--- a/scripts/coverage-baseline.test.js
+++ b/scripts/coverage-baseline.test.js
@@ -26,19 +26,34 @@ test('reviewed coverage baselines match the clean measurement envelopes', () => 
         /exact minimum directly observed by clean runs on the identical source, tests, and total-line scope/
     );
     assert.deepEqual(baselines.profiles.client.measured, { coveredLines: 2976, totalLines: 3362 });
-    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47241, totalLines: 57155 });
+    assert.deepEqual(baselines.profiles.server.measured, { coveredLines: 47244, totalLines: 57155 });
     assert.deepEqual(baselines.profiles.client.observations, {
         cleanRuns: 2,
         minimumCoveredLines: 2976,
         maximumCoveredLines: 2976,
     });
     assert.deepEqual(baselines.profiles.server.observations, {
-        cleanRuns: 2,
+        cleanRuns: 4,
         minimumCoveredLines: 47236,
-        maximumCoveredLines: 47241,
+        maximumCoveredLines: 47244,
     });
     assert.equal(baselines.profiles.client.tolerance.missingCoveredLines, 0);
-    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 5);
+    assert.equal(baselines.profiles.server.tolerance.missingCoveredLines, 8);
+});
+
+test('server hosted high-water update preserves its exact previously reviewed floor', () => {
+    const profile = baselines.profiles.server;
+    for (const [coveredLines, ok, reason] of [
+        [47235, false, 'regression'],
+        [47236, true, 'within-tolerance'],
+        [47241, true, 'within-tolerance'],
+        [47244, true, 'exact'],
+        [47245, false, 'stale-baseline'],
+    ]) {
+        const result = evaluateCoverage({ coveredLines, totalLines: 57155 }, profile);
+        assert.equal(result.ok, ok);
+        assert.equal(result.reason, reason);
+    }
 });
 
 for (const name of ['client', 'server']) {

--- a/scripts/coverage-baselines.json
+++ b/scripts/coverage-baselines.json
@@ -27,17 +27,17 @@
       "scope": "complete Jellyfin.Plugin.JellyfinCanopy assembly",
       "package": "Jellyfin.Plugin.JellyfinCanopy",
       "measured": {
-        "coveredLines": 47241,
+        "coveredLines": 47244,
         "totalLines": 57155
       },
       "observations": {
-        "cleanRuns": 2,
+        "cleanRuns": 4,
         "minimumCoveredLines": 47236,
-        "maximumCoveredLines": 47241
+        "maximumCoveredLines": 47244
       },
       "tolerance": {
-        "missingCoveredLines": 5,
-        "rationale": "The bounded tag-cache save scheduler changes the complete assembly scope from 57,061 to 57,155 instrumented lines. Two clean full runs on the identical 600-file production/test/build-input scope at Canopy commit 8f2cd3e521b565c11cd4c78024b8c7087e519164, using SDK 10.0.302/runtime 10.0.10, each passed all 4,695 tests and measured 47,241/57,155 and 47,236/57,155. Both raw Cobertura reports and complete test logs are retained; their exact class/file/line scope is identical. These observations establish high-water 47,241, directly observed floor 47,236, and exactly five lines of tolerance (about 0.0088 percentage points). TagCacheService coverage is identical at 1,847/1,938 lines in both runs, up from 1,744/1,844 in the preceding scope; 136 of 137 added instrumented lines are covered, with only an existing late-shutdown repair-save call remaining unexecuted. The five-line net spread is located in existing SpoilerSeerrPendingPromoter, PlatformProviderInvocationService and PlatformProviderRegistryOrchestrator cancellation/lifecycle branches; no changed-service coverage is lost. No old-scope, changed-test or failing-test measurement is included. The policy, client baseline, coverage implementation and performance budgets remain unchanged. coverage-baseline.test.js rejects 47,235, requires review above 47,241, and rejects scope drift or an unevidenced broader envelope."
+        "missingCoveredLines": 8,
+        "rationale": "The complete assembly remains at 57,155 instrumented lines after Canopy PR #754. Retain the previously reviewed clean local observations of 47,241 and 47,236 covered lines, and record the 47,244-line observed high-water independently reported by the successful 4,695-test post-merge run for #754 and the successful 4,695-test PR #756 run. The 600 C#/project input files are identical across these measurements; differences from the recorded local source commit are coverage metadata/tests and the two documentation paragraphs in #756, with no plugin, server-test, client-resource source or build changes. All four complete test runs passed; the hosted commands failed only because coverage advanced above the old 47,241 high-water. Both original Cobertura reports and all four logs are retained privately. Hosted XML was not retained, so the exact three additional hosted line hits are not attributed to a particular branch. High-water advances to 47,244; the already reviewed floor remains exactly 47,236, so the eight-line downward bound (about 0.014 percentage points) preserves the existing acceptance floor. No failed test run or changed-source scope is included. The client profile, measurement implementation, policy and performance limits remain unchanged. Coverage tests reject 47,235, require review above 47,244, and reject scope drift or an unevidenced wider envelope."
       }
     }
   }


### PR DESCRIPTION
The server coverage gate rejects successful runs that measure 47,244 covered lines because its recorded maximum is still 47,241. Record the repeated observed maximum while preserving the existing 47,236-line floor and 57,155-line assembly scope.

The envelope contains four complete passing 4,695-test observations: two previously reviewed local measurements (47,241 and 47,236), the #754 post-merge measurement, and the #756 measurement (both 47,244). All tracked server source, test and build-resource inputs match. Hosted XML is unavailable, so the three additional hosted hits are not attributed to particular branches. The eight-line bound is the exact observed range; it does not lower the previous floor.

Validation: all 661 script tests passed; 15 focused coverage tests passed, including exact floor/high-water boundaries and scope-drift rejection. The unchanged parser/evaluator accepts both retained local XML reports and the recorded hosted measurements. Two independent Codex reviews approved the exact change and verified source equivalence. This update changes only the coverage artifact and its regression tests.
